### PR TITLE
Added filter for product ID on purchase event

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -310,7 +310,7 @@ class WC_Facebookcommerce_EventsTracker {
     $content_type = 'product';
     $product_ids = array();
     foreach ($order->get_items() as $item) {
-      $product = wc_get_product($item['product_id']);
+      $product = wc_get_product(apply_filters('facebook_woocommerce_pixel_purchase_event_get_product_id', $item['product_id'], $item));
       $product_ids = array_merge(
         $product_ids,
         WC_Facebookcommerce_Utils::get_fb_content_ids($product));


### PR DESCRIPTION
This filter would provide compatibility with plugins which make use of the WC checkout process and order management, but are selling something else, not WC Products directly.

For example, we've encountered this issue with the plugin LearnPress in conjunction with the extension LearnPress - WooCommerce Payments which enables the selling of access to courses (LearnPress) through the WooCommerce checkout process. In this case, the product ID is not stored inside $item['product_id'] but inside $item['course_id']. Since the value of $item['product_id'] is 0 in this case, the code breaks the checkout confirmation page.