### PR TITLE
Build Oauth URL

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -23,7 +23,10 @@ class Connection {
 	/** @var string Facebook client identifier */
 	const CLIENT_ID = '1234';
 
-	/** @var string WooCommerce connection proxy */
+	/** @var string Facebook OAuth URL */
+	const OAUTH_URL = 'https://facebook.com/dialog/oauth';
+
+	/** @var string WooCommerce connection proxy URL */
 	const PROXY_URL = 'https://connect.woocommerce.com/auth/facebook/';
 
 	/** @var string the action callback for the connection */

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -116,7 +116,7 @@ class Connection {
 	 */
 	public function get_connect_url() {
 
-		return '';
+		return add_query_arg( $this->get_connect_parameters(), self::OAUTH_URL );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -69,7 +69,12 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Connection::get_connect_url() */
 	public function test_get_connect_url() {
 
-		$this->assertIsString( $this->get_connection()->get_connect_url() );
+		$connection     = $this->get_connection();
+		$connection_url = $connection->get_connect_url();
+
+		$this->assertIsString( $connection_url );
+		$this->assertStringContainsString( Connection::OAUTH_URL, $connection_url );
+		$this->assertEquals( add_query_arg( $connection->get_connect_parameters(), Connection::OAUTH_URL ), $connection_url );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR updates the `Connection::get_connect_url()` method to use he FB Oauth URL and the connection params from #1287.

### Story: [CH 54043](https://app.clubhouse.io/skyverge/story/54043/build-the-oauth-url)
### Release: #1277

## QA

### Tests

- [ ] `vendor codecept run integration tests/integration/Handlers/ConnectionTest.php` pass
