### PR TITLE
Generate a unique external business ID

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -151,7 +151,15 @@ class Connection {
 			$this->external_business_id = $value;
 		}
 
-		return $this->external_business_id;
+		/**
+		 * Filters the external business ID.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param string $external_business_id stored external business ID
+		 * @param Connection $connection connection handler instance
+		 */
+		return (string) apply_filters( 'wc_facebook_external_business_id', $this->external_business_id, $this );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -143,7 +143,7 @@ class Connection {
 
 			if ( ! is_string( $value ) ) {
 
-				$value = sanitize_key( get_bloginfo( 'name' ) ) . '-' . uniqid();
+				$value = sanitize_title( get_bloginfo( 'name' ) ) . '-' . uniqid();
 
 				update_option( self::OPTION_EXTERNAL_BUSINESS_ID, $value );
 			}

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -25,7 +25,7 @@ class Connection {
 
 
 	/** @var string|null the generated external merchant settings ID */
-	public $external_business_id;
+	private $external_business_id;
 
 
 	/**

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -24,6 +24,10 @@ class Connection {
 	const OPTION_EXTERNAL_BUSINESS_ID = 'wc_facebook_external_business_id';
 
 
+	/** @var string|null the generated external merchant settings ID */
+	public $external_business_id;
+
+
 	/**
 	 * Constructs a new Connection.
 	 *
@@ -133,7 +137,21 @@ class Connection {
 	 */
 	public function get_external_business_id() {
 
-		return '';
+		if ( ! is_string( $this->external_business_id ) ) {
+
+			$value = get_option( self::OPTION_EXTERNAL_BUSINESS_ID );
+
+			if ( ! is_string( $value ) ) {
+
+				$value = sanitize_key( get_bloginfo( 'name' ) ) . '-' . uniqid();
+
+				update_option( self::OPTION_EXTERNAL_BUSINESS_ID, $value );
+			}
+
+			$this->external_business_id = $value;
+		}
+
+		return $this->external_business_id;
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -20,6 +20,10 @@ defined( 'ABSPATH' ) or exit;
 class Connection {
 
 
+	/** @var string the WordPress option name where the external business ID is stored */
+	const OPTION_EXTERNAL_BUSINESS_ID = 'wc_facebook_external_business_id';
+
+
 	/**
 	 * Constructs a new Connection.
 	 *

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -86,7 +86,24 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Connection::get_external_business_id() */
 	public function test_get_external_business_id() {
 
-		$this->assertIsString( $this->get_connection()->get_external_business_id() );
+		update_option( Connection::OPTION_EXTERNAL_BUSINESS_ID, 'external business id' );
+
+		$this->assertSame( 'external business id', $this->get_connection()->get_external_business_id() );
+	}
+
+
+	/** @see Connection::get_external_business_id() */
+	public function test_get_external_business_id_generation() {
+
+		// force the generation of a new ID
+		delete_option( Connection::OPTION_EXTERNAL_BUSINESS_ID );
+
+		$external_business_id = $this->get_connection()->get_external_business_id();
+
+		$this->assertNotEmpty( $external_business_id );
+		$this->assertIsString( $external_business_id );
+
+		$this->assertEquals( $external_business_id, $this->get_connection()->get_external_business_id() );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -98,12 +98,14 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 		// force the generation of a new ID
 		delete_option( Connection::OPTION_EXTERNAL_BUSINESS_ID );
 
-		$external_business_id = $this->get_connection()->get_external_business_id();
+		$connection           = $this->get_connection();
+		$external_business_id = $connection->get_external_business_id();
 
 		$this->assertNotEmpty( $external_business_id );
 		$this->assertIsString( $external_business_id );
 
-		$this->assertEquals( $external_business_id, $this->get_connection()->get_external_business_id() );
+		$this->assertEquals( $external_business_id, $connection->get_external_business_id() );
+		$this->assertEquals( $external_business_id, get_option( Connection::OPTION_EXTERNAL_BUSINESS_ID ) );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -107,6 +107,18 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_external_business_id() */
+	public function test_get_external_business_id_filter() {
+
+		add_filter( 'wc_facebook_external_business_id', function() {
+
+			return 'filtered';
+		} );
+
+		$this->assertEquals( 'filtered', $this->get_connection()->get_external_business_id() );
+	}
+
+
 	/** @see Connection::get_business_name() */
 	public function test_get_business_name() {
 


### PR DESCRIPTION
# Summary

This PR updates the `Connection::get_external_business_id()` method return the stored external business ID or create one if necessary.

### Story: [CH 54019](https://app.clubhouse.io/skyverge/story/54019)
### Release: #1277

## QA

### Tests

- [x] `vendor codecept run integration tests/integration/Handlers/ConnectionTest.php` pass
