### PR TITLE
Create the base API Request class

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -203,7 +203,7 @@ class API extends Framework\SV_WC_API_Base {
 	 * @param array $args optional request arguments
 	 * @return \SkyVerge\WooCommerce\Facebook\API\Request
 	 */
-	protected function get_new_request( $args = array() ) {
+	protected function get_new_request( $args = [] ) {
 
 		// TODO: Implement get_new_request() method.
 	}

--- a/includes/API.php
+++ b/includes/API.php
@@ -10,18 +10,17 @@
 
 namespace SkyVerge\WooCommerce\Facebook;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Base;
-use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Request;
-use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Plugin;
-
 defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+
 
 /**
  * API handler.
  *
  * @since 2.0.0-dev.1
  */
-class API extends SV_WC_API_Base {
+class API extends Framework\SV_WC_API_Base {
 
 
 	/** @var string the configured access token */
@@ -202,7 +201,7 @@ class API extends SV_WC_API_Base {
 	 * @since 2.0.0-dev.1
 	 *
 	 * @param array $args optional request arguments
-	 * @return SV_WC_API_Request|object
+	 * @return \SkyVerge\WooCommerce\Facebook\API\Request
 	 */
 	protected function get_new_request( $args = array() ) {
 

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -22,4 +22,18 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 class Request extends Framework\SV_WC_API_JSON_Request {
 
 
+	/**
+	 * API request constructor.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $object_id object ID
+	 * @param string $path endpoint route
+	 * @param string $method HTTP method
+	 */
+	public function __construct( $object_id, $path, $method ) {
+
+	}
+
+
 }

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -36,4 +36,16 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 	}
 
 
+	/**
+	 * Sets the request data.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param array $data
+	 */
+	public function set_data( $data ) {
+
+	}
+
+
 }

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+
+/**
+ * Base API request object.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Request extends Framework\SV_WC_API_JSON_Request {
+
+
+}


### PR DESCRIPTION
# Summary

Adds a base API\Request object to extend for FB API requests.

**Main Story:** [CH 54719](https://app.clubhouse.io/skyverge/story/54719/create-the-base-api-request-class)

## Tasks

- [x] Define class `Facebook\API\Requet` that extends `Framework\SV_WC_API_JSON_Request`
- [x] Add the class constructor: `Facebook\API\Request::__construct( $object_id, $path, $method )`
- [x] Add public method `Facebook\API\Request::set_data( $data )`

## QA

N/A