### PR TITLE
Initialize the connection handler object

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -49,6 +49,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var \SkyVerge\WooCommerce\Facebook\Products\Feed product feed handler */
 		private $product_feed;
 
+		/** @var \SkyVerge\WooCommerce\Facebook\Handlers\Connection connection handler */
+		private $connection_handler;
+
 
 		/**
 		 * Constructs the plugin.

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -87,6 +87,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 				include_once 'facebook-commerce.php';
 
+				require_once __DIR__ . '/includes/Handlers/Connection.php';
 				require_once __DIR__ . '/includes/Integrations/Integrations.php';
 				require_once __DIR__ . '/includes/Products.php';
 				require_once __DIR__ . '/includes/Products/Feed.php';
@@ -107,6 +108,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 				$this->integrations = new \SkyVerge\WooCommerce\Facebook\Integrations\Integrations( $this );
 
+				$this->connection_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\Connection();
 			}
 		}
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -243,6 +243,19 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 
 		/**
+		 * Gets the connection handler.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @return \SkyVerge\WooCommerce\Facebook\Handlers\Connection
+		 */
+		public function get_connection_handler() {
+
+			return $this->connection_handler;
+		}
+
+
+		/**
 		 * Gets the integration instance.
 		 *
 		 * @since 1.10.0

--- a/tests/integration/WC_Facebookcommerce_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Test.php
@@ -1,0 +1,25 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
+
+/**
+ * Tests the WC_Facebookcommerce class.
+ */
+class WC_Facebookcommerce_Test extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see WC_Facebookcommerce::get_connection_handler() */
+	public function test_get_connection_handler() {
+
+		$this->assertInstanceOf( Connection::class, facebook_for_woocommerce()->get_connection_handler() );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `WC_Facebookcommerce::get_connection_handler()` method.

### Story: [CH 54006](https://app.clubhouse.io/skyverge/story/54006)
### Release: #1277

## QA

### Tests

- [x] `vendor codecept run integration tests/integration/WC_Facebookcommerce_Test.php` pass
