### PR TITLE
Implement the method to process a job item

### DIFF
--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -143,6 +143,20 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	public function process_item( $item, $job ) {
 
 		list( $product_id, $method ) = $item;
+
+		$product = wc_get_product( $product_id );
+
+		if ( ! $product instanceof \WC_Product ) {
+			// TODO: throw an exception and add a test
+			return;
+		}
+
+		if ( ! in_array( $method, [ Sync::ACTION_UPDATE, Sync::ACTION_DELETE ], true ) ) {
+			// TODO: throw an exception and add a test
+			return;
+		}
+
+		return $this->process_item_update( $product );
 	}
 
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -182,7 +182,11 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 */
 	private function process_item_update( $product ) {
 
-		$product_data = $this->prepare_product_data( $product );
+		if ( $product->is_type( 'variation' ) ) {
+			$product_data = $this->prepare_product_variation_data( $product );
+		} else {
+			$product_data = $this->prepare_product_data( $product );
+		}
 
 		$request = [
 			'retailer_id' => $product_data['retailer_id'],

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -264,47 +264,17 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 *
 	 * @param \WC_Product $product product object
 	 * @return array
-	 * @throws Framework\SV_WC_Plugin_Exception
 	 */
 	private function prepare_product_data( $product ) {
 
-		if ( $product->is_type( 'variation' ) ) {
-
-			$parent_product = wc_get_product( $product->get_parent_id() );
-
-			if ( ! $parent_product instanceof \WC_Product ) {
-				throw new Framework\SV_WC_Plugin_Exception( "No parent product found with ID equal to {$product->get_parent_id()}." );
-			}
-
-			$fb_parent_product = new \WC_Facebook_Product( $parent_product );
-			$fb_product        = new \WC_Facebook_Product( $product->get_id(), $fb_parent_product );
-
-			$retailer_product_group_id = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $parent_product );
-
-		} else {
-
-			$fb_product = new \WC_Facebook_Product( $product->get_id() );
-
-			$retailer_product_group_id = null;
-		}
+		$fb_product = new \WC_Facebook_Product( $product->get_id() );
 
 		$data = $fb_product->prepare_product();
 
-		// allowed values are 'refurbished', 'used', and 'new', but the plugin has always used the latter
-		$data['condition'] = 'new';
+		// products that are not variations use their retailer retailer ID as the retailer product group ID
+		$data['retailer_product_group_id'] = $data['retailer_id'];
 
-		$data['product_type'] = $data['category'];
-
-		$data['retailer_product_group_id'] = $retailer_product_group_id ?: $data['retailer_id'];
-
-		// attributes other than size, color, pattern, or gender need to be included in the additional_variant_attributes field
-		if ( isset( $data['custom_data'] ) && is_array( $data['custom_data'] ) ) {
-
-			$data['additional_variant_attributes'] = $data['custom_data'];
-			unset( $data['custom_data'] );
-		}
-
-		return $data;
+		return $this->normalize_product_data( $data );
 	}
 
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -140,8 +140,9 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 * @param object|\stdClass $job
 	 * @return array
 	 */
-	public function process_item($item, $job) {
-		// TODO
+	public function process_item( $item, $job ) {
+
+		list( $product_id, $method ) = $item;
 	}
 
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -262,10 +262,20 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 */
 	private function process_item_delete( $product ) {
 
-		return [
+		$request = [
 			'retailer_id' => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
 			'method'      => Sync::ACTION_DELETE,
 		];
+
+		/**
+		 * Filters the data that will be included in a DELETE sync request.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param array $request request data
+		 * @param \WC_Product $product product object
+		 */
+		return apply_filters( 'wc_facebook_sync_background_item_delete_request', $request, $product );
 	}
 
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -197,6 +197,7 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 *
 	 * @param \WC_Product $product product object
 	 * @return array
+	 * @throws Framework\SV_WC_Plugin_Exception
 	 */
 	private function prepare_product_data( $product ) {
 
@@ -205,8 +206,7 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 			$parent_product = wc_get_product( $product->get_parent_id() );
 
 			if ( ! $parent_product instanceof \WC_Product ) {
-				// TODO: throw an exception and add a test
-				return;
+				throw new Framework\SV_WC_Plugin_Exception( "No parent product found with ID equal to {$product->get_parent_id()}." );
 			}
 
 			$fb_parent_product = new \WC_Facebook_Product( $parent_product );

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -203,6 +203,35 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 
 
 	/**
+	 * Prepares the data for a product variation to be included in a sync request.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param \WC_Product $product product object
+	 * @return array
+	 * @throws Framework\SV_WC_Plugin_Exception
+	 */
+	private function prepare_product_variation_data( $product ) {
+
+		$parent_product = wc_get_product( $product->get_parent_id() );
+
+		if ( ! $parent_product instanceof \WC_Product ) {
+			throw new Framework\SV_WC_Plugin_Exception( "No parent product found with ID equal to {$product->get_parent_id()}." );
+		}
+
+		$fb_parent_product = new \WC_Facebook_Product( $parent_product );
+		$fb_product        = new \WC_Facebook_Product( $product->get_id(), $fb_parent_product );
+
+		$data = $fb_product->prepare_product();
+
+		// product variations use the parent product's retailer ID as the retailer product group ID
+		$data['retailer_product_group_id'] = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $parent_product );
+
+		return $this->normalize_product_data( $data );
+	}
+
+
+	/**
 	 * Normalizes product data to be included in a sync request.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -147,6 +147,25 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 
 
 	/**
+	 * Processes an UPDATE sync request for the given product.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param \WC_Product $product product object
+	 */
+	private function process_item_update( $product ) {
+
+		$product_data = $this->prepare_product_data( $product );
+
+		return [
+			'retailer_id' => $product_data['retailer_id'],
+			'method'      => Sync::ACTION_UPDATE,
+			'data'        => $product_data,
+		];
+	}
+
+
+	/**
 	 * Prepares the product data to be included in a sync request.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -184,11 +184,21 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 
 		$product_data = $this->prepare_product_data( $product );
 
-		return [
+		$request = [
 			'retailer_id' => $product_data['retailer_id'],
 			'method'      => Sync::ACTION_UPDATE,
 			'data'        => $product_data,
 		];
+
+		/**
+		 * Filters the data that will be included in a UPDATE sync request.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param array $request request data
+		 * @param \WC_Product $product product object
+		 */
+		return apply_filters( 'wc_facebook_sync_background_item_update_request', $request, $product );
 	}
 
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -223,6 +223,20 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	}
 
 
+	/**
+	 * Processes a DELETE sync request for the given product.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param \WC_Product $product product object
+	 */
+	private function process_item_delete( $product ) {
+
+		return [
+			'retailer_id' => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
+			'method'      => Sync::ACTION_DELETE,
+		];
+	}
 
 
 	/**

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -203,6 +203,32 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 
 
 	/**
+	 * Normalizes product data to be included in a sync request.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param \WC_Product $product product object
+	 * @return array
+	 */
+	private function normalize_product_data( $data ) {
+
+		// allowed values are 'refurbished', 'used', and 'new', but the plugin has always used the latter
+		$data['condition'] = 'new';
+
+		$data['product_type'] = $data['category'];
+
+		// attributes other than size, color, pattern, or gender need to be included in the additional_variant_attributes field
+		if ( isset( $data['custom_data'] ) && is_array( $data['custom_data'] ) ) {
+
+			$data['additional_variant_attributes'] = $data['custom_data'];
+			unset( $data['custom_data'] );
+		}
+
+		return $data;
+	}
+
+
+	/**
 	 * Prepares the product data to be included in a sync request.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -230,6 +230,13 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 
 		$data['retailer_product_group_id'] = $retailer_product_group_id ?: $data['retailer_id'];
 
+		// attributes other than size, color, pattern, or gender need to be included in the additional_variant_attributes field
+		if ( isset( $data['custom_data'] ) && is_array( $data['custom_data'] ) ) {
+
+			$data['additional_variant_attributes'] = $data['custom_data'];
+			unset( $data['custom_data'] );
+		}
+
 		return $data;
 	}
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -158,8 +158,7 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 		}
 
 		if ( ! in_array( $method, [ Sync::ACTION_UPDATE, Sync::ACTION_DELETE ], true ) ) {
-			// TODO: throw an exception and add a test
-			return;
+			throw new Framework\SV_WC_Plugin_Exception( "Invalid sync request method: {$method}." );
 		}
 
 		if ( Sync::ACTION_UPDATE === $method ) {

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -177,6 +177,8 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 * @since 2.0.0-dev.1
 	 *
 	 * @param \WC_Product $product product object
+	 * @return array
+	 * @throws Framework\SV_WC_Plugin_Exception
 	 */
 	private function process_item_update( $product ) {
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -156,7 +156,13 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 			return;
 		}
 
-		return $this->process_item_update( $product );
+		if ( Sync::ACTION_UPDATE === $method ) {
+			$request = $this->process_item_update( $product );
+		} else {
+			$request = $this->process_item_delete( $product );
+		}
+
+		return $request;
 	}
 
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -151,6 +151,32 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Background::process_item() */
+	public function test_process_item_update_request_with_product_variation() {
+
+		$parent_product = new \WC_Product_Variable();
+		$parent_product->save();
+
+		$product_variation = new \WC_Product_Variation();
+		$product_variation->save();
+
+		$product_variation->set_parent_id( $parent_product->get_id() );
+		$product_variation->save();
+
+		$parent_product->set_children( [ $product_variation->get_id() ] );
+		$parent_product->save();
+
+		$request = [
+			'retailer_id' => "wc_post_id_{$product_variation->get_id()}",
+			'data'        => [
+				'retailer_product_group_id' => "wc_post_id_{$parent_product->get_id()}"
+			],
+		];
+
+		$this->check_process_item_update_request( $product_variation, $request );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -217,6 +217,52 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * Tests that custom variation attributes are included in the additional_variant_attributes field.
+	 *
+	 * @see Background::process_item()
+	 */
+	public function test_process_item_update_request_with_custom_variation_attributes() {
+
+		$attributes[0] = new \WC_Product_Attribute();
+		$attributes[0]->set_name( 'Test Attribute 2' );
+		$attributes[0]->set_options( [ 'foo-1', 'foo-2', 'foo-3' ] );
+		$attributes[0]->set_visible( true );
+		$attributes[0]->set_variation( true );
+
+		$attributes[1] = new \WC_Product_Attribute();
+		$attributes[1]->set_name( 'Test Attribute 1' );
+		$attributes[1]->set_options( [ 'bar-1', 'bar-2', 'bar-3' ] );
+		$attributes[1]->set_visible( true );
+		$attributes[1]->set_variation( true );
+
+		$parent_product = new \WC_Product_Variable();
+		$parent_product->save();
+
+		$product_variation = new \WC_Product_Variation();
+		$product_variation->save();
+
+		$product_variation->set_parent_id( $parent_product->get_id() );
+		$product_variation->set_attributes( [ 'test-attribute-1' => 'foo-1', 'test-attribute-2' => 'bar-3' ] );
+		$product_variation->save();
+
+		$parent_product->set_children( [ $product_variation->get_id() ] );
+		$parent_product->set_attributes( $attributes );
+		$parent_product->save();
+
+		$request = [
+			'data' => [
+				'additional_variant_attributes' => [
+					'test-attribute-1' => 'foo-1',
+					'test-attribute-2' => 'bar-3',
+				],
+			],
+		];
+
+		$this->check_process_item_update_request( $product_variation, $request );
+	}
+
+
 	/** @see Background::process_item() */
 	public function test_process_item_delete_request() {
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -216,6 +216,21 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Background::process_item() */
+	public function test_process_item_delete_request() {
+
+		$product = new \WC_Product_Simple();
+		$product->save();
+
+		$item = [ $product->get_id(), Sync::ACTION_DELETE ];
+
+		$result = $this->get_background()->process_item( $item, null );
+
+		$this->assertEquals( "wc_post_id_{$product->get_id()}", $result['retailer_id'] );
+		$this->assertEquals( Sync::ACTION_DELETE, $result['method'] );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -177,6 +177,45 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * Tests that the retailer ID field uses the product SKU if avaiable.
+	 *
+	 * @see Background::process_item()
+	 *
+	 * @param string $sku product SKU
+	 * @param string $reatiler_id expected retailer ID
+	 *
+	 * @dataProvider provider_process_item_update_request_retailer_id_generation
+	 */
+	public function test_process_item_update_request_retailer_id_generation( $sku, $retailer_id ) {
+
+		$product = new \WC_Product_Simple();
+		$product->set_sku( $sku );
+		$product->save();
+
+		$retailer_id = sprintf( $retailer_id, $product->get_id() );
+
+		$request = [
+			'retailer_id' => $retailer_id,
+			'data'        => [
+				'retailer_product_group_id' => $retailer_id,
+			],
+		];
+
+		$this->check_process_item_update_request( $product, $request );
+	}
+
+
+	/** @see test_process_item_update_request_retailer_id_generation() */
+	public function provider_process_item_update_request_retailer_id_generation() {
+
+		return [
+			[ 'SKU-123', 'SKU-123_%d' ],
+			[ '',        'wc_post_id_%d' ],
+		];
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -3,6 +3,7 @@
 use Codeception\Stub;
 use SkyVerge\WooCommerce\Facebook\Products\Sync;
 use SkyVerge\WooCommerce\Facebook\Products\Sync\Background;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 /**
  * Tests the Sync\Background class.
@@ -228,6 +229,42 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( "wc_post_id_{$product->get_id()}", $result['retailer_id'] );
 		$this->assertEquals( Sync::ACTION_DELETE, $result['method'] );
+	}
+
+
+	/**
+	 * Tests that an exception is thrown if no product is found with the given product ID.
+	 *
+	 * @see Background::process_item()
+	 *
+	 * @dataProvider provider_process_item_exceptions
+	 */
+	public function test_process_item_exceptions( $product, $method ) {
+
+		$this->expectException( Framework\SV_WC_Plugin_Exception::class );
+
+		$item = [ $product->get_id(), $method ];
+
+		$this->get_background()->process_item( $item, null );
+	}
+
+
+	/** @see test_process_item_exceptions() */
+	public function provider_process_item_exceptions() {
+
+		$valid_product = new \WC_Product_Simple();
+		$valid_product->save();
+
+		$product_without_id = new \WC_Product_Simple();
+
+		$product_variation_without_parent = new \WC_Product_Variation();
+		$product_variation_without_parent->save();
+
+		return [
+			[ $product_without_id,               Sync::ACTION_UPDATE ],
+			[ $product_variation_without_parent, Sync::ACTION_UPDATE ],
+			[ $valid_product,                    'INVALID' ],
+		];
 	}
 
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -314,6 +314,40 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * @see Background::process_item_update()
+	 *
+	 * @param string $filter filter name
+	 * @param string $method sync request method
+	 *
+	 * @dataProvider provider_process_item_filters
+	 */
+	public function test_process_item_filters( $filter, $method ) {
+
+		add_filter( $filter, static function() {
+
+			return [ 'filtered' => true ];
+		} );
+
+		$product = new \WC_Product_Simple();
+		$product->save();
+
+		$request = $this->get_background()->process_item( [ $product, $method ], null );
+
+		$this->assertEquals( [ 'filtered' => true ], $request );
+	}
+
+
+	/** @see test_process_item_filters */
+	public function provider_process_item_filters() {
+
+		return [
+			[ 'wc_facebook_sync_background_item_update_request', Sync::ACTION_UPDATE ],
+			[ 'wc_facebook_sync_background_item_delete_request', Sync::ACTION_DELETE ]
+		];
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -279,7 +279,7 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
-	 * Tests that an exception is thrown if no product is found with the given product ID.
+	 * Tests that process_item() throws exceptions if product or method are invalid.
 	 *
 	 * @see Background::process_item()
 	 *


### PR DESCRIPTION

# Summary

This PR implements the `Sync\Background::process_item()` method.

## Details

I also added a couple of private helper methods to separate the code that processes UPDATE and DELETE requests, and the code that processes the data returned from `WC_Facebook_Product::prepare_product()`.

### Story: [CH 54669](https://app.clubhouse.io/skyverge/story/54669)
### Release: #1277

## QA

- [x] `vendor codecept run integration tests/integration/Products/Sync/BackgroundTest.php` pass