### PR TITLE
Update visibility when the product is synced

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -858,9 +858,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			}
 		}
 
-		// do not attempt to update product visibility during FBE 1.5: the Visible setting was removed so it always seems as if the visibility had been disabled
-		// $this->update_fb_visibility( $product->get_id(), $is_visible ? self::FB_SHOP_PRODUCT_VISIBLE : self::FB_SHOP_PRODUCT_HIDDEN );
-
 		if ( $sync_enabled && $this->is_configured() && $this->get_product_catalog_id() ) {
 
 			switch ( $product->get_type() ) {


### PR DESCRIPTION
# Summary
Removes the call to `update_fb_visibility()` on product save, since it will be handled by the product update.

**Main Story:** [CH 54683](https://app.clubhouse.io/skyverge/story/54683/update-visibility-when-the-product-is-synced)

## Tasks
- [x] Remove commented call to `WC_Facebookcommerce_Integration::update_fb_visibility()` from `::on_product_save()`

## QA

N/A