### PR TITLE
update block comment when HTML script are inlined

### DIFF
--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -113,7 +113,7 @@ src=\"https://www.facebook.com/tr?id=%s&ev=PageView&noscript=1\"/>
   public static function build_event($event_name, $params, $method='track') {
     $params = self::add_version_info($params);
     return sprintf(
-      "// %s Facebook Integration Event Tracking\n".
+      "/* %s Facebook Integration Event Tracking */\n".
       "fbq('%s', '%s', %s);",
       WC_Facebookcommerce_Utils::getIntegrationName(),
       $method,


### PR DESCRIPTION
when I use Fb-for-wc plugin with minify HTML plugins (eg. Cache Enabler), comment on HTML script block created an error. Just passing inline comment into block comment resolved the issue.