### PR TITLE
Fixes #251

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -19,7 +19,31 @@ class WC_Facebookcommerce_EventsTracker {
 
   public function __construct($user_info) {
     $this->pixel = new WC_Facebookcommerce_Pixel($user_info);
+
     add_action('wp_head', array($this, 'apply_filters'));
+
+    // Pixel Tracking Hooks
+    add_action('wp_head',
+	  array($this, 'inject_base_pixel'));
+    add_action('wp_footer',
+	  array($this, 'inject_base_pixel_noscript'));
+    add_action('woocommerce_after_single_product',
+	  array($this, 'inject_view_content_event'));
+    add_action('woocommerce_after_shop_loop',
+	  array($this, 'inject_view_category_event'));
+    add_action('pre_get_posts',
+	  array($this, 'inject_search_event'));
+    add_action('woocommerce_add_to_cart',
+	  array($this, 'inject_add_to_cart_event'));
+    add_action('wc_ajax_fb_inject_add_to_cart_event',
+	  array($this, 'inject_ajax_add_to_cart_event' ));
+    add_action('woocommerce_after_checkout_form',
+	  array($this, 'inject_initiate_checkout_event'));
+    add_action('woocommerce_thankyou',
+	  array($this, 'inject_gateway_purchase_event'));
+    add_action('woocommerce_payment_complete',
+	  array($this, 'inject_purchase_event'));
+
   }
 
   public function apply_filters() {

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -19,7 +19,7 @@ class WC_Facebookcommerce_EventsTracker {
 
   public function __construct($user_info) {
     $this->pixel = new WC_Facebookcommerce_Pixel($user_info);
-    add_action('wp_head', array($this, 'apply_filters'), 9);
+    add_action('wp_head', array($this, 'apply_filters'));
   }
 
   public function apply_filters() {

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -19,10 +19,10 @@ class WC_Facebookcommerce_EventsTracker {
 
   public function __construct($user_info) {
     $this->pixel = new WC_Facebookcommerce_Pixel($user_info);
-    self::apply_filters();
+    add_action('wp_head', array($this, 'apply_filters'), 9);
   }
 
-  public static function apply_filters() {
+  public function apply_filters() {
     self::$isEnabled = apply_filters(
         "facebook_for_woocommerce_integration_pixel_enabled",
         self::$isEnabled);

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -288,29 +288,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
     if ($this->pixel_id) {
       $user_info = WC_Facebookcommerce_Utils::get_user_info($this->use_pii);
       $this->events_tracker = new WC_Facebookcommerce_EventsTracker($user_info);
-
-      // Pixel Tracking Hooks
-      add_action('wp_head',
-        array($this->events_tracker, 'inject_base_pixel'));
-      add_action('wp_footer',
-        array($this->events_tracker, 'inject_base_pixel_noscript'));
-      add_action('woocommerce_after_single_product',
-        array($this->events_tracker, 'inject_view_content_event'));
-      add_action('woocommerce_after_shop_loop',
-        array($this->events_tracker, 'inject_view_category_event'));
-      add_action('pre_get_posts',
-        array($this->events_tracker, 'inject_search_event'));
-      add_action('woocommerce_add_to_cart',
-        array($this->events_tracker, 'inject_add_to_cart_event'));
-      add_action('wc_ajax_fb_inject_add_to_cart_event',
-        array($this->events_tracker, 'inject_ajax_add_to_cart_event' ));
-      add_action('woocommerce_after_checkout_form',
-        array($this->events_tracker, 'inject_initiate_checkout_event'));
-      add_action('woocommerce_thankyou',
-        array($this->events_tracker, 'inject_gateway_purchase_event'));
-      add_action('woocommerce_payment_complete',
-         array($this->events_tracker, 'inject_purchase_event'));
-
     }
   }
 


### PR DESCRIPTION
Static `apply_filters` method moved from constructor to `wp_head` action which allows 3rd party setup filters before they applied. Priority 9 used to make sure that action will be fired before rest of class actions.