### PR TITLE
Add proper plugin version to scripts instead of using time()

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -738,7 +738,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			plugins_url(
 				'/assets/css/facebook-infobanner.css',
 				__FILE__
-			)
+			),
+			[],
+			\WC_Facebookcommerce::PLUGIN_VERSION
 		);
 
 		if ( ! facebook_for_woocommerce()->is_plugin_settings() ) {
@@ -811,7 +813,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			plugins_url(
 				'/assets/css/facebook.css',
 				__FILE__
-			)
+			),
+			[],
+			\WC_Facebookcommerce::PLUGIN_VERSION
 		);
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -571,9 +571,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		wp_enqueue_script(
 			'wc_facebook_metabox_jsx',
 			plugins_url(
-				'/assets/js/facebook-metabox.min.js?ts=' . time(),
+				'/assets/js/facebook-metabox.min.js',
 				__FILE__
-			)
+			),
+			[],
+			\WC_Facebookcommerce::PLUGIN_VERSION
 		);
 		wp_localize_script(
 			'wc_facebook_metabox_jsx',
@@ -719,9 +721,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		wp_enqueue_script(
 			'wc_facebook_infobanner_jsx',
 			plugins_url(
-				'/assets/js/facebook-infobanner.min.js?ts=' . time(),
+				'/assets/js/facebook-infobanner.min.js',
 				__FILE__
-			)
+			),
+			[],
+			\WC_Facebookcommerce::PLUGIN_VERSION
 		);
 		wp_localize_script(
 		 'wc_facebook_infobanner_jsx',
@@ -791,9 +795,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		wp_enqueue_script(
 			'wc_facebook_settings_jsx',
 			plugins_url(
-				'/assets/js/facebook-settings.min.js?ts=' . time(),
+				'/assets/js/facebook-settings.min.js',
 				__FILE__
-			)
+			),
+			[],
+			\WC_Facebookcommerce::PLUGIN_VERSION
 		);
 		wp_localize_script(
 			'wc_facebook_settings_jsx',


### PR DESCRIPTION
Add proper plugin version to scripts instead of using time();

Remove `?ts=' . time()` on the JavaScript files.

Replace with `\WC_Facebookcommerce::PLUGIN_VERSION` using the version option.

Also, add proper plugin version to stylesheets

Fixes #1224