### PR TITLE
Add shutdown hook to schedule background sync

### DIFF
--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -12,6 +12,7 @@ namespace SkyVerge\WooCommerce\Facebook\Products;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Facebook\Products\Sync\Background;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 /**
@@ -52,7 +53,8 @@ class Sync {
 	 * @since 2.0.0-dev.1
 	 */
 	public function add_hooks() {
-		// TODO
+
+		add_action( 'shutdown', [ $this, 'schedule_sync' ] );
 	}
 
 
@@ -90,9 +92,17 @@ class Sync {
 	 * Creates a background job to sync the products in the requests array.
 	 *
 	 * @since 2.0.0-dev.1
+	 *
+	 * @return \stdClass|object|null
 	 */
 	public function schedule_sync() {
-		// TODO
+
+		if ( ! empty( $this->requests ) ) {
+
+			return facebook_for_woocommerce()->get_products_sync_background_handler()->create_job( [
+				'requests' => $this->requests
+			] );
+		}
 	}
 
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -82,6 +82,27 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Sync::schedule_sync() */
+	public function test_schedule_sync() {
+
+		$background  = facebook_for_woocommerce()->get_products_sync_background_handler();
+		$sync        = $this->get_sync();
+		$product_ids = [ 123, 456 ];
+
+		$sync->create_or_update_products( $product_ids );
+
+		$requests_property = new ReflectionProperty( Sync::class, 'requests' );
+		$requests_property->setAccessible( true );
+
+		$requests = $requests_property->getValue( $sync );
+		$job      = $sync->schedule_sync();
+		$bg_job   = $background->get_job( $job->id );
+
+		$this->assertNotNull( $bg_job );
+		$this->assertEquals( $requests, $bg_job->requests );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -12,14 +12,6 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 	protected $tester;
 
 
-	public function _before() {
-
-		parent::_before();
-
-		require_once 'includes/Products/Sync.php';
-	}
-
-
 	/** Test methods **************************************************************************************************/
 
 


### PR DESCRIPTION
# Summary

At the end of each request, we should check whether the requests queue has any items. 

## :vertical_traffic_light: Acceptance criteria

- `schedule_sync()` is registered as an action callback for `shutdown`
- A new background job is created at the end of the current request if the `$requests` queue has any entries

**Main Story:** [ch54644](https://app.clubhouse.io/skyverge/story/54644)

## QA

`vendor/bin/codecept run integration integration/Products/SyncTest.php`