### PR TITLE
Implement the method to schedule product updates

### DIFF
--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -22,6 +22,15 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 class Sync {
 
 
+	/** @var string the prefix used in the array indexes */
+	const PRODUCT_INDEX_PREFIX = 'p-';
+
+	/** @var string the update action */
+	const ACTION_UPDATE = 'UPDATE';
+
+	/** @var string the delete action */
+	const ACTION_DELETE = 'DELETE';
+
 	/** @var array the array of requests to schedule for sync */
 	protected $requests = [];
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -88,4 +88,20 @@ class Sync {
 	public function schedule_sync() {
 		// TODO
 	}
+
+
+	/**
+	 * Gets the prefixed product ID used as the array index.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param $product_id
+	 * @return string
+	 */
+	private function get_product_index( $product_id ) {
+
+		return self::PRODUCT_INDEX_PREFIX . $product_id;
+	}
+
+
 }

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -64,7 +64,10 @@ class Sync {
 	 * @param array $product_ids
 	 */
 	public function create_or_update_products( array $product_ids ) {
-		// TODO
+
+		foreach ( $product_ids as $product_id ) {
+			$this->requests[ $this->get_product_index( $product_id ) ] = self::ACTION_UPDATE;
+		}
 	}
 
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -12,11 +12,55 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 	protected $tester;
 
 
+	public function _before() {
+
+		parent::_before();
+
+		require_once 'includes/Products/Sync.php';
+	}
+
+
 	/** Test methods **************************************************************************************************/
+
+
+	/** @see Sync::create_or_update_products() */
+	public function test_create_or_update_products() {
+
+		$product_ids = [ 123, 456 ];
+
+		$sync = $this->get_sync();
+
+		$sync->create_or_update_products( $product_ids );
+
+		$requests_property = new \ReflectionProperty( Sync::class, 'requests' );
+		$requests_property->setAccessible( true );
+
+		$requests = $requests_property->getValue( $sync );
+
+		$this->assertIsArray( $requests );
+		$this->assertArrayHasKey( 'p-123', $requests );
+		$this->assertArrayHasKey( 'p-456', $requests );
+		$this->assertEquals( 'UPDATE', $requests['p-123'] );
+		$this->assertEquals( 'UPDATE', $requests['p-456'] );
+	}
 
 
 	/** @see Sync::delete_products() */
 	public function test_delete_products() {
+	}
+
+
+	/** Helper methods **************************************************************************************************/
+
+
+	/**
+	 * Gets the handler instance.
+	 *
+	 * @return Sync
+	 */
+	private function get_sync() {
+
+		return new Sync();
 	}
 
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Products\Sync;
+
+/**
+ * Tests the Feed class.
+ */
+class SyncTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Sync::delete_products() */
+	public function test_delete_products() {
+	}
+
+
+}
+


### PR DESCRIPTION
# Summary
Implements `Sync::create_or_update_products()`.

**Main Story:** [CH 54640](https://app.clubhouse.io/skyverge/story/54640/implement-the-method-to-schedule-product-updates)

## Tasks
- [x] Add constants for the prefix and the update and delete actions
- [x] Add a get_product_index method to return the prefixed product ID
- [x] Update `Facebok\Products\Sync::create_or_update_products()` to set or update the request method in the requests array to UPDATE for each product ID given.
- [x] Add test

## QA

- [ ] Integration tests pass