### PR TITLE
Schedule updates for variable products

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1108,24 +1108,24 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 			$this->update_product_group( $woo_product );
 
-			$child_products = $woo_product->get_children();
-			$variation_id   = $woo_product->find_matching_product_variation();
-
-			// check if item_id is default variation. If yes, update in the end.
-			// If default variation value is to update, delete old fb_product_item_id
-			// and create new one in order to make it order correctly.
-			foreach ( $child_products as $item_id ) {
-
-				$fb_product_item_id = $this->on_simple_product_publish( $item_id, null, $woo_product );
-
-				if ( $item_id == $variation_id && $fb_product_item_id ) {
-					$this->set_default_variant( $fb_product_group_id, $fb_product_item_id );
-				}
-			}
-
 		} else {
 
 			$this->create_product_variable( $woo_product );
+		}
+
+		$child_products = $woo_product->get_children();
+		$variation_id   = $woo_product->find_matching_product_variation();
+
+		// check if item_id is default variation. If yes, update in the end.
+		// If default variation value is to update, delete old fb_product_item_id
+		// and create new one in order to make it order correctly.
+		foreach ( $child_products as $item_id ) {
+
+			$fb_product_item_id = $this->on_simple_product_publish( $item_id, null, $woo_product );
+
+			if ( $item_id == $variation_id && $fb_product_item_id ) {
+				$this->set_default_variant( $fb_product_group_id, $fb_product_item_id );
+			}
 		}
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1197,33 +1197,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 	}
 
-	function create_product_variable( $woo_product ) {
-		$retailer_id = WC_Facebookcommerce_Utils::get_fb_retailer_id( $woo_product );
-
-		$fb_product_group_id = $this->create_product_group(
-			$woo_product,
-			$retailer_id,
-			true
-		);
-
-		if ( $fb_product_group_id ) {
-			$child_products = $woo_product->get_children();
-			$variation_id   = $woo_product->find_matching_product_variation();
-			foreach ( $child_products as $item_id ) {
-				$child_product      = new WC_Facebook_Product( $item_id, $woo_product );
-				$retailer_id        =
-				WC_Facebookcommerce_Utils::get_fb_retailer_id( $child_product );
-				$fb_product_item_id = $this->create_product_item(
-					$child_product,
-					$retailer_id,
-					$fb_product_group_id
-				);
-				if ( $item_id == $variation_id && $fb_product_item_id ) {
-						$this->set_default_variant( $fb_product_group_id, $fb_product_item_id );
-				}
-			}
-		}
-	}
 
 	/**
 	 * Create product group and product, store fb-specific info

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1114,18 +1114,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 
 		$child_products = $woo_product->get_children();
-		$variation_id   = $woo_product->find_matching_product_variation();
 
-		// check if item_id is default variation. If yes, update in the end.
-		// If default variation value is to update, delete old fb_product_item_id
-		// and create new one in order to make it order correctly.
+		// scheduled update for each variation
 		foreach ( $child_products as $item_id ) {
 
-			$fb_product_item_id = $this->on_simple_product_publish( $item_id, null, $woo_product );
-
-			if ( $item_id == $variation_id && $fb_product_item_id ) {
-				$this->set_default_variant( $fb_product_group_id, $fb_product_item_id );
-			}
+			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( [ $item_id ] );
 		}
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1096,11 +1096,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			return;
 		}
 
-		$fb_product_group_id = $this->get_product_fbid(
-			self::FB_PRODUCT_GROUP_ID,
-			$wp_id,
-			$woo_product
-		);
+		$fb_product_group_id = $this->get_product_fbid( self::FB_PRODUCT_GROUP_ID, $wp_id, $woo_product );
 
 		if ( $fb_product_group_id ) {
 
@@ -1110,7 +1106,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		} else {
 
-			$this->create_product_variable( $woo_product );
+			$retailer_id = WC_Facebookcommerce_Utils::get_fb_retailer_id( $woo_product->woo_product );
+
+			$this->create_product_group( $woo_product, $retailer_id, true );
 		}
 
 		$child_products = $woo_product->get_children();


### PR DESCRIPTION
# Summary
Updates `WC_Facebookcommerce_Integration::on_variable_product_publish()` to schedule variations update.

**Main Story:** [CH 54685](https://app.clubhouse.io/skyverge/story/54685/schedule-updates-for-variable-products)

## Tasks
- [x] Update `WC_Facebookcommerce_Integration::on_variable_product_publish()` to move the loop that goes over the product variations outside the if statement
- [x] Inside the loop, call `Facebook\Products\Sync::create_or_update_products()` with the IDs for each variation instead of calling `::on_simple_product_publish()`
- [x] If the variable product has a Facebook Product Group ID, call `::update_product_group()`
- [x] If the variable product has no associated Facebook Product Group ID, call `::create_product_group()`

## QA

N/A