### PR TITLE
Implement the business manager ID storage

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -159,7 +159,7 @@ class Connection {
 	 */
 	public function get_business_manager_id() {
 
-		return '';
+		return get_option( self::OPTION_BUSINESS_MANAGER_ID, '' );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -20,6 +20,10 @@ defined( 'ABSPATH' ) or exit;
 class Connection {
 
 
+	/** @var string the business manager ID option name */
+	const OPTION_BUSINESS_MANAGER_ID = 'wc_facebook_business_manager_id';
+
+
 	/**
 	 * Constructs a new Connection.
 	 *

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -198,6 +198,7 @@ class Connection {
 	 */
 	public function update_business_manager_id( $value ) {
 
+		update_option( self::OPTION_BUSINESS_MANAGER_ID, $value );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -100,7 +100,11 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Connection::get_business_manager_id() */
 	public function test_get_business_manager_id() {
 
-		$this->assertIsString( $this->get_connection()->get_business_manager_id() );
+		$business_manager_id = 'business manager id';
+
+		$this->get_connection()->update_business_manager_id( $business_manager_id );
+
+		$this->assertSame( $business_manager_id, $this->get_connection()->get_business_manager_id() );
 	}
 
 
@@ -123,7 +127,9 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 
 		$business_manager_id = 'business manager id';
 
-		$this->assertNull( $this->get_connection()->update_business_manager_id( $business_manager_id ) );
+		$this->get_connection()->update_business_manager_id( $business_manager_id );
+
+		$this->assertSame( $business_manager_id, $this->get_connection()->get_business_manager_id() );
 	}
 
 


### PR DESCRIPTION
# Summary

Adds storage for the business manager ID.

### Story: [CH 54028](https://app.clubhouse.io/skyverge/story/54028)
### Release: #1277 

## UI Changes

N/A

## QA

- [x] `codecept run integration Handlers/ConnectionTest` tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version