### PR TITLE
Create the base API Response class

### DIFF
--- a/includes/API/Response.php
+++ b/includes/API/Response.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+
+class Response extends Framework\SV_WC_API_JSON_Response {
+
+
+}

--- a/includes/API/Response.php
+++ b/includes/API/Response.php
@@ -22,4 +22,14 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 class Response extends Framework\SV_WC_API_JSON_Response {
 
 
+	/**
+	 * Gets the response ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function get_id() {
+
+	}
+
+
 }

--- a/includes/API/Response.php
+++ b/includes/API/Response.php
@@ -14,6 +14,11 @@ defined( 'ABSPATH' ) or exit;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
+/**
+ * Base API response object
+ *
+ * @since 2.0.0-dev.1
+ */
 class Response extends Framework\SV_WC_API_JSON_Response {
 
 

--- a/includes/API/Response.php
+++ b/includes/API/Response.php
@@ -28,7 +28,7 @@ class Response extends Framework\SV_WC_API_JSON_Response {
 	 * @since 2.0.0-dev.1
 	 */
 	public function get_id() {
-
+		// TODO
 	}
 
 


### PR DESCRIPTION
# Summary

Adds a base API\Response object to extend for parsing FB API responses.

**Main Story:** [CH 54723](https://app.clubhouse.io/skyverge/story/54723/create-the-base-api-response-class)

## Tasks

- [x] Define class `Facebook\API\Response` that extends `Framework\SV_WC_API_JSON_Response`
- [x] Implement public method `Facebook\API\Request::get_id()`

## QA

N/A