### PR TITLE
Fix performance issue by reusing existing wp_query object contents

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -88,7 +88,7 @@ class WC_Facebookcommerce_EventsTracker {
     $products = array_values(array_map(function($item) {
         return wc_get_product($item->ID);
       },
-      $wp_query->get_posts()));
+      $wp_query->posts));
 
     // if any product is a variant, fire the pixel with
     // content_type: product_group


### PR DESCRIPTION
Running get_posts() triggers a database query which is unnecessary as
the object wp_query already contains the posts, so rather reuse it
directly.

I hereby contribute this as public domain to Facebook so I don't need to sign extra agreements.