### PR TITLE
Implement the method to process a job

### DIFF
--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -85,7 +85,6 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 		// loop over unprocessed items and process them
 		if ( ! empty( $data ) ) {
 
-			$processed       = 0;
 			$items_per_batch = (int) $items_per_batch;
 
 			foreach ( $data as $item ) {
@@ -125,7 +124,25 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 * @param int $items_per_batch number of items to process in a single request. Defaults to unlimited.
 	 */
 	public function process_items( $job, $data, $items_per_batch = null ) {
-		// TODO
+
+		$processed = 0;
+
+		foreach ( $data as $item ) {
+
+			// process the item
+			$this->process_item( $item, $job );
+
+			$processed++;
+			$job->progress++;
+
+			// update job progress
+			$job = $this->update_job( $job );
+
+			// job limits reached
+			if ( ( $items_per_batch && $processed >= $items_per_batch ) || $this->time_exceeded() || $this->memory_exceeded() ) {
+				break;
+			}
+		}
 	}
 
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -12,6 +12,7 @@ namespace SkyVerge\WooCommerce\Facebook\Products\Sync;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Facebook\Products\Sync;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 /**
@@ -109,10 +110,12 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 
 		$processed = 0;
 
-		foreach ( $data as $item ) {
+		foreach ( $data as $prefixed_product_id => $method ) {
+
+			$product_id = (int) str_replace( Sync::PRODUCT_INDEX_PREFIX, '', $prefixed_product_id );
 
 			// process the item
-			$this->process_item( $item, $job );
+			$this->process_item( [ $product_id, $method ], $job );
 
 			$processed++;
 			$job->progress++;

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -39,7 +39,7 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 * @since 2.0.0-dev.1
 	 *
 	 * @param \stdClass|object $job
-	 * @param int $items_per_batch number of items to process in a single request. Defaults to unlimited.
+	 * @param int|null $items_per_batch number of items to process in a single request (defaults to null for unlimited)
 	 * @throws \Exception when job data is incorrect
 	 * @return \stdClass $job
 	 */
@@ -104,7 +104,7 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 *
 	 * @param \stdClass|object $job
 	 * @param array $data
-	 * @param int $items_per_batch number of items to process in a single request. Defaults to unlimited.
+	 * @param int|null $items_per_batch number of items to process in a single request (defaults to null for unlimited)
 	 */
 	public function process_items( $job, $data, $items_per_batch = null ) {
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -84,25 +84,7 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 
 		// loop over unprocessed items and process them
 		if ( ! empty( $data ) ) {
-
-			$items_per_batch = (int) $items_per_batch;
-
-			foreach ( $data as $item ) {
-
-				// process the item
-				$this->process_item( $item, $job );
-
-				$processed++;
-				$job->progress++;
-
-				// update job progress
-				$job = $this->update_job( $job );
-
-				// job limits reached
-				if ( ( $items_per_batch && $processed >= $items_per_batch ) || $this->time_exceeded() || $this->memory_exceeded() ) {
-					break;
-				}
-			}
+			$this->process_items( $job, $data, (int) $items_per_batch );
 		}
 
 		// complete current job

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Codeception\Stub;
+use SkyVerge\WooCommerce\Facebook\Products\Sync;
+use SkyVerge\WooCommerce\Facebook\Products\Sync\Background;
+
+/**
+ * Tests the Sync\Background class.
+ */
+class BackgroundTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		require_once 'vendor/skyverge/wc-plugin-framework/woocommerce/utilities/class-sv-wp-async-request.php';
+		require_once 'vendor/skyverge/wc-plugin-framework/woocommerce/utilities/class-sv-wp-background-job-handler.php';
+		require_once 'includes/Products/Sync/Background.php';
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see Background::process_job()
+	 *
+	 * @dataProvider provider_process_job_calls_process_items
+	 */
+	public function test_process_job_calls_process_items( $requests ) {
+
+		$background = Stub::make( Background::class, [
+			'process_items' => \Codeception\Stub\Expected::exactly( empty( $requests ) ? 0 : 1 ),
+		], $this );
+
+		$job = (object) [
+			'id'       => uniqid(),
+			'status'   => 'queued',
+			'requests' => $requests,
+		];
+
+		$background->process_job( $job );
+	}
+
+
+	/** @see test_process_job_calls_process_items() */
+	public function provider_process_job_calls_process_items() {
+
+		return [
+			[ [] ],
+			[ [
+				Sync::PRODUCT_INDEX_PREFIX . '1' => Sync::ACTION_UPDATE
+			] ],
+			[ [
+				Sync::PRODUCT_INDEX_PREFIX . '1' => Sync::ACTION_UPDATE,
+				Sync::PRODUCT_INDEX_PREFIX . '2' => Sync::ACTION_UPDATE,
+				Sync::PRODUCT_INDEX_PREFIX . '3' => Sync::ACTION_DELETE,
+			] ],
+		];
+	}
+
+
+	/** Helper methods **************************************************************************************************/
+
+
+	/**
+	 * Gets a test job object.
+	 *
+	 * @return object
+	 */
+	private function get_test_job( array $props = [] ) {
+
+		$defaults = [
+			'id'       => uniqid(),
+			'status'   => 'queued',
+			'requests' => [],
+			'progress' => 0,
+		];
+
+		return (object) array_merge( $defaults, $props );
+	}
+
+
+}
+

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -38,13 +38,7 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 			'process_items' => \Codeception\Stub\Expected::exactly( empty( $requests ) ? 0 : 1 ),
 		], $this );
 
-		$job = (object) [
-			'id'       => uniqid(),
-			'status'   => 'queued',
-			'requests' => $requests,
-		];
-
-		$background->process_job( $job );
+		$background->process_job( $this->get_test_job( [ 'requests' => $requests ] ) );
 	}
 
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -59,6 +59,36 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Background::process_items() */
+	public function test_process_items() {
+
+		$requests = [
+			Sync::PRODUCT_INDEX_PREFIX . '1' => Sync::ACTION_UPDATE,
+			Sync::PRODUCT_INDEX_PREFIX . '2' => Sync::ACTION_UPDATE,
+			Sync::PRODUCT_INDEX_PREFIX . '3' => Sync::ACTION_DELETE,
+		];
+
+		$job = $this->get_test_job( [ 'requests' => $requests ] );
+
+		$background = Stub::make( Background::class, [
+			'start_time'   => time(),
+			'process_item' => function( $item, $job ) {
+
+				// assert the $item has two elements
+				$this->assertEquals( 2, count( $item ) );
+
+				// assert the first position is one of the product IDs
+				$this->assertContains( $item[0], [ 1, 2, 3 ] );
+
+				// assert the second position is one of the accepted sync methods
+				$this->assertContains( $item[1], [ Sync::ACTION_UPDATE, Sync::ACTION_DELETE ] );
+			},
+		] );
+
+		$background->process_items( $job, $requests );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -14,16 +14,6 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	protected $tester;
 
 
-	public function _before() {
-
-		parent::_before();
-
-		require_once 'vendor/skyverge/wc-plugin-framework/woocommerce/utilities/class-sv-wp-async-request.php';
-		require_once 'vendor/skyverge/wc-plugin-framework/woocommerce/utilities/class-sv-wp-background-job-handler.php';
-		require_once 'includes/Products/Sync/Background.php';
-	}
-
-
 	/** Test methods **************************************************************************************************/
 
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -3,7 +3,7 @@
 use SkyVerge\WooCommerce\Facebook\Products\Sync;
 
 /**
- * Tests the Feed class.
+ * Tests the Sync class.
  */
 class SyncTest extends \Codeception\TestCase\WPTestCase {
 


### PR DESCRIPTION
# Summary

This PR implements the `Sync\Background::process_job()` and an initial version of `Sync\Background::process_items()` methods

### Story: [CH 54664](https://app.clubhouse.io/skyverge/story/54664)
### Release: #1277

## QA

- [x] `vendor codecept run integration tests/integration/Products/Sync/BackgroundTest.php` pass
