### PR TITLE
Add admin hooks if the plugin is connected only

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -353,14 +353,14 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				self::FB_PRIORITY_MID
 			);
 
-			// on_product_save() must run with priority larger than 20 to make sure WooCommerce has a chance to save the submitted product information
-			add_action( 'woocommerce_process_product_meta', [ $this, 'on_product_save' ], 40 );
-
 			// don't duplicate product FBID meta
 			add_filter( 'woocommerce_duplicate_product_exclude_meta', [ $this, 'fb_duplicate_product_reset_meta' ] );
 
 			// add product processing hooks if the plugin is configured only
 			if ( $this->is_configured() && $this->get_product_catalog_id() ) {
+
+				// on_product_save() must run with priority larger than 20 to make sure WooCommerce has a chance to save the submitted product information
+				add_action( 'woocommerce_process_product_meta', [ $this, 'on_product_save' ], 40 );
 
 				add_action(
 					'woocommerce_product_quick_edit_save',

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -35,7 +35,7 @@ class Admin {
 		$plugin = facebook_for_woocommerce();
 
 		// only alter the admin UI if the plugin is connected to Facebook and ready to sync products
-		if ( ! $plugin->get_integration()->get_product_catalog_id() ) {
+		if ( ! $plugin->get_connection_handler()->is_connected() || ! $plugin->get_integration()->get_product_catalog_id() ) {
 			return;
 		}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -32,10 +32,10 @@ class Admin {
 		// enqueue admin scripts
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 
-		$integration = facebook_for_woocommerce()->get_integration();
+		$plugin = facebook_for_woocommerce();
 
 		// only alter the admin UI if the plugin is connected to Facebook and ready to sync products
-		if ( ! $integration->get_product_catalog_id() ) {
+		if ( ! $plugin->get_integration()->get_product_catalog_id() ) {
 			return;
 		}
 
@@ -52,7 +52,7 @@ class Admin {
 		// add admin notice to inform that the catalog visibility setting was removed
 		add_action( 'admin_notices', [ $this, 'add_catalog_visibility_settings_removed_notice' ] );
 		// handle dismissal of special notices
-		add_action( 'wc_' . facebook_for_woocommerce()->get_id(). '_dismiss_notice', [ $this, 'handle_dismiss_notice' ], 10, 2 );
+		add_action( 'wc_' . $plugin->get_id(). '_dismiss_notice', [ $this, 'handle_dismiss_notice' ], 10, 2 );
 
 		// add columns for displaying Facebook sync enabled/disabled and catalog visibility status
 		add_filter( 'manage_product_posts_columns',       [ $this, 'add_product_list_table_columns' ] );

--- a/tests/acceptance/Admin/ProductSyncColumnCest.php
+++ b/tests/acceptance/Admin/ProductSyncColumnCest.php
@@ -1,5 +1,7 @@
 <?php
 
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
+
 class ProductSyncColumnCest {
 
 
@@ -19,7 +21,7 @@ class ProductSyncColumnCest {
 		// save a generic product
 		$this->product = $I->haveProductInDatabase();
 
-		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '1234' );
+		$I->haveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN, '1234' );
 		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234' );
 
 		// always log in
@@ -39,6 +41,38 @@ class ProductSyncColumnCest {
 		$I->wantTo( 'Test that the column is present' );
 
 		$I->see( 'FB Sync Enabled', 'table.wp-list-table th' );
+	}
+
+
+	/**
+	 * Test that the column is not present.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 * @param \Codeception\Example $example test data
+	 *
+	 * @dataProvider provider_column_not_present
+	 */
+	public function try_column_not_present( AcceptanceTester $I, \Codeception\Example $example ) {
+
+		$I->haveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN, $example['access_token'] );
+		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, $example['catalog_id'] );
+
+		$I->amOnProductsPage();
+
+		$I->wantTo( 'Test that the column is not present if the plugin is not connected or ready' );
+
+		$I->dontSee( 'FB Sync Enabled', 'table.wp-list-table th' );
+	}
+
+
+	/** @see try_column_not_present() */
+	protected function provider_column_not_present() {
+
+		return [
+			[ 'access_token' => '',     'catalog_id' => '' ],
+			[ 'access_token' => '1234', 'catalog_id' => '' ],
+			[ 'access_token' => '',     'catalog_id' => '1234'],
+		];
 	}
 
 


### PR DESCRIPTION
# Summary

This updates `\WC_Facebookcommerce_Integration` and `Facebook\Admin` to avoid registering hooks or altering the UI if the plugin is not connected.

### Story: [CH 54109](https://app.clubhouse.io/skyverge/story/54109)
### Release: #1277

## UI Changes

N/A

## QA

### Setup

Add a handler for the `wc_facebook_connection_access_token` filter and return a valid user access token.

Note: user access tokens can be generated using the [Graph API explorer](https://developers.facebook.com/tools/explorer/)

```php
add_filter( 'wc_facebook_connection_access_token', function() {

    return 'access_token';
} );
```

### Steps

- [x] Code review
- [x] `codecept run tests/acceptance/Admin/ProductSyncColumnCest.php:try_column_not_present` pass

#### Edit Product

1. Create a product
1. Make sure Include in Facebook sync is enabled
1. Define a price for the product
1. Add a custom description for Facebook
1. Publish the product
    - [x] The product is synced to Facebook
1. Remove the callback for the `wc_facebook_connection_access_token` filter
1. Edit the product
    - [x] The metabox and Facebook settings are not shown
    - [x] Saving the product does not update the changes in Facebook
