### PR TITLE
Update is configured to check for a stored page ID

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -3878,7 +3878,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function is_configured() {
 
-		return facebook_for_woocommerce()->get_connection_handler()->is_connected();
+		return $this->get_facebook_page_id() && facebook_for_woocommerce()->get_connection_handler()->is_connected();
 	}
 
 
@@ -4100,7 +4100,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function get_page_name() {
 
-		if ( $this->get_facebook_page_id() && $this->is_configured() ) {
+		if ( $this->is_configured() ) {
 			$page_name = $this->fbgraph->get_page_name( $this->get_facebook_page_id() );
 		} else {
 			$page_name = '';
@@ -4119,7 +4119,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function get_page_url() {
 
-		if ( $this->get_facebook_page_id() && $this->is_configured() ) {
+		if ( $this->is_configured() ) {
 			$page_url = $this->fbgraph->get_page_url( $this->get_facebook_page_id() );
 		} else {
 			$page_url = '';

--- a/tests/acceptance/Admin/ProductMetaboxCest.php
+++ b/tests/acceptance/Admin/ProductMetaboxCest.php
@@ -54,6 +54,11 @@ class ProductMetaboxCest {
 		$I->wantTo( 'Test that product metabox is shown when the plugin is connected' );
 
 		$I->haveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN, 'xyz' );
+		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, 'xyz' );
+
+		$I->haveFacebookForWooCommerceSettingsInDatabase( [
+			\WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID => '1234',
+		] );
 
 		$I->amEditingPostWithId( $this->product->get_id() );
 		$I->waitForElementVisible( 'input[type="submit"][value="Update"]', 5 );

--- a/tests/acceptance/Admin/ProductSyncEnabledFilterCest.php
+++ b/tests/acceptance/Admin/ProductSyncEnabledFilterCest.php
@@ -1,5 +1,7 @@
 <?php
 
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
+
 class ProductSyncEnabledFilterCest {
 
 
@@ -36,7 +38,7 @@ class ProductSyncEnabledFilterCest {
 		list( $excluded_category_id, $excluded_category_taxonomy_id ) = $I->haveTermInDatabase( 'Excluded Category', 'product_cat' );
 		list( $excluded_tag_id, $excluded_tag_taxonomy_id )           = $I->haveTermInDatabase( 'Excluded Tag', 'product_tag' );
 
-		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '1234' );
+		$I->haveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN, '1234' );
 		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234' );
 
 		// configure the category and tag as excluded from facebook sync

--- a/tests/acceptance/Admin/ProductSyncSettingCest.php
+++ b/tests/acceptance/Admin/ProductSyncSettingCest.php
@@ -1,5 +1,6 @@
 <?php
 
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
 use SkyVerge\WooCommerce\Facebook\Products;
 
 class ProductSyncSettingCest {
@@ -33,8 +34,16 @@ class ProductSyncSettingCest {
 	 */
 	public function _before( AcceptanceTester $I ) {
 
-		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '1234' );
+		/**
+		 * Set these in the database so that the product processing hooks are properly set
+		 * @see \WC_Facebookcommerce_Integration::__construct()
+		 */
+		$I->haveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN, '1234' );
 		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234' );
+
+		$I->haveFacebookForWooCommerceSettingsInDatabase( [
+			\WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID => '1234',
+		] );
 
 		// save two generic products
 		$this->sync_enabled_product  = $I->haveProductInDatabase();
@@ -111,13 +120,6 @@ class ProductSyncSettingCest {
 	 */
 	public function try_field_enable( AcceptanceTester $I ) {
 
-		/**
-		 * Set these in the database so that the product processing hooks are properly set
-		 * @see \WC_Facebookcommerce_Integration::__construct()
-		 */
-		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN, '1234' );
-		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234' );
-
 		$I->amEditingPostWithId( $this->sync_disabled_product->get_id() );
 
 		$I->wantTo( 'Test that the field value is saved correctly when enabling sync' );
@@ -141,13 +143,6 @@ class ProductSyncSettingCest {
 	 * @throws Exception
 	 */
 	public function try_field_disable( AcceptanceTester $I ) {
-
-		/**
-		 * Set these in the database so that the product processing hooks are properly set
-		 * @see \WC_Facebookcommerce_Integration::__construct()
-		 */
-		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN, '1234' );
-		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234' );
 
 		$I->amEditingPostWithId( $this->sync_enabled_product->get_id() );
 

--- a/tests/acceptance/Admin/ProductVariationSyncSettingCest.php
+++ b/tests/acceptance/Admin/ProductVariationSyncSettingCest.php
@@ -1,5 +1,6 @@
 <?php
 
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
 use SkyVerge\WooCommerce\Facebook\Products;
 
 class ProductVariationSyncSettingCest {
@@ -24,8 +25,16 @@ class ProductVariationSyncSettingCest {
 	 */
     public function _before( AcceptanceTester $I ) {
 
-	    $I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '1234' );
-	    $I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234' );
+		/**
+		 * Set these in the database so that the product processing hooks are properly set
+		 * @see \WC_Facebookcommerce_Integration::__construct()
+		 */
+		$I->haveOptionInDatabase( Connection::OPTION_ACCESS_TOKEN, '1234' );
+		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234' );
+
+		$I->haveFacebookForWooCommerceSettingsInDatabase( [
+			\WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID => '1234',
+		] );
 
 		$product_objects = $I->haveVariableProductInDatabase();
 

--- a/tests/integration/Admin_Test.php
+++ b/tests/integration/Admin_Test.php
@@ -28,7 +28,7 @@ class Admin_Test extends \Codeception\TestCase\WPTestCase {
 		$this->integration = facebook_for_woocommerce()->get_integration();
 
 		// simulate a complete plugin configuration so that actions and filters callbacks are setup
-		$this->integration->update_page_access_token( '1234' );
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( '1234' );
 		$this->integration->update_product_catalog_id( '1234' );
 
 		$this->admin = new \SkyVerge\WooCommerce\Facebook\Admin();


### PR DESCRIPTION
# Summary

This PR updates `is_configured()` to the initial behavior of checking that a page access token is available and a page ID is stored.

It also updates several tests to insert the new user access token instead of the old page access token to simulate a configured plugin.

### Story: [CH 54112](https://app.clubhouse.io/skyverge/story/54112)
### Release: #1277

## QA

I keep getting `ModuleException` when I try to run all tests in the acceptance suite together, but they are passing if you try them individually or one Cest at a time :/

````
[ModuleException] Db: SQLSTATE[HY000]: General error: 1100 Table 'wp_actionscheduler_actions' was not locked with LOCK TABLES
SQL query being executed:
DROP TABLE IF EXISTS `wp_actionscheduler_actions`
```

### Steps

- [ ] Integration tests pass
- [x] Acceptance tests pass (pre-checking because it takes some time re-run these and can randomly fail with the exception from above)