### PR TITLE
Add an API method to create a Product Group

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -73,7 +73,7 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function create_product_group( $catalog_id, $data ) {
 
-		$request = new Request( $catalog_id, '/product_groups', 'POST' );
+		$request = $this->get_new_request( [ $catalog_id, '/product_groups', 'POST' ] );
 
 		$request->set_data( $data );
 
@@ -213,11 +213,13 @@ class API extends Framework\SV_WC_API_Base {
 	 * @since 2.0.0-dev.1
 	 *
 	 * @param array $args optional request arguments
-	 * @return \SkyVerge\WooCommerce\Facebook\API\Request
+	 * @return Request
 	 */
 	protected function get_new_request( $args = [] ) {
 
-		// TODO: Implement get_new_request() method.
+		list( $object_id, $path, $method ) = $args;
+
+		return new Request( $object_id ?: null, $path ?: null, $method ?: null );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -12,6 +12,7 @@ namespace SkyVerge\WooCommerce\Facebook;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Facebook\API\Request;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 
@@ -62,12 +63,12 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param string $catalog_id
-	 * @param array $data
+	 * @param string $catalog_id catalog ID
+	 * @param array $data product group data
 	 */
 	public function create_product_group( $catalog_id, $data ) {
 
-		// TODO: Implement create_product_group() method.
+		$request = new Request( $catalog_id, '/product_groups', 'POST' );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -66,6 +66,8 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 * @param string $catalog_id catalog ID
 	 * @param array $data product group data
+	 * @return Response
+	 * @throws Framework\SV_WC_API_Exception
 	 */
 	public function create_product_group( $catalog_id, $data ) {
 
@@ -75,6 +77,7 @@ class API extends Framework\SV_WC_API_Base {
 
 		$this->response_handler = Response::class;
 
+		return $this->perform_request( $request );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -13,6 +13,7 @@ namespace SkyVerge\WooCommerce\Facebook;
 defined( 'ABSPATH' ) or exit;
 
 use SkyVerge\WooCommerce\Facebook\API\Request;
+use SkyVerge\WooCommerce\Facebook\API\Response;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 
@@ -69,6 +70,8 @@ class API extends Framework\SV_WC_API_Base {
 	public function create_product_group( $catalog_id, $data ) {
 
 		$request = new Request( $catalog_id, '/product_groups', 'POST' );
+
+		$this->response_handler = Response::class;
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -71,7 +71,10 @@ class API extends Framework\SV_WC_API_Base {
 
 		$request = new Request( $catalog_id, '/product_groups', 'POST' );
 
+		$request->set_data( $data );
+
 		$this->response_handler = Response::class;
+
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -75,7 +75,7 @@ class API extends Framework\SV_WC_API_Base {
 
 		$request->set_data( $data );
 
-		$this->response_handler = Response::class;
+		$this->set_response_handler( Response::class );
 
 		return $this->perform_request( $request );
 	}

--- a/includes/API.php
+++ b/includes/API.php
@@ -21,6 +21,8 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
  * API handler.
  *
  * @since 2.0.0-dev.1
+ *
+ * @method Response perform_request( $request )
  */
 class API extends Framework\SV_WC_API_Base {
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -12,6 +12,7 @@ namespace SkyVerge\WooCommerce\Facebook\Products;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Facebook\Products\Sync\Background;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 /**
@@ -52,7 +53,8 @@ class Sync {
 	 * @since 2.0.0-dev.1
 	 */
 	public function add_hooks() {
-		// TODO
+
+		add_action( 'shutdown', [ $this, 'schedule_sync' ] );
 	}
 
 
@@ -90,9 +92,17 @@ class Sync {
 	 * Creates a background job to sync the products in the requests array.
 	 *
 	 * @since 2.0.0-dev.1
+	 *
+	 * @return \stdClass|object|null
 	 */
 	public function schedule_sync() {
-		// TODO
+
+		if ( ! empty( $this->requests ) ) {
+
+			return facebook_for_woocommerce()->get_products_sync_background_handler()->create_job( [
+				'requests' => $this->requests
+			] );
+		}
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -1,9 +1,16 @@
 <?php
 
+use SkyVerge\WooCommerce\Facebook\API;
+use SkyVerge\WooCommerce\Facebook\API\Request;
+use SkyVerge\WooCommerce\Facebook\API\Response;
+
 /**
  * Tests the API class.
  */
 class APITest extends \Codeception\TestCase\WPTestCase {
+
+
+	use \Codeception\Test\Feature\Stub;
 
 
 	/** @var \IntegrationTester */
@@ -15,6 +22,11 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	 */
 	protected function _before() {
 
+		parent::_before();
+
+		require_once 'includes/API.php';
+		require_once 'includes/API/Request.php';
+		require_once 'includes/API/Response.php';
 	}
 
 
@@ -28,5 +40,26 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 
 	/** Test methods **************************************************************************************************/
 
+
+	/** @see API::create_product_group() */
+	public function test_create_product_group() {
+
+		$product_group_data = [ 'test' => 'test' ];
+
+		// test will fail if Request::set_data() is not called once
+		$request = $this->make( Request::class, [
+			'set_data' => \Codeception\Stub\Expected::once( $product_group_data ),
+		] );
+
+		$response = new Response( '' );
+
+		$api = $this->make( API::class, [
+			'get_new_request' => $request,
+			'perform_request' => $response,
+		] );
+
+		// assert that perform_request() was called
+		$this->assertSame( $response, $api->create_product_group( '123456', $product_group_data ) );
+	}
 
 }

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -3,7 +3,7 @@
 /**
  * Tests the API class.
  */
-class API_Test extends \Codeception\TestCase\WPTestCase {
+class APITest extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @var \IntegrationTester */

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -62,4 +62,60 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 		$this->assertSame( $response, $api->create_product_group( '123456', $product_group_data ) );
 	}
 
+
+	/** @see API::update_product_group() */
+	public function test_update_product_group() {
+
+		// TODO
+	}
+
+	/** @see API::delete_product_group() */
+	public function test_delete_product_group() {
+
+		// TODO
+	}
+
+	/** @see API::find_product_item() */
+	public function test_find_product_item() {
+
+		// TODO
+	}
+
+	/** @see API::create_product_item() */
+	public function test_create_product_item() {
+
+		// TODO
+	}
+
+	/** @see API::update_product_item() */
+	public function test_update_product_item() {
+
+		// TODO
+	}
+
+	/** @see API::delete_product_item() */
+	public function test_delete_product_item() {
+
+		// TODO
+	}
+
+	/** @see API::set_rate_limit_delay() */
+	public function test_set_rate_limit_delay() {
+
+		// TODO
+	}
+
+	/** @see API::get_rate_limit_delay() */
+	public function test_get_rate_limit_delay() {
+
+		// TODO
+	}
+
+	/** @see API::calculate_rate_limit_delay() */
+	public function test_calculate_rate_limit_delay() {
+
+		// TODO
+	}
+
+
 }

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -82,6 +82,27 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Sync::schedule_sync() */
+	public function test_schedule_sync() {
+
+		$background  = facebook_for_woocommerce()->get_products_sync_background_handler();
+		$sync        = $this->get_sync();
+		$product_ids = [ 123, 456 ];
+
+		$sync->create_or_update_products( $product_ids );
+
+		$requests_property = new ReflectionProperty( Sync::class, 'requests' );
+		$requests_property->setAccessible( true );
+
+		$requests = $requests_property->getValue( $sync );
+		$job      = $sync->schedule_sync();
+		$bg_job   = $background->get_job( $job->id );
+
+		$this->assertNotNull( $bg_job );
+		$this->assertEquals( $requests, $bg_job->requests );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -12,14 +12,6 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 	protected $tester;
 
 
-	public function _before() {
-
-		parent::_before();
-
-		require_once 'includes/Products/Sync.php';
-	}
-
-
 	/** Test methods **************************************************************************************************/
 
 


### PR DESCRIPTION
# Summary

This PR implements the `API::create_product_group()` method.

### Story: [CH 54743](https://app.clubhouse.io/skyverge/story/54753/add-an-api-method-to-create-a-product-group)
### Release: #1277

## QA

- [x] `vendor codecept run tests/integration/APITest.php` pass