### PR TITLE
Disable Facebook sync options for Virtual products

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 *** Facebook for WooCommerce Changelog ***
 
 2020.nn.nn - version 2.0.0-dev.1
+ * Tweak - Hide Facebook options for virtual products and virtual variations
+ * Tweak - Do not allow merchant to bulk enable sync for virtual products
+ * Tweak - On upgrade, automatically disable sync for virtual products and virtual variations
  * Tweak - When using checkboxes for tags, make sure the modal is displayed when trying to enable sync for a product with an excluded tag
  * Fix - Use the plugin version instead of of a timestamp as the version number for enqueued scripts and stylesheets
  * Fix - Prevent tracking of a duplicated purchase event in some circumstances such as when the customer reloads the "Thank You" page after completing an order

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -112,7 +112,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				$this->product_feed            = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
 				$this->products_sync_handler   = new \SkyVerge\WooCommerce\Facebook\Products\Sync();
 				$this->sync_background_handler = new \SkyVerge\WooCommerce\Facebook\Products\Sync\Background();
-				$this->product_feed = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
 
 				if ( is_ajax() ) {
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -9,6 +9,7 @@
  */
 
 use SkyVerge\WooCommerce\Facebook\Lifecycle;
+use SkyVerge\WooCommerce\Facebook\Utilities\Background_Disable_Virtual_Products_Sync;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
@@ -57,6 +58,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 		/** @var \SkyVerge\WooCommerce\Facebook\Handlers\Connection connection handler */
 		private $connection_handler;
+
+		/** @var Background_Disable_Virtual_Products_Sync instance */
+		protected $background_disable_virtual_products_sync;
 
 
 		/**
@@ -108,6 +112,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				$this->product_feed            = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
 				$this->products_sync_handler   = new \SkyVerge\WooCommerce\Facebook\Products\Sync();
 				$this->sync_background_handler = new \SkyVerge\WooCommerce\Facebook\Products\Sync\Background();
+				$this->product_feed = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
 
 				if ( is_ajax() ) {
 
@@ -122,6 +127,13 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				$this->integrations = new \SkyVerge\WooCommerce\Facebook\Integrations\Integrations( $this );
 
 				$this->connection_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\Connection();
+
+				if ( 'yes' !== get_option( 'wc_facebook_sync_virtual_products_disabled', 'no' ) ) {
+
+					require_once __DIR__ . '/includes/Utilities/Background_Disable_Virtual_Products_Sync.php';
+
+					$this->background_disable_virtual_products_sync = new Background_Disable_Virtual_Products_Sync();
+				}
 			}
 		}
 
@@ -276,6 +288,19 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		public function get_connection_handler() {
 
 			return $this->connection_handler;
+		}
+
+
+		/**
+		 * Gets the background disable virtual products sync handler instance.
+		 *
+		 * @since 1.11.3-dev.2
+		 *
+		 * @return \SkyVerge\WooCommerce\Facebook\Utilities\Background_Disable_Virtual_Products_Sync
+		 */
+		public function get_background_disable_virtual_products_sync_instance() {
+
+			return $this->background_disable_virtual_products_sync;
 		}
 
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -294,7 +294,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Gets the background disable virtual products sync handler instance.
 		 *
-		 * @since 1.11.3-dev.2
+		 * @since 2.0.0-dev.1
 		 *
 		 * @return \SkyVerge\WooCommerce\Facebook\Utilities\Background_Disable_Virtual_Products_Sync
 		 */

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -294,7 +294,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Gets the background disable virtual products sync handler instance.
 		 *
-		 * @since 2.0.0-dev.1
+		 * @since 1.11.3-dev.2
 		 *
 		 * @return \SkyVerge\WooCommerce\Facebook\Utilities\Background_Disable_Virtual_Products_Sync
 		 */

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -836,7 +836,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$sync_enabled = ! empty( $_POST['fb_sync_enabled'] );
+		$sync_enabled = ! $product->is_virtual() && ! empty( $_POST['fb_sync_enabled'] );
 		$is_visible   = ! empty( $_POST[ Products::VISIBILITY_META_KEY ] );
 
 		if ( ! $product->is_type( 'variable' ) ) {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -692,7 +692,7 @@ class Admin {
 	 *
 	 * @internal
 	 *
-	 * @since 2.0.0-dev.1
+	 * @since 1.11.3-dev.2
 	 */
 	public function add_enabling_virtual_products_sync_notice() {
 		global $current_screen;
@@ -720,7 +720,7 @@ class Admin {
 	 *
 	 * @internal
 	 *
-	 * @since 2.0.0-dev.1
+	 * @since 1.11.3-dev.2
 	 */
 	public function add_disabled_virtual_products_sync_notice() {
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -692,7 +692,7 @@ class Admin {
 	 *
 	 * @internal
 	 *
-	 * @since 1.11.3-dev.2
+	 * @since 2.0.0-dev.1
 	 */
 	public function add_enabling_virtual_products_sync_notice() {
 		global $current_screen;
@@ -720,7 +720,7 @@ class Admin {
 	 *
 	 * @internal
 	 *
-	 * @since 1.11.3-dev.2
+	 * @since 2.0.0-dev.1
 	 */
 	public function add_disabled_virtual_products_sync_notice() {
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -221,7 +221,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 	/**
 	 * Upgrades to version 1.11.3.
 	 *
-	 * @since 1.11.3-dev.2
+	 * @since 2.0.0-dev.1
 	 */
 	protected function upgrade_to_1_11_3() {
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -39,7 +39,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 			'1.10.0',
 			'1.10.1',
 			'1.11.0',
-			'1.11.3',
+			'2.0.0',
 		];
 	}
 
@@ -219,11 +219,11 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 
 
 	/**
-	 * Upgrades to version 1.11.3.
+	 * Upgrades to version 2.0.0.
 	 *
 	 * @since 2.0.0-dev.1
 	 */
-	protected function upgrade_to_1_11_3() {
+	protected function upgrade_to_2_0_0() {
 
 		if ( $handler = $this->get_plugin()->get_background_disable_virtual_products_sync_instance() ) {
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -39,7 +39,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 			'1.10.0',
 			'1.10.1',
 			'1.11.0',
-			'2.0.0',
+			'1.11.3',
 		];
 	}
 
@@ -219,11 +219,11 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 
 
 	/**
-	 * Upgrades to version 2.0.0.
+	 * Upgrades to version 1.11.3.
 	 *
-	 * @since 2.0.0-dev.1
+	 * @since 1.11.3-dev.2
 	 */
-	protected function upgrade_to_2_0_0() {
+	protected function upgrade_to_1_11_3() {
 
 		if ( $handler = $this->get_plugin()->get_background_disable_virtual_products_sync_instance() ) {
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -39,6 +39,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 			'1.10.0',
 			'1.10.1',
 			'1.11.0',
+			'1.11.3',
 		];
 	}
 
@@ -213,6 +214,22 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 		// moves the upload ID to a standalone option
 		if ( ! empty( $settings['fb_upload_id'] ) ) {
 			$this->get_plugin()->get_integration()->update_upload_id( $settings['fb_upload_id'] );
+		}
+	}
+
+
+	/**
+	 * Upgrades to version 1.11.3.
+	 *
+	 * @since 1.11.3-dev.2
+	 */
+	protected function upgrade_to_1_11_3() {
+
+		if ( $handler = $this->get_plugin()->get_background_disable_virtual_products_sync_instance() ) {
+
+			// create_job() expects an non-empty array of attributes
+			$handler->create_job( [ 'created_at' => current_time( 'mysql' ) ] );
+			$handler->dispatch();
 		}
 	}
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -73,6 +73,12 @@ class Products {
 
 						if ( $product_variation instanceof \WC_Product ) {
 
+							if ( $enabled && $product_variation->is_virtual() ) {
+
+								// never enable sync for virtual variations
+								continue;
+							}
+
 							$product_variation->update_meta_data( self::SYNC_ENABLED_META_KEY, $enabled );
 							$product_variation->save_meta_data();
 						}

--- a/includes/Utilities/Background_Disable_Virtual_Products_Sync.php
+++ b/includes/Utilities/Background_Disable_Virtual_Products_Sync.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Utilities;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+
+
+/**
+ * Background job handler to exclude virtual products and virtual product variations from sync.
+ *
+ * @since 1.11.3-dev.2
+ */
+class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Background_Job_Handler {
+
+
+	/**
+	 * Background job constructor.
+	 *
+	 * @since 1.11.3-dev.2
+	 */
+	public function __construct() {
+
+		$this->prefix = 'wc_facebook';
+		$this->action = 'background_disable_virtual_products_sync';
+
+		parent::__construct();
+	}
+
+
+	/**
+	 * Processes job.
+	 *
+	 * This job continues to update products and product variations meta data until we run out of memory
+	 * or exceed the time limit. There is no list of items to loop over.
+	 *
+	 * @since 1.11.3-dev.2
+	 *
+	 * @param object $job
+	 * @param int $items_per_batch number of items to process in a single request. Defaults to unlimited.
+	 * @return object
+	 */
+	public function process_job( $job, $items_per_batch = null ) {
+
+		if ( ! isset( $job->total ) ) {
+			$job->total = $this->count_remaining_products();
+
+			if ( empty( $job->total ) ) {
+
+				// no products or variations need to be excluded from sync, do not display admin notice
+				update_option( 'wc_facebook_sync_virtual_products_disabled_skipped', 'yes' );
+			}
+		}
+
+		if ( ! isset( $job->progress ) ) {
+			$job->progress = 0;
+		}
+
+		$remaining_products = $job->total;
+		$processed_products = 0;
+
+		// disable sync until memory or time limit is exceeded
+		while ( $processed_products < $remaining_products ) {
+
+			$rows_updated = $this->disable_sync();
+
+			$processed_products += $rows_updated;
+			$job->progress      += $rows_updated;
+
+			// update job progress
+			$job = $this->update_job( $job );
+
+			// memory or time limit reached
+			if ( $this->time_exceeded() || $this->memory_exceeded() ) {
+				break;
+			}
+		}
+
+		// job complete! :)
+		if ( $this->count_remaining_products() === 0 ) {
+
+			update_option( 'wc_facebook_sync_virtual_products_disabled', 'yes' );
+
+			$this->complete_job( $job );
+		}
+
+		return $job;
+	}
+
+
+	/**
+	 * Counts the number of virtual products or product variations with sync enabled.
+	 *
+	 * @since 1.11.3-dev.2
+	 *
+	 * @return bool
+	 */
+	private function count_remaining_products() {
+		global $wpdb;
+
+		$sql = "
+			SELECT COUNT( posts.ID )
+			FROM {$wpdb->posts} AS posts
+			INNER JOIN {$wpdb->postmeta} AS virtual_meta ON ( posts.ID = virtual_meta.post_id AND virtual_meta.meta_key = '_virtual' AND virtual_meta.meta_value = 'yes' )
+			LEFT JOIN {$wpdb->postmeta} AS sync_meta ON ( posts.ID = sync_meta.post_id AND sync_meta.meta_key = '_wc_facebook_sync_enabled' )
+			WHERE posts.post_type IN ( 'product', 'product_variation' )
+			AND ( sync_meta.meta_value IS NULL OR sync_meta.meta_value = 'yes' )
+		";
+
+		return (int) $wpdb->get_var( $sql );
+	}
+
+
+	/**
+	 * Update rows into the postmeta table to disable sync.
+	 *
+	 * @since 1.11.3-dev.2
+	 *
+	 * @return int
+	 */
+	private function disable_sync() {
+		global $wpdb;
+
+		$rows_inserted = 0;
+
+		// get post IDs to update
+		$sql = "
+			SELECT DISTINCT( posts.ID )
+			FROM {$wpdb->posts} AS posts
+			INNER JOIN {$wpdb->postmeta} AS virtual_meta ON ( posts.ID = virtual_meta.post_id AND virtual_meta.meta_key = '_virtual' AND virtual_meta.meta_value = 'yes' )
+			LEFT JOIN {$wpdb->postmeta} AS sync_meta ON ( posts.ID = sync_meta.post_id AND sync_meta.meta_key = '_wc_facebook_sync_enabled' )
+			WHERE posts.post_type IN ( 'product', 'product_variation' )
+			AND ( sync_meta.meta_value IS NULL OR sync_meta.meta_value = 'yes' )
+			LIMIT 1000
+		";
+
+		$post_ids = $wpdb->get_col( $sql );
+
+		if ( empty( $post_ids ) ) {
+
+			facebook_for_woocommerce()->log( 'There are no products or products variations to update.' );
+
+		} else {
+
+			$post_ids_str = implode( "','", $post_ids );
+
+			// delete the metadata so we can insert it without creating duplicates
+			$sql = "
+				DELETE FROM {$wpdb->postmeta}
+					WHERE meta_key = '_wc_facebook_sync_enabled'
+					AND post_id IN ( '{$post_ids_str}' )
+			";
+
+			$wpdb->query( $sql );
+
+			$values = [];
+
+			foreach ( $post_ids as $post_id ) {
+
+				$values[] = "('$post_id', '_wc_facebook_sync_enabled', 'no')";
+			}
+
+			$values_str = implode( ',', $values );
+
+			// we need to explicitly insert the metadata and set it to no, because not having it means sync is enabled
+			$sql = "
+				INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value )
+					VALUES {$values_str}
+			";
+
+			$rows_inserted = $wpdb->query( $sql );
+
+			if ( false === $rows_inserted ) {
+
+				$message = sprintf( 'There was an error trying to set products and variations meta data. %s', $wpdb->last_error );
+
+				facebook_for_woocommerce()->log( $message );
+			}
+		}
+
+		return (int) $rows_inserted;
+	}
+
+
+	/**
+	 * No-op
+	 *
+	 * @since 1.11.3-dev.2
+	 */
+	protected function process_item( $item, $job ) {
+		// void
+	}
+
+
+}

--- a/includes/Utilities/Background_Disable_Virtual_Products_Sync.php
+++ b/includes/Utilities/Background_Disable_Virtual_Products_Sync.php
@@ -18,7 +18,7 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 /**
  * Background job handler to exclude virtual products and virtual product variations from sync.
  *
- * @since 2.0.0-dev.1
+ * @since 1.11.3-dev.2
  */
 class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Background_Job_Handler {
 
@@ -26,7 +26,7 @@ class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Backgroun
 	/**
 	 * Background job constructor.
 	 *
-	 * @since 2.0.0-dev.1
+	 * @since 1.11.3-dev.2
 	 */
 	public function __construct() {
 
@@ -43,7 +43,7 @@ class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Backgroun
 	 * This job continues to update products and product variations meta data until we run out of memory
 	 * or exceed the time limit. There is no list of items to loop over.
 	 *
-	 * @since 2.0.0-dev.1
+	 * @since 1.11.3-dev.2
 	 *
 	 * @param object $job
 	 * @param int $items_per_batch number of items to process in a single request. Defaults to unlimited.
@@ -100,7 +100,7 @@ class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Backgroun
 	/**
 	 * Counts the number of virtual products or product variations with sync enabled.
 	 *
-	 * @since 2.0.0-dev.1
+	 * @since 1.11.3-dev.2
 	 *
 	 * @return bool
 	 */
@@ -123,7 +123,7 @@ class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Backgroun
 	/**
 	 * Update rows into the postmeta table to disable sync.
 	 *
-	 * @since 2.0.0-dev.1
+	 * @since 1.11.3-dev.2
 	 *
 	 * @return int
 	 */
@@ -194,7 +194,7 @@ class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Backgroun
 	/**
 	 * No-op
 	 *
-	 * @since 2.0.0-dev.1
+	 * @since 1.11.3-dev.2
 	 */
 	protected function process_item( $item, $job ) {
 		// void

--- a/includes/Utilities/Background_Disable_Virtual_Products_Sync.php
+++ b/includes/Utilities/Background_Disable_Virtual_Products_Sync.php
@@ -18,7 +18,7 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 /**
  * Background job handler to exclude virtual products and virtual product variations from sync.
  *
- * @since 1.11.3-dev.2
+ * @since 2.0.0-dev.1
  */
 class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Background_Job_Handler {
 
@@ -26,7 +26,7 @@ class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Backgroun
 	/**
 	 * Background job constructor.
 	 *
-	 * @since 1.11.3-dev.2
+	 * @since 2.0.0-dev.1
 	 */
 	public function __construct() {
 
@@ -43,7 +43,7 @@ class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Backgroun
 	 * This job continues to update products and product variations meta data until we run out of memory
 	 * or exceed the time limit. There is no list of items to loop over.
 	 *
-	 * @since 1.11.3-dev.2
+	 * @since 2.0.0-dev.1
 	 *
 	 * @param object $job
 	 * @param int $items_per_batch number of items to process in a single request. Defaults to unlimited.
@@ -100,7 +100,7 @@ class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Backgroun
 	/**
 	 * Counts the number of virtual products or product variations with sync enabled.
 	 *
-	 * @since 1.11.3-dev.2
+	 * @since 2.0.0-dev.1
 	 *
 	 * @return bool
 	 */
@@ -123,7 +123,7 @@ class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Backgroun
 	/**
 	 * Update rows into the postmeta table to disable sync.
 	 *
-	 * @since 1.11.3-dev.2
+	 * @since 2.0.0-dev.1
 	 *
 	 * @return int
 	 */
@@ -194,7 +194,7 @@ class Background_Disable_Virtual_Products_Sync extends Framework\SV_WP_Backgroun
 	/**
 	 * No-op
 	 *
-	 * @since 1.11.3-dev.2
+	 * @since 2.0.0-dev.1
 	 */
 	protected function process_item( $item, $job ) {
 		// void

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,9 @@ When opening a bug on GitHub, please give us as many details as possible.
 == Changelog ==
 
 = 2020.nn.nn - version 2.0.0-dev.1 =
+ * Tweak - Hide Facebook options for virtual products and virtual variations
+ * Tweak - Do not allow merchant to bulk enable sync for virtual products
+ * Tweak - On upgrade, automatically disable sync for virtual products and virtual variations
  * Tweak - When using checkboxes for tags, make sure the modal is displayed when trying to enable sync for a product with an excluded tag
  * Fix - Use the plugin version instead of of a timestamp as the version number for enqueued scripts and stylesheets
  * Fix - Prevent tracking of a duplicated purchase event in some circumstances such as when the customer reloads the "Thank You" page after completing an order

--- a/tests/acceptance/Admin/ProductSyncBulkActionsCest.php
+++ b/tests/acceptance/Admin/ProductSyncBulkActionsCest.php
@@ -1,0 +1,324 @@
+<?php
+
+class ProductSyncBulkActionsCest {
+
+
+	// product objects created for the tests */
+	/** @var \WC_Product */
+	private $product;
+
+
+	/**
+	 * Runs before each test.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 * @throws \Exception
+	 */
+	public function _before( AcceptanceTester $I ) {
+
+		// save a generic product
+		$this->product = $I->haveProductInDatabase();
+
+		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '1234' );
+		$I->haveOptionInDatabase( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234' );
+
+		// always log in
+		$I->loginAsAdmin();
+	}
+
+
+	/**
+	 * Test that the Include in Facebook sync enables sync for a standard product.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_include_bulk_action_standard( AcceptanceTester $I ) {
+
+		// disable sync for the product before viewing the Products page
+		\SkyVerge\WooCommerce\Facebook\Products::disable_sync_for_products( [ $this->product ] );
+
+		$I->amOnProductsPage();
+
+		$I->see( 'Disabled', 'table.wp-list-table td' );
+
+		$I->wantTo( 'Test that the Include in Facebook sync enables sync for a standard product' );
+
+		$I->click( "#cb-select-{$this->product->get_id()}" );
+		$I->selectOption( '[name=action]', 'Include in Facebook sync' );
+		$I->click( '#doaction' );
+		$I->waitForElement( "#cb-select-{$this->product->get_id()}:not(:checked)" );
+
+		$I->see( 'Enabled', 'table.wp-list-table td' );
+	}
+
+
+	/**
+	 * Test that the Include in Facebook sync enables sync when using the secondary dropdown at the bottom of the list table.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_include_bulk_action_secondary_dropdown( AcceptanceTester $I ) {
+
+		// disable sync for the product before viewing the Products page
+		\SkyVerge\WooCommerce\Facebook\Products::disable_sync_for_products( [ $this->product ] );
+
+		$I->amOnProductsPage();
+
+		$I->see( 'Disabled', 'table.wp-list-table td' );
+
+		$I->wantTo( 'Test that the Include in Facebook sync enables sync for a standard product when using the secondary dropdown at the bottom of the list table' );
+
+		$I->click( "#cb-select-{$this->product->get_id()}" );
+		$I->selectOption( '[name=action2]', 'Include in Facebook sync' );
+		$I->click( '#doaction2' );
+		$I->waitForElement( "#cb-select-{$this->product->get_id()}:not(:checked)" );
+
+		$I->see( 'Enabled', 'table.wp-list-table td' );
+	}
+
+
+	/**
+	 * Test that the Include in Facebook sync does not enable sync for a product in an excluded category.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_include_bulk_action_excluded_category( AcceptanceTester $I ) {
+
+		// disable sync for the product before viewing the Products page
+		\SkyVerge\WooCommerce\Facebook\Products::disable_sync_for_products( [ $this->product ] );
+
+		// have an excluded category
+		list( $excluded_category_id, $excluded_category_taxonomy_id ) = $I->haveTermInDatabase( 'Excluded category', 'product_cat' );
+		$I->haveFacebookForWooCommerceSettingsInDatabase( [
+			\WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS => [ $excluded_category_id ]
+		] );
+
+		// add the product to the excluded category
+		wp_add_object_terms( $this->product->get_id(), [ $excluded_category_id ], 'product_cat' );
+
+		$I->amOnProductsPage();
+
+		$I->see( 'Excluded category', 'table.wp-list-table td' );
+		$I->see( 'Disabled', 'table.wp-list-table td' );
+
+		$I->wantTo( 'Test that the Include in Facebook sync does not enable sync for a product in an excluded category' );
+
+		$I->click( "#cb-select-{$this->product->get_id()}" );
+		$I->selectOption( '[name=action]', 'Include in Facebook sync' );
+		$I->click( '#doaction' );
+
+		$I->waitForElementVisible( '#wc-backbone-modal-dialog' );
+		$I->see( 'One or more of the selected products belongs to a category or tag that is excluded from the Facebook catalog sync. To sync these products to Facebook, please remove the category or tag exclusion from the plugin settings.', '#wc-backbone-modal-dialog' );
+		$I->see( 'Go to Settings', '#wc-backbone-modal-dialog' );
+		$I->see( 'Cancel', '#wc-backbone-modal-dialog' );
+
+		$I->click( 'Cancel', '#wc-backbone-modal-dialog' );
+
+		$I->waitForElementNotVisible( '#wc-backbone-modal-dialog' );
+		$I->see( 'Disabled', 'table.wp-list-table td' );
+	}
+
+
+	/**
+	 * Test that the Include in Facebook sync does not enable sync for a product with an excluded tag.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_include_bulk_action_excluded_tag( AcceptanceTester $I ) {
+
+		// disable sync for the product before viewing the Products page
+		\SkyVerge\WooCommerce\Facebook\Products::disable_sync_for_products( [ $this->product ] );
+
+		// have an excluded tag
+		list( $excluded_tag_id, $excluded_tag_taxonomy_id ) = $I->haveTermInDatabase( 'Excluded tag', 'product_tag' );
+		$I->haveFacebookForWooCommerceSettingsInDatabase( [
+			\WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_TAG_IDS => [ $excluded_tag_id ]
+		] );
+
+		// add the excluded tag to the product
+		wp_add_object_terms( $this->product->get_id(), [ $excluded_tag_id ], 'product_tag' );
+
+		$I->amOnProductsPage();
+
+		$I->see( 'Excluded tag', 'table.wp-list-table td' );
+		$I->see( 'Disabled', 'table.wp-list-table td' );
+
+		$I->wantTo( 'Test that the Include in Facebook sync does not enable sync for a product with an excluded tag' );
+
+		$I->click( "#cb-select-{$this->product->get_id()}" );
+		$I->selectOption( '[name=action]', 'Include in Facebook sync' );
+		$I->click( '#doaction' );
+
+		$I->waitForElementVisible( '#wc-backbone-modal-dialog' );
+		$I->see( 'One or more of the selected products belongs to a category or tag that is excluded from the Facebook catalog sync. To sync these products to Facebook, please remove the category or tag exclusion from the plugin settings.', '#wc-backbone-modal-dialog' );
+		$I->see( 'Go to Settings', '#wc-backbone-modal-dialog' );
+		$I->see( 'Cancel', '#wc-backbone-modal-dialog' );
+
+		$I->click( 'Cancel', '#wc-backbone-modal-dialog' );
+
+		$I->waitForElementNotVisible( '#wc-backbone-modal-dialog' );
+		$I->see( 'Disabled', 'table.wp-list-table td' );
+	}
+
+
+	/**
+	 * Test that the Include in Facebook sync does not enable sync for a virtual product.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_include_bulk_action_virtual( AcceptanceTester $I ) {
+
+		// disable sync for the product before viewing the Products page
+		\SkyVerge\WooCommerce\Facebook\Products::disable_sync_for_products( [ $this->product ] );
+
+		// make the product virtual
+		$this->product->set_virtual( true );
+		$this->product->save();
+
+		$I->amOnProductsPage();
+
+		$I->see( 'Disabled', 'table.wp-list-table td' );
+
+		$I->wantTo( 'Test that the Include in Facebook sync does not enable sync for a virtual product' );
+
+		$I->click( "#cb-select-{$this->product->get_id()}" );
+		$I->selectOption( '[name=action]', 'Include in Facebook sync' );
+		$I->click( '#doaction' );
+		$I->waitForElement( "#cb-select-{$this->product->get_id()}:not(:checked)" );
+
+		$I->see( 'Heads up! Facebook does not support selling virtual products, so we can\'t include virtual products in your catalog sync. Click here to read more about Facebook\'s policy.', 'div.notice.is-dismissible' );
+		$I->see( 'Disabled', 'table.wp-list-table td' );
+	}
+
+
+	/**
+	 * Test that the Exclude from Facebook sync disables sync for a standard product.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_exclude_bulk_action_standard( AcceptanceTester $I ) {
+
+		// enable sync for the product before viewing the Products page
+		\SkyVerge\WooCommerce\Facebook\Products::enable_sync_for_products( [ $this->product ] );
+
+		$I->amOnProductsPage();
+
+		$I->see( 'Enabled', 'table.wp-list-table td' );
+
+		$I->wantTo( 'Test that the Exclude from Facebook sync disables sync for a standard product' );
+
+		$I->click( "#cb-select-{$this->product->get_id()}" );
+		$I->selectOption( '[name=action]', 'Exclude from Facebook sync' );
+		$I->click( '#doaction' );
+		$I->waitForElement( "#cb-select-{$this->product->get_id()}:not(:checked)" );
+
+		$I->see( 'Disabled', 'table.wp-list-table td' );
+	}
+
+
+	/**
+	 * Test that the Exclude from Facebook sync disables sync when using the secondary dropdown at the bottom of the list table.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_exclude_bulk_action_secondary_dropdown( AcceptanceTester $I ) {
+
+		// enable sync for the product before viewing the Products page
+		\SkyVerge\WooCommerce\Facebook\Products::enable_sync_for_products( [ $this->product ] );
+
+		$I->amOnProductsPage();
+
+		$I->see( 'Enabled', 'table.wp-list-table td' );
+
+		$I->wantTo( 'Test that the Exclude from Facebook sync disables sync for a standard product when using the secondary dropdown at the bottom of the list table' );
+
+		$I->click( "#cb-select-{$this->product->get_id()}" );
+		$I->selectOption( '[name=action2]', 'Exclude from Facebook sync' );
+		$I->click( '#doaction2' );
+		$I->waitForElement( "#cb-select-{$this->product->get_id()}:not(:checked)" );
+
+		$I->see( 'Disabled', 'table.wp-list-table td' );
+	}
+
+
+	/**
+	 * Test that the Include in Facebook sync only enables sync for non-virtual variations.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_include_bulk_action_virtual_variation( AcceptanceTester $I ) {
+
+		// save a variable product
+		$result = $I->haveVariableProductInDatabase( [
+			'attributes' => [
+				'color' => [ 'red', 'green' ]
+			],
+			'variations' => [
+				'regular_variation' => [ 'color' => 'red' ],
+				'virtual_variation' => [ 'color' => 'green' ],
+			],
+		] );
+
+		$variable_product = $result['product'];
+
+		/** @var WC_Product_Variation[] $variations */
+		$variations = $result['variations'];
+
+		$virtual_variation = $variations['virtual_variation'];
+		$virtual_variation->set_virtual( true );
+		$virtual_variation->save();
+
+		// disable sync for the product before viewing the Products page
+		\SkyVerge\WooCommerce\Facebook\Products::disable_sync_for_products( [ $variable_product ] );
+
+		$I->amOnProductsPage();
+
+		$I->wantTo( 'Test that the Include in Facebook sync only enables sync for non-virtual variations' );
+
+		$I->click( "#cb-select-{$variable_product->get_id()}" );
+		$I->selectOption( '[name=action]', 'Include in Facebook sync' );
+		$I->click( '#doaction' );
+		$I->waitForElement( "#cb-select-{$variable_product->get_id()}:not(:checked)" );
+
+		$I->see( 'Heads up! Facebook does not support selling virtual products, so we can\'t include virtual products in your catalog sync. Click here to read more about Facebook\'s policy.', 'div.notice.is-dismissible' );
+		$I->see( 'Enabled', 'table.wp-list-table td' );
+
+		$variable_product = wc_get_product( $variable_product );
+		$variation_ids    = $variable_product->get_children();
+
+		foreach ( $variation_ids as $variation_id ) {
+
+			$variation = wc_get_product( $variation_id );
+
+			$meta_criteria = [
+				'post_id'    => $variation_id,
+				'meta_key'   => '_wc_facebook_sync_enabled',
+				'meta_value' => 'yes',
+			];
+
+			if ( ! $variation->is_virtual() ) {
+				$I->seePostMetaInDatabase( $meta_criteria );
+			} else {
+				$I->dontSeePostMetaInDatabase( $meta_criteria );
+			}
+		}
+	}
+
+
+}

--- a/tests/acceptance/Admin/ProductSyncSettingCest.php
+++ b/tests/acceptance/Admin/ProductSyncSettingCest.php
@@ -231,4 +231,67 @@ class ProductSyncSettingCest {
 	}
 
 
+	/**
+	 * Test that the tab is hidden for virtual products.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 */
+	public function try_tab_hidden_virtual_products( AcceptanceTester $I ) {
+
+		$I->amEditingPostWithId( $this->sync_enabled_product->get_id() );
+
+		$I->wantTo( 'Test that the tab is hidden when the product is made virtual' );
+
+		// checkOption does not work here for some reason
+		$I->click( '#_virtual' );
+
+		$I->dontSee( 'Facebook', '.fb_commerce_tab_options' );
+
+		$I->wantTo( 'Test that the tab and fields are shown when the product is made non virtual' );
+
+		$I->click( '#_virtual' );
+
+		$I->see( 'Facebook', '.fb_commerce_tab_options' );
+
+		$I->click( 'Facebook', '.fb_commerce_tab_options' );
+
+		$I->see( 'Include in Facebook sync', '.form-field' );
+		$I->see( 'Facebook Description', '.form-field' );
+		$I->see( 'Facebook Product Image', '.form-field' );
+		$I->see( 'Facebook Price', '.form-field' );
+	}
+
+
+	/**
+	 * Test that the sync is automatically disabled when saving virtual products.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_sync_disabled_saving_virtual_products( AcceptanceTester $I ) {
+
+		$I->amEditingPostWithId( $this->sync_enabled_product->get_id() );
+
+		$I->wantTo( 'Test that the sync is automatically disabled when saving virtual products' );
+
+		// checkOption does not work here for some reason
+		$I->click( '#_virtual' );
+
+		// scroll to and click the Update button
+		$I->scrollTo( '#publish', 0, -200 );
+		$I->click( '#publish' );
+
+		$I->waitForText( 'Product updated' );
+
+		// uncheck the Virtual checkbox just so we can see the value of the sync enabled checkbox
+		$I->click( '#_virtual' );
+
+		$I->click( 'Facebook', '.fb_commerce_tab_options' );
+
+		$I->see( 'Include in Facebook sync', '.form-field' );
+		$I->dontSeeCheckboxIsChecked( '#fb_sync_enabled' );
+	}
+
+
 }

--- a/tests/acceptance/Admin/ProductVariationSyncSettingCest.php
+++ b/tests/acceptance/Admin/ProductVariationSyncSettingCest.php
@@ -257,4 +257,72 @@ class ProductVariationSyncSettingCest {
 	}
 
 
+	/**
+	 * Test that the fields are hidden for virtual variations.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_fields_hidden_virtual_variations( AcceptanceTester $I ) {
+
+		$index = $I->amEditingProductVariation( $this->product_variation );
+
+		$I->wantTo( 'Test that the fields are hidden when the variation is made virtual' );
+
+		$I->waitForElementVisible( "#variable_description{$index}" );
+
+		$I->click( "[name='variable_is_virtual[{$index}]']" );
+
+		$I->dontSeeElement( "#variable_fb_sync_enabled{$index}" );
+		$I->dontSeeElement( "#variable_fb_product_description{$index}" );
+		$I->dontSeeElement( ".variable_fb_product_image_source{$index}_field" );
+		$I->dontSeeElement( "#variable_fb_product_image{$index}" );
+		$I->dontSeeElement( "#variable_fb_product_price{$index}" );
+
+		$I->wantTo( 'Test that the fields are shown when the variation is made non virtual' );
+
+		$I->click( "[name='variable_is_virtual[{$index}]']" );
+
+		$I->seeElement( "#variable_fb_sync_enabled{$index}" );
+		$I->seeElement( "#variable_fb_product_description{$index}" );
+		$I->seeElement( ".variable_fb_product_image_source{$index}_field" );
+		$I->seeElement( "#variable_fb_product_image{$index}" );
+		$I->seeElement( "#variable_fb_product_price{$index}" );
+	}
+
+
+	/**
+	 * Test that the sync is automatically disabled when saving virtual variations.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 *
+	 * @throws Exception
+	 */
+	public function try_sync_disabled_saving_virtual_variations( AcceptanceTester $I ) {
+
+		$index = $I->amEditingProductVariation( $this->product_variation );
+
+		$I->wantTo( 'Test that the sync is automatically disabled when saving virtual variations' );
+
+		$I->waitForElementVisible( "#variable_description{$index}" );
+
+		$I->click( "[name='variable_is_virtual[{$index}]']" );
+
+		$I->click( [ 'css' => '.save-variation-changes' ] );
+
+		$I->wait( 4 );
+
+		$index = $I->openVariationMetabox( $this->product_variation );
+
+		$I->waitForElementVisible( "#variable_description{$index}" );
+
+		// uncheck the Virtual checkbox just so we can see the value of the sync enabled checkbox
+		$I->click( "[name='variable_is_virtual[{$index}]']" );
+
+		$I->seeElement( "#variable_fb_sync_enabled{$index}" );
+		$I->dontSeeCheckboxIsChecked( "#variable_fb_sync_enabled{$index}" );
+	}
+
+
 }


### PR DESCRIPTION
This PR brings the following changes from the private repo:

```
 * Tweak - Hide Facebook options for virtual products and virtual variations
 * Tweak - Do not allow merchant to bulk enable sync for virtual products
 * Tweak - On upgrade, automatically disable sync for virtual products and virtual variations
```