### PR TITLE
Create a request to get a Page object

### DIFF
--- a/includes/API/Pages/Read/Request.php
+++ b/includes/API/Pages/Read/Request.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Pages\Read;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Page API request object.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Request extends API\Request  {
+
+
+}

--- a/includes/API/Pages/Read/Request.php
+++ b/includes/API/Pages/Read/Request.php
@@ -22,4 +22,17 @@ use SkyVerge\WooCommerce\Facebook\API;
 class Request extends API\Request  {
 
 
+	/**
+	 * Gets the request parameters.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_params() {
+
+		return [ 'fields' => 'name,link' ];
+	}
+
+
 }

--- a/tests/integration/API/Pages/Read/RequestTest.php
+++ b/tests/integration/API/Pages/Read/RequestTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Pages\Read;
+
+use SkyVerge\WooCommerce\Facebook\API\Pages\Read\Request;
+
+/**
+ * Tests the API\Pages\Read\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		require_once 'includes/API/Request.php';
+		require_once 'includes/API/Pages/Read/Request.php';
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Request::__construct() */
+	public function test_constructor() {
+
+		$request = new Request( '1234', null, 'GET' );
+
+		$this->assertEquals( '/1234', $request->get_path() );
+		$this->assertEquals( 'GET', $request->get_method() );
+	}
+
+
+	/** @see Request::get_params() */
+	public function test_get_params() {
+
+		$request = new Request( '1234', null, null );
+
+		$this->assertEquals( [ 'fields' => 'name,link' ], $request->get_params() );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR implements the `API\Pages\Read\Request` class.

## Details

Branches off `ch54727/api-request-to-send-item-updates` because of the additions to the base Request class.

### Story: [CH 54743](https://app.clubhouse.io/skyverge/story/54743/create-a-request-to-get-a-page-object)
### Release: #1277

## QA

- [x] `vendor codecept run tests/integration/API/Pages/Read/RequestTest.php` pass