### PR TITLE
Create a request to Send Item Updates

### DIFF
--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -42,4 +42,17 @@ class Request extends API\Request  {
 	}
 
 
+	/**
+	 * Sets the array of item update requests.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param array $requests item update requests
+	 */
+	public function set_requests( array $requests ) {
+
+		$this->requests = $requests;
+	}
+
+
 }

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -30,6 +30,19 @@ class Request extends API\Request  {
 
 
 	/**
+	 * Gets the ID of this request for rate limiting purposes.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'ads_management_api_request';
+	}
+
+
+	/**
 	 * API request constructor.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -21,4 +21,12 @@ use SkyVerge\WooCommerce\Facebook\API;
  */
 class Request extends API\Request  {
 
+
+	/** @var array an arary of item update requests */
+	protected $requests = [];
+
+	/** @var bool determines whether updates for products that are not currently in the catalog should create new items */
+	protected $allow_upsert = true;
+
+
 }

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -73,7 +73,7 @@ class Request extends API\Request  {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param bool $allow_upsert wehther to allow updates to insert new items
+	 * @param bool $allow_upsert whether to allow updates to insert new items
 	 */
 	public function set_allow_upsert( $allow_upsert ) {
 

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -22,7 +22,7 @@ use SkyVerge\WooCommerce\Facebook\API;
 class Request extends API\Request  {
 
 
-	/** @var array an arary of item update requests */
+	/** @var array an array of item update requests */
 	protected $requests = [];
 
 	/** @var bool determines whether updates for products that are not currently in the catalog should create new items */

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -29,4 +29,17 @@ class Request extends API\Request  {
 	protected $allow_upsert = true;
 
 
+	/**
+	 * API request constructor.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $catalog_id catalog ID
+	 */
+	public function __construct( $catalog_id ) {
+
+		parent::__construct( $catalog_id, '/batch', 'POST' );
+	}
+
+
 }

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -73,7 +73,7 @@ class Request extends API\Request  {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param array $data
+	 * @param bool $allow_upsert wehther to allow updates to insert new items
 	 */
 	public function set_allow_upsert( $allow_upsert ) {
 

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) or exit;
 use SkyVerge\WooCommerce\Facebook\API;
 
 /**
- * Base API request object.
+ * Request object for the Send Item Updates API request.
  *
  * @since 2.0.0-dev.1
  */

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Catalog\Send_Item_Updates;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Base API request object.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Request extends API\Request  {
+
+}

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -55,4 +55,17 @@ class Request extends API\Request  {
 	}
 
 
+	/**
+	 * Sets whether updates for products that are not currently in the catalog should create new items.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param array $data
+	 */
+	public function set_allow_upsert( $allow_upsert ) {
+
+		$this->allow_upsert = (bool) $allow_upsert;
+	}
+
+
 }

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -47,6 +47,7 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 	 */
 	public function set_data( $data ) {
 
+		$this->data = $data;
 	}
 
 

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -33,6 +33,8 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 	 */
 	public function __construct( $object_id, $path, $method ) {
 
+		$this->method = $method;
+		$this->path   = $path ? sprintf( '/%s/%s', $object_id, trim( $path, '/' ) ) : "/{$object_id}";
 	}
 
 

--- a/tests/integration/API/Catalog/Send_Item_Updates/RequestTest.php
+++ b/tests/integration/API/Catalog/Send_Item_Updates/RequestTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\API\Catalog\Send_Item_Updates\Request;
+
+/**
+ * Tests the API\Catalog\Send_Item_Updates\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		require_once 'includes/API/Request.php';
+		require_once 'includes/API/Catalog/Send_Item_Updates/Request.php';
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Request::__construct() */
+	public function test_constructor() {
+
+		$request = new Request( '1234' );
+
+		$this->assertEquals( '/1234/batch', $request->get_path() );
+		$this->assertEquals( 'POST', $request->get_method() );
+	}
+
+
+	/** @see Request::set_requests() */
+	public function test_set_requests() {
+
+		$request = new Request( '1234 ');
+
+		$request->set_requests( [] );
+
+		// TODO: assert that the array of requests is included in get_data()
+	}
+
+
+	/** @see Request::set_allow_upsert() */
+	public function test_set_allow_upsert() {
+
+		$request = new Request( '1234 ');
+
+		$request->set_allow_upsert( false );
+
+		// TODO: assert that the allow upsert is included in get_data()
+	}
+
+
+}

--- a/tests/integration/API/Catalog/Send_Item_Updates/RequestTest.php
+++ b/tests/integration/API/Catalog/Send_Item_Updates/RequestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Catalog\Send_Item_Updates;
+
 use SkyVerge\WooCommerce\Facebook\API\Catalog\Send_Item_Updates\Request;
 
 /**

--- a/tests/integration/API/RequestTest.php
+++ b/tests/integration/API/RequestTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\API\Request;
+
+/**
+ * Tests the API\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		require_once 'includes/API/Request.php';
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see Request::__construct()
+	 *
+	 * @param string $object_id object ID
+	 * @param string $path endpoint route
+	 * @param string $method HTTP method
+	 *
+	 * @dataProvider provider_constructor
+	 */
+	public function test_constructor( $object_id, $path, $method, $expect_path ) {
+
+		$request = new Request( $object_id, $path, $method );
+
+		$this->assertEquals( $expect_path, $request->get_path() );
+		$this->assertEquals( $method, $request->get_method() );
+	}
+
+	/** @see test_constructor */
+	public function provider_constructor( $requests ) {
+
+		return [
+			[ 'me', '', 'GET', '/me' ],
+			[ '1234', '/products', 'GET', '/1234/products' ],
+
+			[ '1234', 'batch', 'POST', '/1234/batch' ],
+			[ '1234', '/batch/', 'POST', '/1234/batch' ],
+			[ '1234', '', 'POST', '/1234' ],
+		];
+	}
+
+
+	/** @see Request::set_data() */
+	public function test_set_data() {
+
+		$request = new Request( null, null, null );
+		$data    = [ 'key' => 'value' ];
+
+		$request->set_data( $data );
+
+		$this->assertEquals( $data, $request->get_data() );
+	}
+
+
+}

--- a/tests/integration/API/RequestTest.php
+++ b/tests/integration/API/RequestTest.php
@@ -31,6 +31,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	 * @param string $object_id object ID
 	 * @param string $path endpoint route
 	 * @param string $method HTTP method
+	 * @param string $expected_path expected request path
 	 *
 	 * @dataProvider provider_constructor
 	 */

--- a/tests/integration/API/RequestTest.php
+++ b/tests/integration/API/RequestTest.php
@@ -34,11 +34,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @dataProvider provider_constructor
 	 */
-	public function test_constructor( $object_id, $path, $method, $expect_path ) {
+	public function test_constructor( $object_id, $path, $method, $expected_path ) {
 
 		$request = new Request( $object_id, $path, $method );
 
-		$this->assertEquals( $expect_path, $request->get_path() );
+		$this->assertEquals( $expected_path, $request->get_path() );
 		$this->assertEquals( $method, $request->get_method() );
 	}
 

--- a/tests/integration/API/RequestTest.php
+++ b/tests/integration/API/RequestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SkyVerge\WooCommerce\Facebook\Tests\API;
+
 use SkyVerge\WooCommerce\Facebook\API\Request;
 
 /**


### PR DESCRIPTION
# Summary

This PR implements the `API\Catalog\Send_Item_Updates\Request` class, the constructor and new setter methods.

## Details

I also added the implementation for the constructor and `set_data()` methods in the parent class.

### Story: [CH 54727](https://app.clubhouse.io/skyverge/story/54727)
### Release: #1277

## QA

- [ ] `vendor codecept run integration tests/tests/integration/API/RequestTest.php` pass
- [ ] `vendor codecept run integration tests/tests/integration/API/Catalog/Send_Item_Updates/RequestTest.php` pass