### PR TITLE
Add filterable getter for proxy URL

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -307,7 +307,14 @@ class Connection {
 	 */
 	public function get_proxy_url() {
 
-		return self::PROXY_URL;
+		/**
+		 * Filters the proxy URL.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param string $proxy_url the connection proxy URL
+		 */
+		return (string) apply_filters( 'wc_facebook_connection_proxy_url', self::PROXY_URL );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -299,6 +299,19 @@ class Connection {
 
 
 	/**
+	 * Gets the proxy URL.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string URL
+	 */
+	public function get_proxy_url() {
+
+		return self::PROXY_URL;
+	}
+
+
+	/**
 	 * Gets the full redirect URL where the user will return to after OAuth.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -355,7 +355,7 @@ class Connection {
 		 */
 		return apply_filters( 'wc_facebook_connection_parameters', [
 			'client_id'     => self::CLIENT_ID,
-			'redirect_uri'  => self::PROXY_URL,
+			'redirect_uri'  => $this->get_proxy_url(),
 			'state'         => $this->get_redirect_url(),
 			'display'       => 'page',
 			'response_type' => 'code',

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -227,6 +227,27 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_proxy_url() */
+	public function test_get_proxy_url() {
+
+		$proxy_url = $this->get_connection()->get_proxy_url();
+
+		$this->assertIsString( $proxy_url );
+		$this->assertEquals( Connection::PROXY_URL, $proxy_url );
+	}
+
+
+	/** @see Connection::get_proxy_url() */
+	public function test_get_proxy_url_filter() {
+
+		add_filter( 'wc_facebook_connection_proxy_url', static function() {
+			return 'filtered';
+		} );
+
+		$this->assertEquals( 'filtered', $this->get_connection()->get_proxy_url() );
+	}
+
+
 	/** @see Connection::get_redirect_url() */
 	public function test_get_redirect_url() {
 
@@ -242,8 +263,7 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Connection::get_redirect_url() */
 	public function test_get_redirect_url_filter() {
 
-		add_filter( 'wc_facebook_connection_redirect_url', function() {
-
+		add_filter( 'wc_facebook_connection_redirect_url', static function() {
 			return 'filtered';
 		} );
 


### PR DESCRIPTION
# Summary

This PR adds a `Connection::get_proxy_url()` method to return a filterable proxy url.

### Story: [CH 54804](https://app.clubhouse.io/skyverge/story/54804/add-method-to-get-the-proxy-url-and-make-it-filterable)
### Release: #1277

## QA

### Tests

- [x] `vendor codecept run integration tests/integration/Handlers/ConnectionTest.php` pass
