### PR TITLE
Initialize products sync background handler

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -93,6 +93,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 				include_once 'facebook-commerce.php';
 
+				require_once $this->get_framework_path() . '/utilities/class-sv-wp-async-request.php';
+				require_once $this->get_framework_path() . '/utilities/class-sv-wp-background-job-handler.php';
+
 				require_once __DIR__ . '/includes/Handlers/Connection.php';
 				require_once __DIR__ . '/includes/Integrations/Integrations.php';
 				require_once __DIR__ . '/includes/Products.php';

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -52,6 +52,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var \SkyVerge\WooCommerce\Facebook\Products\Sync products sync handler */
 		private $products_sync_handler;
 
+		/** @var \SkyVerge\WooCommerce\Facebook\Products\Sync\Background background sync handler */
+		private $sync_background_handler;
+
 		/** @var \SkyVerge\WooCommerce\Facebook\Handlers\Connection connection handler */
 		private $connection_handler;
 
@@ -95,11 +98,13 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/includes/Products.php';
 				require_once __DIR__ . '/includes/Products/Feed.php';
 				require_once __DIR__ . '/includes/Products/Sync.php';
+				require_once __DIR__ . '/includes/Products/Sync/Background.php';
 				require_once __DIR__ . '/includes/fbproductfeed.php';
 				require_once __DIR__ . '/facebook-commerce-messenger-chat.php';
 
-				$this->product_feed          = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
-				$this->products_sync_handler = new \SkyVerge\WooCommerce\Facebook\Products\Sync();
+				$this->product_feed            = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
+				$this->products_sync_handler   = new \SkyVerge\WooCommerce\Facebook\Products\Sync();
+				$this->sync_background_handler = new \SkyVerge\WooCommerce\Facebook\Products\Sync\Background();
 
 				if ( is_ajax() ) {
 
@@ -242,6 +247,19 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		public function get_products_sync_handler() {
 
 			return $this->products_sync_handler;
+		}
+
+
+		/**
+		 * Gets the products sync background handler.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @return \SkyVerge\WooCommerce\Facebook\Products\Sync\Background
+		 */
+		public function get_products_sync_background_handler() {
+
+			return $this->sync_background_handler;
 		}
 
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -33,16 +33,6 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 
 
 	/**
-	 * Background Sync Handler constructor.
-	 *
-	 * @since 2.0.0-dev.1
-	 */
-	public function __construct() {
-		// TODO
-	}
-
-
-	/**
 	 * Processes a job.
 	 *
 	 * @since 2.0.0-dev.1

--- a/tests/integration/WC_Facebookcommerce_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Test.php
@@ -1,6 +1,8 @@
 <?php
 
 use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
+use SkyVerge\WooCommerce\Facebook\Products\Sync;
+use SkyVerge\WooCommerce\Facebook\Products\Sync\Background;
 
 /**
  * Tests the WC_Facebookcommerce class.
@@ -19,6 +21,20 @@ class WC_Facebookcommerce_Test extends \Codeception\TestCase\WPTestCase {
 	public function test_get_connection_handler() {
 
 		$this->assertInstanceOf( Connection::class, facebook_for_woocommerce()->get_connection_handler() );
+	}
+
+
+	/** @see WC_Facebookcommerce::get_products_sync_handler() */
+	public function test_get_products_sync_handler() {
+
+		$this->assertInstanceOf( Sync::class, facebook_for_woocommerce()->get_products_sync_handler() );
+	}
+
+
+	/** @see WC_Facebookcommerce::get_products_sync_background_handler() */
+	public function test_get_products_sync_background_handler() {
+
+		$this->assertInstanceOf( Background::class, facebook_for_woocommerce()->get_products_sync_handler() );
 	}
 
 

--- a/tests/integration/WC_Facebookcommerce_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Test.php
@@ -34,7 +34,7 @@ class WC_Facebookcommerce_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see WC_Facebookcommerce::get_products_sync_background_handler() */
 	public function test_get_products_sync_background_handler() {
 
-		$this->assertInstanceOf( Background::class, facebook_for_woocommerce()->get_products_sync_handler() );
+		$this->assertInstanceOf( Background::class, facebook_for_woocommerce()-> get_products_sync_background_handler() );
 	}
 
 


### PR DESCRIPTION
- [x] Wait for #1304 and #1305, then retarget `release-2.0.0` to avoid merge conflicts

# Summary

Add `WC_Facebookcommerce::get_products_sync_background_handler()` and the private property to store the initialized instance

**Main Story:** [ch54660](https://app.clubhouse.io/skyverge/story/54660)

## QA

- [ ] `vendor codecept run integration tests/integration/WC_Facebookcommerce_Test.php` pass