### PR TITLE
Create a request to find a Product Item

### DIFF
--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -37,6 +37,19 @@ class Request extends \SkyVerge\WooCommerce\Facebook\API\Request {
 
 
 	/**
+	 * Gets the request parameters.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_params() {
+
+		return [ 'fields' => 'id,product_group{id}' ];
+	}
+
+
+	/**
 	 * Gets the rate limit ID for this request.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -12,12 +12,14 @@ namespace SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Find;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Facebook\API;
+
 /**
  * Find Product Item API request object.
  *
  * @since 2.0.0-dev.1
  */
-class Request extends \SkyVerge\WooCommerce\Facebook\API\Request {
+class Request extends API\Request {
 
 
 	/**

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -43,9 +43,9 @@ class Request extends \SkyVerge\WooCommerce\Facebook\API\Request {
 	 */
 	public function __construct( $catalog_id, $retailer_id ) {
 
-		$path = "catalog:{$catalog_id}:" . base64_encode( $retailer_id );
+		parent::__construct( null, null, 'GET' );
 
-		parent::__construct( $catalog_id, $path, 'GET' );
+		$this->path = "catalog:{$catalog_id}:" . base64_encode( $retailer_id );
 	}
 
 

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -20,4 +20,20 @@ defined( 'ABSPATH' ) or exit;
 class Request extends \SkyVerge\WooCommerce\Facebook\API\Request {
 
 
+	/**
+	 * Find Product Item API request constructor.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $catalog_id catalog ID
+	 * @param string $retailer_id retailer ID of the product
+	 */
+	public function __construct( $catalog_id, $retailer_id ) {
+
+		$path = "catalog:{$catalog_id}:" . base64_encode( $retailer_id );
+
+		parent::__construct( $catalog_id, $path, 'GET' );
+	}
+
+
 }

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Find;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * Find Product Item API request object.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Request extends \SkyVerge\WooCommerce\Facebook\API\Request {
+
+
+}

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -21,7 +21,20 @@ class Request extends \SkyVerge\WooCommerce\Facebook\API\Request {
 
 
 	/**
-	 * Find Product Item API request constructor.
+	 * Gets the ID of this request for rate limiting purposes.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'wc_facebook_ads_management_api_request';
+	}
+
+
+	/**
+	 * API request constructor.
 	 *
 	 * @since 2.0.0-dev.1
 	 *
@@ -46,19 +59,6 @@ class Request extends \SkyVerge\WooCommerce\Facebook\API\Request {
 	public function get_params() {
 
 		return [ 'fields' => 'id,product_group{id}' ];
-	}
-
-
-	/**
-	 * Gets the rate limit ID for this request.
-	 *
-	 * @since 2.0.0-dev.1
-	 *
-	 * @return string
-	 */
-	public static function get_rate_limit_id() {
-
-		return 'wc_facebook_ads_management_api_request';
 	}
 
 

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -36,4 +36,17 @@ class Request extends \SkyVerge\WooCommerce\Facebook\API\Request {
 	}
 
 
+	/**
+	 * Gets the rate limit ID for this request.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'wc_facebook_ads_management_api_request';
+	}
+
+
 }

--- a/tests/integration/API/Catalog/Product_Item/Find/RequestTest.php
+++ b/tests/integration/API/Catalog/Product_Item/Find/RequestTest.php
@@ -5,7 +5,7 @@ use SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Find\Request;
 /**
  * Tests the API\Catalog\Product_Item\Find\Request class.
  */
-class Request_Test extends \Codeception\TestCase\WPTestCase {
+class RequestTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @var \IntegrationTester */

--- a/tests/integration/API/Catalog/Product_Item/Find/Request_Test.php
+++ b/tests/integration/API/Catalog/Product_Item/Find/Request_Test.php
@@ -3,7 +3,7 @@
 use SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Find\Request;
 
 /**
- * Tests the Find Product Item Request class.
+ * Tests the API\Catalog\Product_Item\Find\Request class.
  */
 class Request_Test extends \Codeception\TestCase\WPTestCase {
 
@@ -16,6 +16,8 @@ class Request_Test extends \Codeception\TestCase\WPTestCase {
 	 * Runs before each test.
 	 */
 	protected function _before() {
+
+		parent::_before();
 
 		require_once 'includes/API/Request.php';
 		require_once 'includes/API/Catalog/Product_Item/Find/Request.php';

--- a/tests/integration/API/Catalog/Product_Item/Find/Request_Test.php
+++ b/tests/integration/API/Catalog/Product_Item/Find/Request_Test.php
@@ -47,4 +47,11 @@ class Request_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see \SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Find\Request::get_rate_limit_id() */
+	public function test_get_rate_limit_id() {
+
+		$this->assertEquals( 'wc_facebook_ads_management_api_request', Request::get_rate_limit_id() );
+	}
+
+
 }

--- a/tests/integration/API/Catalog/Product_Item/Find/Request_Test.php
+++ b/tests/integration/API/Catalog/Product_Item/Find/Request_Test.php
@@ -1,0 +1,50 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Find\Request;
+
+/**
+ * Tests the Find Product Item Request class.
+ */
+class Request_Test extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+		require_once 'includes/API/Request.php';
+		require_once 'includes/API/Catalog/Product_Item/Find/Request.php';
+	}
+
+
+	/**
+	 * Runs after each test.
+	 */
+	protected function _after() {
+
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see \SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Find\Request::__construct */
+	public function test_constructor() {
+
+		$catalog_id  = '165835951532406';
+		$retailer_id = base64_decode( 'd3BfcG9zdF8xMDQx' );
+
+		$request = new Request( $catalog_id, $retailer_id );
+
+		$this->assertInstanceOf( Request::class, $request );
+		$this->assertEquals( 'catalog:165835951532406:d3BfcG9zdF8xMDQx', $request->get_path() );
+		$this->assertEquals( 'GET', $request->get_method() );
+	}
+
+
+}

--- a/tests/integration/API/Catalog/Product_Item/Find/Request_Test.php
+++ b/tests/integration/API/Catalog/Product_Item/Find/Request_Test.php
@@ -54,4 +54,16 @@ class Request_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see \SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Find\Request::get_params() */
+	public function test_get_params() {
+
+		$catalog_id  = '165835951532406';
+		$retailer_id = base64_decode( 'd3BfcG9zdF8xMDQx' );
+
+		$request = new Request( $catalog_id, $retailer_id );
+
+		$this->assertEquals( [ 'fields' => 'id,product_group{id}' ], $request->get_params() );
+	}
+
+
 }


### PR DESCRIPTION
# Summary

This PR implements the `API\Catalog\Product_Item\Find\Request` class.

## Details

Branches off `ch54727/api-request-to-send-item-updates` because of the additions to the base Request class.

### Story: [CH 54739](https://app.clubhouse.io/skyverge/story/54739/create-a-request-to-find-a-product-item)
### Release: #1277

## QA

- [x] `vendor codecept run tests/integration/API/Catalog/Product_Item/Find/RequestTest.php` pass