### PR TITLE
Define the connection scopes

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -130,7 +130,7 @@ class Connection {
 		 * @param string[] $scopes connection scopes
 		 * @param Connection $connection connection handler instance
 		 */
-		return (array) apply_filters( 'wc_faceobok_connection_scopes', $scopes, $this );
+		return (array) apply_filters( 'wc_facebook_connection_scopes', $scopes, $this );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -116,7 +116,11 @@ class Connection {
 	 */
 	public function get_scopes() {
 
-		return [];
+		return [
+			'manage_business_extension',
+			'catalog_management',
+			'business_management',
+		];
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -123,7 +123,7 @@ class Connection {
 		];
 
 		/**
-		 * Filters the connection scopes that will be requested during the connection flow.
+		 * Filters the scopes that will be requested during the connection flow.
 		 *
 		 * @since 2.0.0-dev.1
 		 *

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -116,11 +116,21 @@ class Connection {
 	 */
 	public function get_scopes() {
 
-		return [
+		$scopes = [
 			'manage_business_extension',
 			'catalog_management',
 			'business_management',
 		];
+
+		/**
+		 * Filters the connection scopes that will be requested during the connection flow.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param string[] $scopes connection scopes
+		 * @param Connection $connection connection handler instance
+		 */
+		return (array) apply_filters( 'wc_faceobok_connection_scopes', $scopes, $this );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -87,7 +87,6 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 
 		$scopes = $this->get_connection()->get_scopes();
 
-		$this->assertIsArray( $scopes );
 		$this->assertContains( $scope, $scopes );
 	}
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -79,7 +79,12 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Connection::get_scopes() */
 	public function test_get_scopes() {
 
-		$this->assertIsArray( $this->get_connection()->get_scopes() );
+		$scopes = $this->get_connection()->get_scopes();
+
+		$this->assertIsArray( $scopes );
+		$this->assertContains( 'manage_business_extension', $scopes );
+		$this->assertContains( 'catalog_management', $scopes );
+		$this->assertContains( 'business_management', $scopes );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -76,15 +76,30 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Connection::get_scopes() */
-	public function test_get_scopes() {
+	/**
+	 * @see Connection::get_scopes()
+	 *
+	 * @param string $scope an API scope that should be included
+	 *
+	 * @dataProvider provider_get_scopes
+	 */
+	public function test_get_scopes( $scope ) {
 
 		$scopes = $this->get_connection()->get_scopes();
 
 		$this->assertIsArray( $scopes );
-		$this->assertContains( 'manage_business_extension', $scopes );
-		$this->assertContains( 'catalog_management', $scopes );
-		$this->assertContains( 'business_management', $scopes );
+		$this->assertContains( $scope, $scopes );
+	}
+
+
+	/** @see test_get_scopes() */
+	public function provider_get_scopes() {
+
+		return [
+			'manage_business_extension' => [ 'manage_business_extension' ],
+			'catalog_management'        => [ 'catalog_management' ],
+			'business_management'       => [ 'business_management' ],
+		];
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -105,7 +105,7 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Connection::get_scopes() */
 	public function test_get_scopes_filter() {
 
-		add_filter( 'wc_faceobok_connection_scopes', function() {
+		add_filter( 'wc_facebook_connection_scopes', function() {
 
 			return [ 'filtered' ];
 		} );

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -102,6 +102,18 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_scopes() */
+	public function test_get_scopes_filter() {
+
+		add_filter( 'wc_faceobok_connection_scopes', function() {
+
+			return [ 'filtered' ];
+		} );
+
+		$this->assertSame( [ 'filtered' ], $this->get_connection()->get_scopes() );
+	}
+
+
 	/** @see Connection::get_external_business_id() */
 	public function test_get_external_business_id() {
 


### PR DESCRIPTION
# Summary

This PR updates the `Connection::get_scopes()` method to return the API scopes we are going to request.

### Story: [CH 54010](https://app.clubhouse.io/skyverge/story/54010)
### Release: #1277

## QA

### Tests

- [x] `vendor codecept run integration tests/integration/Handlers/ConnectionTest.php` pass
