### PR TITLE
Schedule deletes for variable products

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -937,19 +937,19 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function on_product_delete( $product_id ) {
 
-		$woo_product = wc_get_product( $product_id );
+		$product = wc_get_product( $product_id );
 
 		// bail if product does not exist
-		if ( ! $woo_product instanceof \WC_Product ) {
+		if ( ! $product instanceof \WC_Product ) {
 			return;
 		}
 
 		// bail if not enabled for sync
-		if ( ! Products::product_should_be_synced( $woo_product ) ) {
+		if ( ! Products::product_should_be_synced( $product ) ) {
 			return;
 		}
 
-		if ( ! $woo_product->is_type( 'variable' ) ) {
+		if ( ! $product->is_type( 'variable' ) ) {
 
 			$fb_product_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product_id );
 
@@ -959,7 +959,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		} else {
 
-			$product_ids = array_merge( [ $product_id ], $woo_product->get_children() );
+			$product_ids = array_merge( [ $product_id ], $product->get_children() );
 
 			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( $product_ids );
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -937,21 +937,21 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function on_product_delete( $product_id ) {
 
-		$woo_product = new \WC_Facebook_Product( $product_id );
+		$woo_product = wc_get_product( $product_id );
 
 		// bail if product does not exist
-		if ( ! $woo_product->woo_product instanceof \WC_Product || ! $woo_product->exists() ) {
+		if ( ! $woo_product instanceof \WC_Product ) {
 			return;
 		}
 
 		// bail if not enabled for sync
-		if ( ! Products::product_should_be_synced( $woo_product->woo_product ) ) {
+		if ( ! Products::product_should_be_synced( $woo_product ) ) {
 			return;
 		}
 
-		if ( ! $woo_product->woo_product->is_type( 'variable' ) ) {
+		if ( ! $woo_product->is_type( 'variable' ) ) {
 
-			$fb_product_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product_id, $woo_product );
+			$fb_product_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product_id );
 
 			if ( $fb_product_id ) {
 				$this->delete_product_item( $product_id );
@@ -965,7 +965,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 
 
-		$fb_product_group_id = $this->get_product_fbid( self::FB_PRODUCT_GROUP_ID, $product_id, $woo_product );
+		$fb_product_group_id = $this->get_product_fbid( self::FB_PRODUCT_GROUP_ID, $product_id );
 
 		if ( $fb_product_group_id ) {
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -951,7 +951,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		if ( ! $woo_product->woo_product->is_type( 'variable' ) ) {
 
-			$fb_product_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $wp_id, $woo_product );
+			$fb_product_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product_id, $woo_product );
 
 			if ( $fb_product_id ) {
 				$this->delete_product_item( $product_id );

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -76,7 +76,7 @@ class Sync {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param array $product_ids
+	 * @param int[] $product_ids
 	 */
 	public function delete_products( array $product_ids ) {
 


### PR DESCRIPTION
# Summary

Updates `WC_Facebookcommerce_Integration::on_product_delete()` to schedule variations deletion.

**Main Story:** [CH 54692](https://app.clubhouse.io/skyverge/story/54692/schedule-deletes-for-variable-products)

## Tasks

- [x] Update `WC_Facebookcommerce_Integration::on_product_delete()` to not bail if the product does not have Facebook Product ID or Facebook Product Group ID defined
- [x] If the product is not variable and the product has a Facebook Product ID, call `::delete_product_item()`
- [x] If the product is variable call `Facebook\Products\Sync::delete_products()` with the ID of each variation
- [x] If the product has a Facebook Product Group ID, call `::delete_product_group()`

## QA

N/A