### PR TITLE
Initialize the sync handler class

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -49,6 +49,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var \SkyVerge\WooCommerce\Facebook\Products\Feed product feed handler */
 		private $product_feed;
 
+		/** @var \SkyVerge\WooCommerce\Facebook\Products\Sync products sync handler */
+		private $products_sync_handler;
+
 		/** @var \SkyVerge\WooCommerce\Facebook\Handlers\Connection connection handler */
 		private $connection_handler;
 
@@ -91,10 +94,12 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/includes/Integrations/Integrations.php';
 				require_once __DIR__ . '/includes/Products.php';
 				require_once __DIR__ . '/includes/Products/Feed.php';
+				require_once __DIR__ . '/includes/Products/Sync.php';
 				require_once __DIR__ . '/includes/fbproductfeed.php';
 				require_once __DIR__ . '/facebook-commerce-messenger-chat.php';
 
-				$this->product_feed = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
+				$this->product_feed          = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
+				$this->products_sync_handler = new \SkyVerge\WooCommerce\Facebook\Products\Sync();
 
 				if ( is_ajax() ) {
 
@@ -224,6 +229,19 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		public function get_product_feed_handler() {
 
 			return $this->product_feed;
+		}
+
+
+		/**
+		 * Gets the products sync handler.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @return \SkyVerge\WooCommerce\Facebook\Products\Sync
+		 */
+		public function get_products_sync_handler() {
+
+			return $this->products_sync_handler;
 		}
 
 


### PR DESCRIPTION
# Summary
Add `WC_Facebookcommerce::get_products_sync_handler()` and the private property to store the initialized instance

**Main Story:** [ch54636](https://app.clubhouse.io/skyverge/story/54636)

## Tasks
- [x] Define the `WC_Facebookcommerce::get_products_sync_handler()` to return the sync handler instance
- [x] Add a `sync_handler` property to `WC_Facebookcommerce` to hold an instance of `Facebook\Products\Sync`
- [x] Update `WC_Facebookcommerce::init()` to assign a new instance of `Facebook\Products\Sync` to the `sync_handler` property

## QA

N/A