### PR TITLE
Check if fb_api_key is set before calling it

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -832,7 +832,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			,feedPingUrl: ''
 			,samples: <?php echo $this->get_sample_product_feed(); ?>
 	  }
-	  ,tokenExpired: '<?php echo $this->settings['fb_api_key'] && ! $this->get_page_name(); ?>'
+	  ,tokenExpired: '<?php echo isset( $this->settings['fb_api_key'] ) ? $this->settings['fb_api_key'] && ! $this->get_page_name() : ''; ?>'
 	};
 	</script>
 		<?php


### PR DESCRIPTION
When PHP notices are on (or when WP_DEBUG is on) the following line produces a warning (Undefined index: fb_api_key) when the plug-in isn't setup yet. This in turn generates a JavaScript error which leaves the user unable to  start initial setup.