### PR TITLE
Build the connection redirect URL

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -172,7 +172,9 @@ class Connection {
 	 */
 	public function get_redirect_url() {
 
-		return '';
+		$redirect_url = add_query_arg( 'wc-api', self::ACTION_CONNECT, home_url() );
+
+		return wp_nonce_url( $redirect_url, self::ACTION_CONNECT, 'nonce' );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -20,6 +20,10 @@ defined( 'ABSPATH' ) or exit;
 class Connection {
 
 
+	/** @var string the action callback for the connection */
+	const ACTION_CONNECT = 'wc_facebook_connect';
+
+
 	/**
 	 * Constructs a new Connection.
 	 *

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -172,9 +172,17 @@ class Connection {
 	 */
 	public function get_redirect_url() {
 
-		$redirect_url = add_query_arg( 'wc-api', self::ACTION_CONNECT, home_url() );
+		$redirect_url = wp_nonce_url( add_query_arg( 'wc-api', self::ACTION_CONNECT, home_url() ), self::ACTION_CONNECT, 'nonce' );
 
-		return wp_nonce_url( $redirect_url, self::ACTION_CONNECT, 'nonce' );
+		/**
+		 * Filters the redirect URL where the user will return to after OAuth.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param string $redirect_url redirect URL
+		 * @param Connection $connection connection handler instance
+		 */
+		return (string) apply_filters( 'wc_facebook_redirect_url', $redirect_url, $this );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -182,7 +182,7 @@ class Connection {
 		 * @param string $redirect_url redirect URL
 		 * @param Connection $connection connection handler instance
 		 */
-		return (string) apply_filters( 'wc_facebook_redirect_url', $redirect_url, $this );
+		return (string) apply_filters( 'wc_facebook_connection_redirect_url', $redirect_url, $this );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -107,7 +107,12 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Connection::get_redirect_url() */
 	public function test_get_redirect_url() {
 
-		$this->assertIsString( $this->get_connection()->get_redirect_url() );
+		$redirect_url = $this->get_connection()->get_redirect_url();
+
+		$this->assertIsString( $redirect_url );
+		$this->assertStringContainsString( home_url(), $redirect_url );
+		$this->assertStringContainsString( 'wc-api=' . Connection::ACTION_CONNECT, $redirect_url );
+		$this->assertStringContainsString( 'nonce=', $redirect_url );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -119,7 +119,7 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Connection::get_redirect_url() */
 	public function test_get_redirect_url_filter() {
 
-		add_filter( 'wc_facebook_redirect_url', function() {
+		add_filter( 'wc_facebook_connection_redirect_url', function() {
 
 			return 'filtered';
 		} );

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -116,6 +116,18 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_redirect_url() */
+	public function test_get_redirect_url_filter() {
+
+		add_filter( 'wc_facebook_redirect_url', function() {
+
+			return 'filtered';
+		} );
+
+		$this->assertEquals( 'filtered', $this->get_connection()->get_redirect_url() );
+	}
+
+
 	/** @see Connection::get_connect_parameters() */
 	public function test_get_connect_parameters() {
 


### PR DESCRIPTION
# Summary

This PR updates the `Connection::get_redirect_url()` method to build the connection redirect URL.

### Story: [CH 54012](https://app.clubhouse.io/skyverge/story/54012)
### Release: #1277

## QA

### Tests

- [x] `vendor codecept run integration tests/integration/Handlers/ConnectionTest.php` pass
