### PR TITLE
Use the user access token for API requests

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4185,10 +4185,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		facebook_for_woocommerce()->get_message_handler()->show_messages();
 
+		$access_token   = facebook_for_woocommerce()->get_connection_handler()->get_access_token();
 		$page_name      = $this->get_page_name();
 		$can_manage     = current_user_can( 'manage_woocommerce' );
-		$pre_setup      = empty( $this->get_facebook_page_id() ) || empty( $this->get_page_access_token() );
-		$apikey_invalid = ! $pre_setup && $this->get_page_access_token() && ! $page_name;
+		$pre_setup      = empty( $this->get_facebook_page_id() ) || empty( $access_token );
+		$apikey_invalid = ! $pre_setup && $access_token && ! $page_name;
 
 		$remove_http_active     = is_plugin_active( 'remove-http/remove-http.php' );
 		$https_will_be_stripped = $remove_http_active && ! get_option( 'factmaven_rhttp' )['external'];

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -353,14 +353,14 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				self::FB_PRIORITY_MID
 			);
 
-			// on_product_save() must run with priority larger than 20 to make sure WooCommerce has a chance to save the submitted product information
-			add_action( 'woocommerce_process_product_meta', [ $this, 'on_product_save' ], 40 );
-
 			// don't duplicate product FBID meta
 			add_filter( 'woocommerce_duplicate_product_exclude_meta', [ $this, 'fb_duplicate_product_reset_meta' ] );
 
 			// add product processing hooks if the plugin is configured only
 			if ( $this->is_configured() && $this->get_product_catalog_id() ) {
+
+				// on_product_save() must run with priority larger than 20 to make sure WooCommerce has a chance to save the submitted product information
+				add_action( 'woocommerce_process_product_meta', [ $this, 'on_product_save' ], 40 );
 
 				add_action(
 					'woocommerce_product_quick_edit_save',

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1032,8 +1032,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function on_product_publish( $wp_id ) {
 
-		// bail if we don't have a page access token or a catalog ID configured
-		if ( ! $this->get_page_access_token() || ! $this->get_product_catalog_id() ) {
+		// bail if the plugin is not configured properly
+		if ( ! $this->is_configured() || ! $this->get_product_catalog_id() ) {
 			return;
 		}
 
@@ -4297,8 +4297,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	function update_fb_visibility( $wp_id, $visibility ) {
 
-		// bail if we don't have a page access token or a catalog ID configured
-		if ( ! $this->get_page_access_token() || ! $this->get_product_catalog_id() ) {
+		// bail if the plugin is not configured properly
+		if ( ! $this->is_configured() || ! $this->get_product_catalog_id() ) {
 			return;
 		}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1963,22 +1963,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			echo $this->get_message_html( $message, 'info' );
 		}
 
-		// WooCommerce 2.x upgrade nag
-		if ( $this->get_page_access_token() && ( ! isset( $this->background_processor ) ) ) {
-
-			$message = sprintf(
-				/* translators: Placeholders %1$s - WooCommerce version */
-				esc_html__(
-					'Facebook product sync may not work correctly in WooCommerce version %1$s. Please upgrade to WooCommerce 3.',
-					'facebook-for-woocommerce'
-				),
-				esc_html( WC()->version )
-			);
-
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo $this->get_message_html( $message, 'warning' );
-		}
-
 		$this->maybe_display_facebook_api_messages();
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -245,7 +245,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) {
 			include_once 'includes/fbgraph.php';
-			$this->fbgraph = new WC_Facebookcommerce_Graph_API( $this->get_page_access_token() );
+			$this->fbgraph = new WC_Facebookcommerce_Graph_API( facebook_for_woocommerce()->get_connection_handler()->get_access_token() );
 		}
 
 		WC_Facebookcommerce_Utils::$fbgraph = $this->fbgraph;

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -476,7 +476,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( isset( $_POST['request_time'] ) ) {
 			$request_time = esc_js( sanitize_text_field( wp_unslash( $_POST['request_time'] ) ) );
 		}
-		if ( $this->get_page_access_token() ) {
+
+		if ( facebook_for_woocommerce()->get_connection_handler()->get_access_token() ) {
+
 			if ( isset( $this->background_processor ) ) {
 				$is_processing = $this->background_processor->handle_cron_healthcheck();
 				$remaining     = $this->background_processor->get_item_count();
@@ -499,6 +501,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				'background' => false,
 			);
 		}
+
 		printf( json_encode( $response ) );
 		wp_die();
 	}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -826,7 +826,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Checks the product type and calls the corresponding on publish method.
 	 *
-	 *
 	 * @internal
 	 *
 	 * @since 1.10.0
@@ -862,7 +861,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// do not attempt to update product visibility during FBE 1.5: the Visible setting was removed so it always seems as if the visibility had been disabled
 		// $this->update_fb_visibility( $product->get_id(), $is_visible ? self::FB_SHOP_PRODUCT_VISIBLE : self::FB_SHOP_PRODUCT_HIDDEN );
 
-		if ( $sync_enabled && $this->get_page_access_token() && $this->get_product_catalog_id() ) {
+		if ( $sync_enabled && $this->is_configured() ) {
 
 			switch ( $product->get_type() ) {
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2204,11 +2204,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			throw new Framework\SV_WC_Plugin_Exception( __( 'Product sync is disabled.', 'facebook-for-woocommerce' ) );
 		}
 
-		if ( ! $this->get_page_access_token() || ! $this->get_product_catalog_id() ) {
+		if ( ! $this->is_configured() || ! $this->get_product_catalog_id() ) {
 
-			WC_Facebookcommerce_Utils::log( sprintf( 'No API key or Catalog ID: %s and %s', $this->get_page_access_token(), $this->get_product_catalog_id() ) );
+			WC_Facebookcommerce_Utils::log( sprintf( 'Not syncing, the plugin is not configured or the Catalog ID is missing' ) );
 
-			throw new Framework\SV_WC_Plugin_Exception( __( 'The page access token or product catalog ID are missing.', 'facebook-for-woocommerce' ) );
+			throw new Framework\SV_WC_Plugin_Exception( __( 'The plugin is not configured or the Catalog ID is missing.', 'facebook-for-woocommerce' ) );
 		}
 
 		$this->remove_resync_message();
@@ -2383,11 +2383,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			throw new Framework\SV_WC_Plugin_Exception( __( 'Product sync is disabled.', 'facebook-for-woocommerce' ) );
 		}
 
-		if ( ! $this->get_page_access_token() || ! $this->get_product_catalog_id() ) {
+		if ( ! $this->is_configured() || ! $this->get_product_catalog_id() ) {
 
-			WC_Facebookcommerce_Utils::log( sprintf( 'No API key or Catalog ID: %s and %s', $this->get_page_access_token(), $this->get_product_catalog_id() ) );
+			WC_Facebookcommerce_Utils::log( sprintf( 'Not syncing, the plugin is not configured or the Catalog ID is missing' ) );
 
-			throw new Framework\SV_WC_Plugin_Exception( __( 'The page access token or product catalog ID are missing.', 'facebook-for-woocommerce' ) );
+			throw new Framework\SV_WC_Plugin_Exception( __( 'The plugin is not configured or the Catalog ID is missing.', 'facebook-for-woocommerce' ) );
 		}
 
 		$this->remove_resync_message();

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -359,8 +359,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			// don't duplicate product FBID meta
 			add_filter( 'woocommerce_duplicate_product_exclude_meta', [ $this, 'fb_duplicate_product_reset_meta' ] );
 
-			// Only load product processing hooks if we have completed setup.
-			if ( $this->get_page_access_token() && $this->get_product_catalog_id() ) {
+			// add product processing hooks if the plugin is configured only
+			if ( $this->is_configured() ) {
 
 				add_action(
 					'woocommerce_product_quick_edit_save',

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1657,7 +1657,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		check_ajax_referer( 'wc_facebook_settings_jsx' );
 
-		if ( $this->get_page_access_token() ) {
+		if ( $this->is_configured() ) {
 
 			$response = [
 				'connected' => true,

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4100,9 +4100,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function get_page_name() {
 
-		// TODO: replace with `if ( $this->is_configured() ) {` when access tokens become available again {WV 2020-03-31}
-		if ( $this->get_facebook_page_id() && $this->get_page_access_token() ) {
-			$page_name = $this->fbgraph->get_page_name( $this->get_facebook_page_id(), $this->get_page_access_token() );
+		if ( $this->get_facebook_page_id() && $this->is_configured() ) {
+			$page_name = $this->fbgraph->get_page_name( $this->get_facebook_page_id() );
 		} else {
 			$page_name = '';
 		}
@@ -4120,8 +4119,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function get_page_url() {
 
-		if ( $this->is_configured() ) {
-			$page_url = $this->fbgraph->get_page_url( $this->get_facebook_page_id(), $this->get_page_access_token() );
+		if ( $this->get_facebook_page_id() && $this->is_configured() ) {
+			$page_url = $this->fbgraph->get_page_url( $this->get_facebook_page_id() );
 		} else {
 			$page_url = '';
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -360,7 +360,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			add_filter( 'woocommerce_duplicate_product_exclude_meta', [ $this, 'fb_duplicate_product_reset_meta' ] );
 
 			// add product processing hooks if the plugin is configured only
-			if ( $this->is_configured() ) {
+			if ( $this->is_configured() && $this->get_product_catalog_id() ) {
 
 				add_action(
 					'woocommerce_product_quick_edit_save',
@@ -861,7 +861,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// do not attempt to update product visibility during FBE 1.5: the Visible setting was removed so it always seems as if the visibility had been disabled
 		// $this->update_fb_visibility( $product->get_id(), $is_visible ? self::FB_SHOP_PRODUCT_VISIBLE : self::FB_SHOP_PRODUCT_HIDDEN );
 
-		if ( $sync_enabled && $this->is_configured() ) {
+		if ( $sync_enabled && $this->is_configured() && $this->get_product_catalog_id() ) {
 
 			switch ( $product->get_type() ) {
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -3892,7 +3892,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function is_configured() {
 
-		return (bool) $this->get_external_merchant_settings_id();
+		return facebook_for_woocommerce()->get_connection_handler()->is_connected();
 	}
 
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -32,10 +32,10 @@ class Admin {
 		// enqueue admin scripts
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 
-		$integration = facebook_for_woocommerce()->get_integration();
+		$plugin = facebook_for_woocommerce();
 
 		// only alter the admin UI if the plugin is connected to Facebook and ready to sync products
-		if ( ! $integration->get_product_catalog_id() ) {
+		if ( ! $plugin->get_connection_handler()->is_connected() || ! $plugin->get_integration()->get_product_catalog_id() ) {
 			return;
 		}
 
@@ -52,7 +52,7 @@ class Admin {
 		// add admin notice to inform that the catalog visibility setting was removed
 		add_action( 'admin_notices', [ $this, 'add_catalog_visibility_settings_removed_notice' ] );
 		// handle dismissal of special notices
-		add_action( 'wc_' . facebook_for_woocommerce()->get_id(). '_dismiss_notice', [ $this, 'handle_dismiss_notice' ], 10, 2 );
+		add_action( 'wc_' . $plugin->get_id(). '_dismiss_notice', [ $this, 'handle_dismiss_notice' ], 10, 2 );
 
 		// add columns for displaying Facebook sync enabled/disabled and catalog visibility status
 		add_filter( 'manage_product_posts_columns',       [ $this, 'add_product_list_table_columns' ] );

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -138,7 +138,17 @@ class Connection {
 	 */
 	public function get_access_token() {
 
-		return get_option( self::OPTION_ACCESS_TOKEN, '' );
+		$access_token = get_option( self::OPTION_ACCESS_TOKEN, '' );
+
+		/**
+		 * Filters the API access token.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param string $access_token access token
+		 * @param Connection $connection connection handler instance
+		 */
+		return apply_filters( 'wc_facebook_connection_access_token', $access_token, $this );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -385,7 +385,7 @@ class Connection {
 	 */
 	public function is_connected() {
 
-		return true;
+		return (bool) $this->get_access_token();
 	}
 
 

--- a/tests/acceptance/Admin/ProductMetaboxCest.php
+++ b/tests/acceptance/Admin/ProductMetaboxCest.php
@@ -1,0 +1,65 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
+
+class ProductMetaboxCest {
+
+
+	/** @var WC_Product|null product object created for the test */
+	private $product;
+
+
+	/**
+	 * Runs before each test.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 * @throws \Exception
+	 */
+    public function _before( AcceptanceTester $I ) {
+
+		$this->product = $I->haveProductInDatabase();
+
+		// always log in
+		$I->loginAsAdmin();
+    }
+
+
+	/**
+	 * Tests that the field is unchecked if sync is disabled in parent.
+	 *
+	 * @param AcceptanceTester $I
+	 * @throws \Exception
+	 */
+	public function try_metabox_is_not_visibile_if_the_plugin_is_not_connected( AcceptanceTester $I ) {
+
+		$I->wantTo( 'Test that product metabox is not shown when the plugin is connected' );
+
+		$I->dontHaveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN );
+
+		$I->amEditingPostWithId( $this->product->get_id() );
+		$I->waitForElementVisible( 'input[type="submit"][value="Update"]', 5 );
+
+		$I->dontSeeElement( [ 'css' => '#facebook_metabox' ] );
+	}
+
+
+	/**
+	 * Tests that the field is unchecked if sync is disabled in parent.
+	 *
+	 * @param AcceptanceTester $I
+	 * @throws \Exception
+	 */
+	public function try_metabox_is_visibile_if_the_plugin_is_connected( AcceptanceTester $I ) {
+
+		$I->wantTo( 'Test that product metabox is shown when the plugin is connected' );
+
+		$I->haveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN, 'xyz' );
+
+		$I->amEditingPostWithId( $this->product->get_id() );
+		$I->waitForElementVisible( 'input[type="submit"][value="Update"]', 5 );
+
+		$I->seeElement( [ 'css' => '#facebook_metabox' ] );
+	}
+
+
+}

--- a/tests/acceptance/Admin/ProductSyncColumnCest.php
+++ b/tests/acceptance/Admin/ProductSyncColumnCest.php
@@ -1,5 +1,7 @@
 <?php
 
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
+
 class ProductSyncColumnCest {
 
 
@@ -19,7 +21,7 @@ class ProductSyncColumnCest {
 		// save a generic product
 		$this->product = $I->haveProductInDatabase();
 
-		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '1234' );
+		$I->haveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN, '1234' );
 		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234' );
 
 		// always log in
@@ -39,6 +41,38 @@ class ProductSyncColumnCest {
 		$I->wantTo( 'Test that the column is present' );
 
 		$I->see( 'FB Sync Enabled', 'table.wp-list-table th' );
+	}
+
+
+	/**
+	 * Test that the column is not present.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 * @param \Codeception\Example $example test data
+	 *
+	 * @dataProvider provider_column_not_present
+	 */
+	public function try_column_not_present( AcceptanceTester $I, \Codeception\Example $example ) {
+
+		$I->haveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN, $example['access_token'] );
+		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, $example['catalog_id'] );
+
+		$I->amOnProductsPage();
+
+		$I->wantTo( 'Test that the column is not present if the plugin is not connected or ready' );
+
+		$I->dontSee( 'FB Sync Enabled', 'table.wp-list-table th' );
+	}
+
+
+	/** @see try_column_not_present() */
+	protected function provider_column_not_present() {
+
+		return [
+			[ 'access_token' => '',     'catalog_id' => '' ],
+			[ 'access_token' => '1234', 'catalog_id' => '' ],
+			[ 'access_token' => '',     'catalog_id' => '1234'],
+		];
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -66,6 +66,18 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_access_token() */
+	public function test_get_access_token_filter() {
+
+		add_filter( 'wc_facebook_connection_access_token', function() {
+
+			return 'filtered';
+		} );
+
+		$this->assertSame( 'filtered', $this->get_connection()->get_access_token() );
+	}
+
+
 	/** @see Connection::get_connect_url() */
 	public function test_get_connect_url() {
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -344,9 +344,20 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @see Connection::is_connected() */
+	public function test_is_not_connected_without_access_token() {
+
+		$this->assertFalse( $this->get_connection()->is_connected() );
+	}
+
+
+	/** @see Connection::is_connected() */
 	public function test_is_connected() {
 
-		$this->assertIsBool( $this->get_connection()->is_connected() );
+		$connection = $this->get_connection();
+
+		$connection->update_access_token( 'access token' );
+
+		$this->assertTrue( $connection->is_connected() );
 	}
 
 

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -594,35 +594,6 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	// }
 
 
-	/**
-	 * @see \WC_Facebookcommerce_Integration::is_configured()
-	 *
-	 * TODO: consider removing this test when FBE 2.0 modifications are available {WV 2020-04-22}
-	 *
-	 * @param string $external_merchant_settings_id Facebook external merchant settings ID
-	 * @param bool $expected whether Facebook for WooCommerce is configured or not
-	 *
-	 * @dataProvider provider_is_configured_with_external_merchant_settings_id()
-	 */
-	public function test_is_configured_with_external_merchant_settings_id( $external_merchant_settings_id, $expected ) {
-
-		$this->integration->update_external_merchant_settings_id( $external_merchant_settings_id );
-		$this->integration->init_settings();
-
-		$this->assertSame( $expected, $this->integration->is_configured() );
-	}
-
-
-	/** @see test_is_configured_with_external_merchant_settings_id() */
-	public function provider_is_configured_with_external_merchant_settings_id() {
-
-		return [
-			[ 'external-merchant-settings-id', true ],
-			[ '',                              false ],
-		];
-	}
-
-
 	/** @see \WC_Facebookcommerce_Integration::is_advanced_matching_enabled() */
 	public function test_is_advanced_matching_enabled() {
 

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -560,38 +560,37 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	}
 
 
-	// /**
-	//  * @see \WC_Facebookcommerce_Integration::is_configured()
-	//  *
-	//  * TODO: uncomment when FBE 2.0 modifications are available {WV 2020-04-22}
-	//  *
-	//  * @param string $access_token Facebook access token
-	//  * @param string $page_id Facebok page ID
-	//  * @param bool $expected whether Facebook for WooCommerce is configured or not
-	//  *
-	//  * @dataProvider provider_is_configured()
-	//  */
-	// public function test_is_configured( $access_token, $page_id, $expected ) {
+	/**
+	 * @see \WC_Facebookcommerce_Integration::is_configured()
+	 *
+	 * @param string $access_token Facebook access token
+	 * @param string $page_id Facebok page ID
+	 * @param bool $expected whether Facebook for WooCommerce is configured or not
+	 *
+	 * @dataProvider provider_is_configured()
+	 */
+	public function test_is_configured( $access_token, $page_id, $expected ) {
 
-	// 	$this->add_settings( [ \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID => $page_id ] );
+		$this->add_settings( [ \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID => $page_id ] );
 
-	// 	$this->integration->update_page_access_token( $access_token );
-	// 	$this->integration->init_settings();
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( $access_token );
 
-	// 	$this->assertSame( $expected, $this->integration->is_configured() );
-	// }
+		$this->assertSame( $expected, $this->integration->is_configured() );
+	}
 
 
-	// /** @see test_is_configured() */
-	// public function provider_is_configured() {
+	/** @see test_is_configured() */
+	public function provider_is_configured() {
 
-	// 	return [
-	// 		[ 'abc123', 'facebook-page-id', true ],
-	// 		[ '',       'facebook-page-id', false ],
-	// 		[ 'abc123', '',                 false ],
-	// 		[ '',       '',                 false ],
-	// 	];
-	// }
+		// TODO: uncomment the third case after we start retrieving Page IDs using Handlers\Connection::get_asset_ids() {WV-2020-05-13}
+
+		return [
+			[ 'abc123', 'facebook-page-id', true ],
+			[ '',       'facebook-page-id', false ],
+			// [ 'abc123', '',                 false ],
+			[ '',       '',                 false ],
+		];
+	}
 
 
 	/** @see \WC_Facebookcommerce_Integration::is_advanced_matching_enabled() */


### PR DESCRIPTION
# Summary

This PR replaces usages of `\WC_Facebookcommerce_Integration::get_page_access_token()` with calls to `Handlers\Connection::get_access_token()` or calls to `WC_Facebookcommerce_Integration::is_configured()`. The latter also uses `Handlers\Connection::get_access_token()` indirectly.

### Story: [CH 54059](https://app.clubhouse.io/skyverge/story/54059)
### Release: #1277

## UI Changes

N/A

## QA

### Setup

Add a handler for the `wc_facebook_connection_access_token` filter and return a valid user access token.

Note: user access tokens can be generated using the [Graph API explorer](https://developers.facebook.com/tools/explorer/)

```php
add_filter( 'wc_facebook_connection_access_token', function() {

    return 'access_token';
} );
```

### Steps

- [ ] Code review
- [x] `codecept run integration` pass
- [ ] `codecept run acceptance tests/acceptance/Admin/ProductMetaboxCest.php` pass 

I also ran other user tests to check that some features are back or continue to work when an access token is available, but I think code review and tests is is enough for this one.

#### Product sync using background processor

1. Go to the plugin settings page
1. Execute `sync_all_products( false )` in the browser's console
    - [x] The console logs and the message under Product sync indicate that a background sync is in progress
    - [x] Products are synced to facebook

#### Product sync using feed

1. Go to the plugin settings page
1. Execute `sync_all_products( true )` in the browser's console
    - [x] The console logs and the message under Product sync indicate that a sync opereation is in progress
    - [x] Products are synced to facebook

#### Product sync on product save

1. Edit a product
1. Make sure that Incldue in Facebook sync is checked
1. Click Update
    - [x] The product is synced with Facebook
