### PR TITLE
added missing closing tag

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -317,6 +317,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
          ));
         }
       ?>
+      </div>
     </div><?php
   }
 


### PR DESCRIPTION
Without this tag, `<div id='facebook_options' class='panel woocommerce_options_panel'>` eats other elements within the admin, breaking any plugins that render their `woocommerce_options_panel` elements after it.