### PR TITLE
Schedule visibility updates for variable products

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4278,10 +4278,13 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		} else {
 
-		    // parent product
+			// parent product
 			Products::set_product_visibility( $product, $should_set_visible );
 
-			$product_ids = [ $product_id ];
+			// we should not add the parent product ID to the array of product IDs to be
+			// updated because product groups, which are used to represent the parent product
+			// for variable products, don't have the visibility property on Facebook
+			$product_ids = [];
 
 			// set visibility for all children
 			foreach ( $product->get_children() as $index => $id ) {

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4278,10 +4278,12 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		} else {
 
+		    // parent product
 			Products::set_product_visibility( $product, $should_set_visible );
 
 			$product_ids = [ $product_id ];
 
+			// set visibility for all children
 			foreach ( $product->get_children() as $index => $id ) {
 
 				$product = wc_get_product( $id );
@@ -4295,6 +4297,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				$product_ids[] = $product->get_id();
 			}
 
+			// sync product with all variations
 			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( $product_ids );
 		}
 	}

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -61,7 +61,7 @@ class Sync {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param array $product_ids
+	 * @param int[] $product_ids
 	 */
 	public function create_or_update_products( array $product_ids ) {
 


### PR DESCRIPTION
# Summary

Updates `WC_Facebookcommerce_Integration::update_fb_visibility()` to schedule visibility updates for variable products.

**Main Story:** [CH 54701](https://app.clubhouse.io/skyverge/story/54701/schedule-visibility-updates-for-variable-products)

## Tasks

- [x] Add an if statement before the foreach loop in `WC_Facebookcommerce_Integration::update_fb_visibility()` to check whether the product is variable
- [x] If the product is NOT variable, use `Products::set_product_visibility()` to set the visibility of the product
- [x] If the product is NOT variable, use `$this->fbgraph->update_product_item()`, as its currently done, to update the visibility of the product
- [x] If the product is variable, loop over all the product variations and use `Products::set_product_visibility()` to set the visibility of each variation
- [x] If the product is variable, call `Facebook\Products\Sync::create_or_update_products()` to enqueue the variations to be synced

## QA

N/A