### PR TITLE
WP_DEBUG: Make the error message more precise

### DIFF
--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -71,7 +71,7 @@ class WC_Facebookcommerce {
       <p>
       <?php
         printf(__('To use Facebook for WooCommerce,
-          please disable WP_DEBUG_DISPLAY in your wp-config.php file.
+          please disable WP_DEBUG and WP_DEBUG_DISPLAY in your wp-config.php file.
           Contact your server administrator for more assistance.',
           'facebook-for-woocommerce'));
        ?>


### PR DESCRIPTION
I've updated the error message to match the `condition` specified here: https://github.com/facebookincubator/facebook-for-woocommerce/blob/78afec714689242dabbd32216c195c77103ada73/facebook-for-woocommerce.php#L44

I think it can be misleading right now.