### PR TITLE
Implement the business name value

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -142,7 +142,18 @@ class Connection {
 	 */
 	public function get_business_name() {
 
-		return '';
+		$business_name = html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES, 'UTF-8' );
+
+		/**
+		 * Filters the shop's business name.
+		 *
+		 * This is passed to Facebook when connecting. Defaults to the site name.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param string $business_name the shop's business name
+		 */
+		return apply_filters( 'wc_facebook_connection_business_name', $business_name );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -90,10 +90,46 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Connection::get_business_name() */
-	public function test_get_business_name() {
+	/**
+	 * @see Connection::get_business_name()
+	 *
+	 * @dataProvider provider_get_business_name
+	 *
+	 * @param string $option_value the option value to set
+	 */
+	public function test_get_business_name( $option_value ) {
 
-		$this->assertIsString( $this->get_connection()->get_business_name() );
+		update_option( 'blogname', $option_value );
+
+		$this->assertSame( $option_value, $this->get_connection()->get_business_name() );
+	}
+
+
+	/** @see test_get_business_name() */
+	public function provider_get_business_name() {
+
+		return [
+			[ 'Test Store' ],
+			[ 'Tèst Store' ],
+			[ "Test's Store" ],
+			[ 'Test "Store"' ],
+			[ 'Test & Store' ]
+		];
+	}
+
+
+	/** @see Connection::get_business_name() */
+	public function test_get_business_name_filtered() {
+
+		$option_value = 'Test Store';
+
+		update_option( 'blogname', $option_value );
+
+		add_filter( 'wc_facebook_connection_business_name', function() {
+			return 'Filtered Test Store';
+		} );
+
+		$this->assertSame( 'Filtered Test Store', $this->get_connection()->get_business_name() );
 	}
 
 


### PR DESCRIPTION
# Summary

Returns the site name as business name.

### Story: [CH 54025](https://app.clubhouse.io/skyverge/story/54025)
### Release: #1277 

## Details

The name is returned HTML-encoded, so we decode here to pass to Facebook.

## UI Changes

N/A

## QA

- [x] `codecept run integration Handlers/ConnectionTest` tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version