### PR TITLE
Implement the method to schedule product deletes

### DIFF
--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -79,7 +79,10 @@ class Sync {
 	 * @param array $product_ids
 	 */
 	public function delete_products( array $product_ids ) {
-		// TODO
+
+		foreach ( $product_ids as $product_id ) {
+			$this->requests[ $this->get_product_index( $product_id ) ] = self::ACTION_DELETE;
+		}
 	}
 
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -45,8 +45,40 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Sync::delete_products() */
-	public function test_delete_products() {
+	/**
+     * @see Sync::delete_products()
+     *
+     * @dataProvider provider_delete_products()
+     */
+    public function test_delete_products( $product_ids ) {
+
+        // TODO: remove when this file is included in the main plugin class {WV 2020-05-19}
+        require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/Products/Sync.php';
+
+        $sync = new Sync();
+
+        $sync->delete_products( $product_ids );
+
+        $requests_property = new ReflectionProperty( Sync::class, 'requests' );
+        $requests_property->setAccessible( true );
+
+        $requests = $requests_property->getValue( $sync );
+
+        foreach ( $product_ids as $product_id ) {
+            $this->assertEquals( Sync::ACTION_DELETE, $requests["p-{$product_id}"] );
+        }
+
+        $this->assertEquals( count( $requests ), count( $product_ids ) );
+    }
+
+
+    /** @see test_delete_products() */
+    public function provider_delete_products() {
+
+        return [
+            [ [] ],
+            [ [ 1, 2, 3, 4 ] ],
+        ];
 	}
 
 


### PR DESCRIPTION
# Summary

This PR adds the `Sync::delete_products()` method

### Story: [CH 54642](https://app.clubhouse.io/skyverge/story/54642)
### Release: #1277

## QA

- [x] `vendor codecept run integration tests/integration/Products/SyncTest.php` pass
