### PR TITLE
Create the base connection handler

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -20,208 +20,208 @@ defined( 'ABSPATH' ) or exit;
 class Connection {
 
 
-    /**
-     * Constructs a new Connection.
-     *
-     * @since 2.0.0-dev.1
-     */
-    public function __construct() {
+	/**
+	 * Constructs a new Connection.
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function __construct() {
 
-    }
-
-
-    /**
-     * Processes the returned connection.
-     *
-     * @internal
-     *
-     * @since 2.0.0-dev.1
-     */
-    public function handle_connect() {
-
-    }
+	}
 
 
-    /**
-     * Disconnects the integration using the Graph API.
-     *
-     * @internal
-     *
-     * @since 2.0.0-dev.1
-     */
-    public function handle_disconnect() {
+	/**
+	 * Processes the returned connection.
+	 *
+	 * @internal
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function handle_connect() {
 
-    }
-
-
-    /**
-     * Converts a temporary user token to a system user token via the Graph API.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @param string $user_token
-     * @return string
-     */
-    public function create_system_user_token( $user_token ) {
-
-        return $user_token;
-    }
+	}
 
 
-    /**
-     * Gets the API access token.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @return string
-     */
-    public function get_access_token() {
+	/**
+	 * Disconnects the integration using the Graph API.
+	 *
+	 * @internal
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function handle_disconnect() {
 
-        return '';
-    }
-
-
-    /**
-     * Gets the URL to start the connection flow.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @return string
-     */
-    public function get_connect_url() {
-
-        return '';
-    }
+	}
 
 
-    /**
-     * Gets the URL for disconnecting.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @return string
-     */
-    public function get_disconnect_url() {
+	/**
+	 * Converts a temporary user token to a system user token via the Graph API.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $user_token
+	 * @return string
+	 */
+	public function create_system_user_token( $user_token ) {
 
-        return '';
-    }
-
-
-    /**
-     * Gets the scopes that will be requested during the connection flow.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @return string[]
-     */
-    public function get_scopes() {
-
-        return [];
-    }
+		return $user_token;
+	}
 
 
-    /**
-     * Gets the stored external business ID.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @return string
-     */
-    public function get_external_business_id() {
+	/**
+	 * Gets the API access token.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_access_token() {
 
-        return '';
-    }
-
-
-    /**
-     * Gets the site's business name.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @return string
-     */
-    public function get_business_name() {
-
-        return '';
-    }
+		return '';
+	}
 
 
-    /**
-     * Gets the business manager ID value.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @return string
-     */
-    public function get_business_manager_id() {
+	/**
+	 * Gets the URL to start the connection flow.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_connect_url() {
 
-        return '';
-    }
-
-
-    /**
-     * Gets the full redirect URL where the user will return to after OAuth.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @return string
-     */
-    public function get_redirect_url() {
-
-        return '';
-    }
+		return '';
+	}
 
 
-    /**
-     * Gets the full set of connection parameters for starting OAuth.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @return array
-     */
-    public function get_connect_parameters() {
+	/**
+	 * Gets the URL for disconnecting.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_disconnect_url() {
 
-        return [];
-    }
-
-
-    /**
-     * Stores the given ID value.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @param string $value the business manager ID
-     */
-    public function update_business_manager_id( $value ) {
-
-    }
+		return '';
+	}
 
 
-    /**
-     * Stores the given token value.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @param string $value the access token
-     */
-    public function update_access_token( $value ) {
+	/**
+	 * Gets the scopes that will be requested during the connection flow.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string[]
+	 */
+	public function get_scopes() {
 
-    }
+		return [];
+	}
 
 
-    /**
-     * Determines whether the site is connected.
-     *
-     * A site is connected if there is an access token stored.
-     *
-     * @since 2.0.0-dev.1
-     *
-     * @return bool
-     */
-    public function is_connected() {
+	/**
+	 * Gets the stored external business ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_external_business_id() {
 
-        return true;
-    }
+		return '';
+	}
+
+
+	/**
+	 * Gets the site's business name.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_business_name() {
+
+		return '';
+	}
+
+
+	/**
+	 * Gets the business manager ID value.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_business_manager_id() {
+
+		return '';
+	}
+
+
+	/**
+	 * Gets the full redirect URL where the user will return to after OAuth.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_redirect_url() {
+
+		return '';
+	}
+
+
+	/**
+	 * Gets the full set of connection parameters for starting OAuth.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_connect_parameters() {
+
+		return [];
+	}
+
+
+	/**
+	 * Stores the given ID value.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $value the business manager ID
+	 */
+	public function update_business_manager_id( $value ) {
+
+	}
+
+
+	/**
+	 * Stores the given token value.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $value the access token
+	 */
+	public function update_access_token( $value ) {
+
+	}
+
+
+	/**
+	 * Determines whether the site is connected.
+	 *
+	 * A site is connected if there is an access token stored.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function is_connected() {
+
+		return true;
+	}
 
 
 }

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Handlers;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+
+/**
+ * The connection handler.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Connection {
+
+
+}

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -22,4 +22,204 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 class Connection {
 
 
+    /**
+     * Constructs a new Connection.
+     *
+     * @since 2.0.0-dev.1
+     */
+    public function __construct() {
+
+    }
+
+
+    /**
+     * Processes the returned connection.
+     *
+     * @internal
+     *
+     * @since 2.0.0-dev.1
+     */
+    public function handle_connect() {
+
+    }
+
+
+    /**
+     * Disconnects the integration using the Graph API.
+     *
+     * @internal
+     *
+     * @since 2.0.0-dev.1
+     */
+    public function handle_disconnect() {
+
+    }
+
+
+    /**
+     * Converts a temporary user token to a system user token via the Graph API.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @param string $user_token
+     * @return string
+     */
+    public function create_system_user_token( $user_token ) {
+
+        return $user_token;
+    }
+
+
+    /**
+     * Gets the API access token.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @return string
+     */
+    public function get_access_token() {
+
+        return '';
+    }
+
+
+    /**
+     * Gets the URL to start the connection flow.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @return string
+     */
+    public function get_connect_url() {
+
+        return '';
+    }
+
+
+    /**
+     * Gets the URL for disconnecting.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @return string
+     */
+    public function get_disconnect_url() {
+
+        return '';
+    }
+
+
+    /**
+     * Gets the scopes that will be requested during the connection flow.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @return string[]
+     */
+    public function get_scopes() {
+
+        return [];
+    }
+
+
+    /**
+     * Gets the stored external business ID.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @return string
+     */
+    public function get_external_business_id() {
+
+        return '';
+    }
+
+
+    /**
+     * Gets the site's business name.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @return string
+     */
+    public function get_business_name() {
+
+        return '';
+    }
+
+
+    /**
+     * Gets the business manager ID value.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @return string
+     */
+    public function get_business_manager_id() {
+
+        return '';
+    }
+
+
+    /**
+     * Gets the full redirect URL where the user will return to after OAuth.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @return string
+     */
+    public function get_redirect_url() {
+
+        return '';
+    }
+
+
+    /**
+     * Gets the full set of connection parameters for starting OAuth.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @return array
+     */
+    public function get_connect_parameters() {
+
+        return [];
+    }
+
+
+    /**
+     * Stores the given ID value.
+     *
+     * @since 2.0.0-dev.1
+     */
+    public function update_business_manager_id( $value ) {
+
+    }
+
+
+    /**
+     * Stores the given token value.
+     *
+     * @since 2.0.0-dev.1
+     */
+    public function update_access_token( $value ) {
+
+    }
+
+
+    /**
+     * Determines whether the site is connected.
+     *
+     * A site is connected if there is an access token stored.
+     *
+     * @since 2.0.0-dev.1
+     *
+     * @return bool
+     */
+    public function is_connected() {
+
+        return true;
+    }
+
+
 }

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -12,8 +12,6 @@ namespace SkyVerge\WooCommerce\Facebook\Handlers;
 
 defined( 'ABSPATH' ) or exit;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
-
 /**
  * The connection handler.
  *

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -191,6 +191,8 @@ class Connection {
      * Stores the given ID value.
      *
      * @since 2.0.0-dev.1
+     *
+     * @param string $value the business manager ID
      */
     public function update_business_manager_id( $value ) {
 
@@ -201,6 +203,8 @@ class Connection {
      * Stores the given token value.
      *
      * @since 2.0.0-dev.1
+     *
+     * @param string $value the access token
      */
     public function update_access_token( $value ) {
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
+
+/**
+ * Tests the Connection class.
+ */
+class ConnectionTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		require_once 'includes/Handlers/Connection.php';
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Connection::__construct() */
+	public function test_constructor() {
+
+        $connection = $this->get_connection();
+
+        $this->assertInstanceOf( Connection::class, $connection );
+	}
+
+
+	/** @see Connection::handle_connect() */
+	public function test_handle_connect() {
+
+		$this->assertNull( $this->get_connection()->handle_connect() );
+	}
+
+
+	/** @see Connection::handle_disconnect() */
+	public function test_handle_disconnect() {
+
+		$this->assertNull( $this->get_connection()->handle_disconnect() );
+	}
+
+
+	/** @see Connection::create_system_user_token() */
+	public function test_create_system_user_token() {
+
+		$user_token = 'user token';
+
+		$this->assertEquals( $user_token, $this->get_connection()->create_system_user_token( $user_token ) );
+	}
+
+
+	/** @see Connection::get_access_token() */
+	public function test_get_access_token() {
+
+		$this->assertIsString( $this->get_connection()->get_access_token() );
+	}
+
+
+	/** @see Connection::get_connect_url() */
+	public function test_get_connect_url() {
+
+		$this->assertIsString( $this->get_connection()->get_connect_url() );
+	}
+
+
+	/** @see Connection::get_disconnect_url() */
+	public function test_get_disconnect_url() {
+
+		$this->assertIsString( $this->get_connection()->get_disconnect_url() );
+	}
+
+
+	/** @see Connection::get_scopes() */
+	public function test_get_scopes() {
+
+		$this->assertIsArray( $this->get_connection()->get_scopes() );
+	}
+
+
+	/** @see Connection::get_external_business_id() */
+	public function test_get_external_business_id() {
+
+		$this->assertIsString( $this->get_connection()->get_external_business_id() );
+	}
+
+
+	/** @see Connection::get_business_name() */
+	public function test_get_business_name() {
+
+		$this->assertIsString( $this->get_connection()->get_business_name() );
+	}
+
+
+	/** @see Connection::get_business_manager_id() */
+	public function test_get_business_manager_id() {
+
+		$this->assertIsString( $this->get_connection()->get_business_manager_id() );
+	}
+
+
+	/** @see Connection::get_redirect_url() */
+	public function test_get_redirect_url() {
+
+		$this->assertIsString( $this->get_connection()->get_redirect_url() );
+	}
+
+
+	/** @see Connection::get_connect_parameters() */
+	public function test_get_connect_parameters() {
+
+		$this->assertIsArray( $this->get_connection()->get_connect_parameters() );
+	}
+
+
+	/** @see Connection::update_business_manager_id() */
+	public function test_update_business_manager_id() {
+
+		$business_manager_id = 'business manager id';
+
+		$this->assertNull( $this->get_connection()->update_business_manager_id( $business_manager_id ) );
+	}
+
+
+	/** @see Connection::update_access_token() */
+	public function test_update_access_token() {
+
+		$access_token = 'access token';
+
+		$this->assertNull( $this->get_connection()->update_access_token( $access_token ) );
+	}
+
+
+	/** @see Connection::is_connected() */
+	public function test_is_connected() {
+
+		$this->assertIsBool( $this->get_connection()->is_connected() );
+	}
+
+
+	/** Helper methods **************************************************************************************************/
+
+
+	/**
+	 * Gets the connection instance.
+	 *
+	 * @return Connection
+	 */
+	private function get_connection() {
+
+		return new Connection();
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `Handlers\Connection` class and empty versions of the public methods.

### Story: [CH 54003](https://app.clubhouse.io/skyverge/story/54003)
### Release: #1277 

## QA

### Tests

- [x] `vendor/bin/codecept run integration tests/integration/Handlers` pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
