### PR TITLE
Handle the connection callback

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4197,6 +4197,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	function admin_options() {
 
+		facebook_for_woocommerce()->get_message_handler()->show_messages();
+
 		$page_name      = $this->get_page_name();
 		$can_manage     = current_user_can( 'manage_woocommerce' );
 		$pre_setup      = empty( $this->get_facebook_page_id() ) || empty( $this->get_page_access_token() );

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -63,6 +63,25 @@ class Connection {
 			return;
 		}
 
+		try {
+
+			if ( empty( $_GET['nonce'] ) || ! wp_verify_nonce( $_GET['nonce'], self::ACTION_CONNECT ) ) {
+				throw new SV_WC_API_Exception( 'Invalid nonce' );
+			}
+
+			$access_token = ! empty( $_GET['access_token'] ) ? sanitize_text_field( $_GET['access_token'] ) : '';
+
+			$this->update_access_token( $access_token );
+
+			facebook_for_woocommerce()->get_message_handler()->add_message( __( 'Connection successful', 'facebook-for-woocommerce' ) );
+
+		} catch ( SV_WC_API_Exception $exception ) {
+
+			facebook_for_woocommerce()->log( sprintf( 'Connection failed: %s', $exception->getMessage() ) );
+
+			facebook_for_woocommerce()->get_message_handler()->add_error( __( 'Connection unsuccessful. Please try again.', 'facebook-for-woocommerce' ) );
+		}
+
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -88,6 +88,8 @@ class Connection {
 			facebook_for_woocommerce()->get_message_handler()->add_error( __( 'Connection unsuccessful. Please try again.', 'facebook-for-woocommerce' ) );
 		}
 
+		wp_safe_redirect( facebook_for_woocommerce()->get_settings_url() );
+		exit;
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -10,6 +10,8 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Handlers;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Exception;
+
 defined( 'ABSPATH' ) or exit;
 
 /**
@@ -55,6 +57,11 @@ class Connection {
 	 * @since 2.0.0-dev.1
 	 */
 	public function handle_connect() {
+
+		// don't handle anything unless the user can manage WooCommerce settings
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
 
 	}
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -267,7 +267,10 @@ class Connection {
 	 */
 	public function get_redirect_url() {
 
-		$redirect_url = wp_nonce_url( add_query_arg( 'wc-api', self::ACTION_CONNECT, home_url() ), self::ACTION_CONNECT, 'nonce' );
+		$redirect_url = add_query_arg( [
+			'wc-api' => self::ACTION_CONNECT,
+			'nonce'  => wp_create_nonce( self::ACTION_CONNECT ),
+		], home_url( '/' ) );
 
 		/**
 		 * Filters the redirect URL where the user will return to after OAuth.

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -75,6 +75,8 @@ class Connection {
 				throw new SV_WC_API_Exception( 'Access token is missing' );
 			}
 
+			$access_token = $this->create_system_user_token( $access_token );
+
 			$this->update_access_token( $access_token );
 
 			facebook_for_woocommerce()->get_message_handler()->add_message( __( 'Connection successful', 'facebook-for-woocommerce' ) );

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -46,6 +46,7 @@ class Connection {
 	 */
 	public function __construct() {
 
+		add_action( 'woocommerce_api_' . self::ACTION_CONNECT, [ $this, 'handle_connect' ] );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -71,6 +71,10 @@ class Connection {
 
 			$access_token = ! empty( $_GET['access_token'] ) ? sanitize_text_field( $_GET['access_token'] ) : '';
 
+			if ( ! $access_token ) {
+				throw new SV_WC_API_Exception( 'Access token is missing' );
+			}
+
 			$this->update_access_token( $access_token );
 
 			facebook_for_woocommerce()->get_message_handler()->add_message( __( 'Connection successful', 'facebook-for-woocommerce' ) );

--- a/tests/acceptance/ConnectionCest.php
+++ b/tests/acceptance/ConnectionCest.php
@@ -1,0 +1,64 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
+
+class ConnectionCest {
+
+
+	/** @see Connection::handle_connect() */
+	public function try_handle_connect_as_guest( AcceptanceTester $I ) {
+
+		$I->wantTo( 'Ensure the token is not stored by the callback for guests' );
+
+		$I->amOnUrl( add_query_arg( 'access_token', 'xyz', facebook_for_woocommerce()->get_connection_handler()->get_redirect_url() ) );
+
+		$I->dontHaveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN );
+		$I->see( '-1' );
+	}
+
+
+	/** @see Connection::handle_connect() */
+	public function try_handle_connect_with_bad_nonce( AcceptanceTester $I ) {
+
+		$I->wantTo( 'Ensure the token is not stored by the callback with an invalid nonce' );
+
+		$I->loginAsAdmin();
+
+		$url = add_query_arg( 'access_token', 'xyz', facebook_for_woocommerce()->get_connection_handler()->get_redirect_url() );
+
+		// override the nonce with a fake
+		$url = add_query_arg( 'nonce', 'bad-nonce', $url );
+
+		$I->amOnUrl( $url );
+
+		$I->dontHaveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN );
+	}
+
+
+	/** @see Connection::handle_connect() */
+	public function try_handle_connect_with_no_token( AcceptanceTester $I ) {
+
+		$I->wantTo( 'Ensure the callback halts if the access token is missing' );
+
+		$I->loginAsAdmin();
+
+		$I->amOnUrl( facebook_for_woocommerce()->get_connection_handler()->get_redirect_url() );
+
+		$I->dontHaveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN );
+	}
+
+
+	/** @see Connection::handle_connect() */
+	public function try_handle_connect( AcceptanceTester $I ) {
+
+		$I->wantTo( 'Ensure the callback stores the token if everything passes security checks' );
+
+		$I->loginAsAdmin();
+
+		$I->amOnUrl( add_query_arg( 'access_token', 'xyz', facebook_for_woocommerce()->get_connection_handler()->get_redirect_url() ) );
+
+		$I->haveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN, 'xyz' );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

Implements the connection redirect callback to validate security and store the given token.

### Story: [CH 54075](https://app.clubhouse.io/skyverge/story/54075)
### Release: #1277

## Details

I went with a set of acceptance tests for this, since it is a browser flow.

## QA

### Tests

- [x] `codecept run acceptance ConnectionCest` passes
