### PR TITLE
Add an API method to update a Product Group

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -94,6 +94,8 @@ class API extends Framework\SV_WC_API_Base {
 	public function update_product_group( $product_group_id, $data ) {
 
 		$request = $this->get_new_request( [ $product_group_id, '', 'POST' ] );
+
+		$this->set_response_handler( Response::class );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -93,7 +93,7 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function update_product_group( $product_group_id, $data ) {
 
-		// TODO: Implement update_product_group() method.
+		$request = $this->get_new_request( [ $product_group_id, '', 'POST' ] );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -90,6 +90,8 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 * @param string $product_group_id
 	 * @param array $data
+	 * @return Response
+	 * @throws Framework\SV_WC_API_Exception
 	 */
 	public function update_product_group( $product_group_id, $data ) {
 
@@ -98,6 +100,8 @@ class API extends Framework\SV_WC_API_Base {
 		$request->set_data( $data );
 
 		$this->set_response_handler( Response::class );
+
+		return $this->perform_request( $request );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -95,6 +95,8 @@ class API extends Framework\SV_WC_API_Base {
 
 		$request = $this->get_new_request( [ $product_group_id, '', 'POST' ] );
 
+		$request->set_data( $data );
+
 		$this->set_response_handler( Response::class );
 	}
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -62,4 +62,26 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 		$this->assertSame( $response, $api->create_product_group( '123456', $product_group_data ) );
 	}
 
+
+	/** @see API::update_product_group() */
+	public function test_update_product_group() {
+
+		$product_group_data = [ 'test' => 'test' ];
+
+		// test will fail if Request::set_data() is not called once
+		$request = $this->make( Request::class, [
+			'set_data' => \Codeception\Stub\Expected::once( $product_group_data ),
+		] );
+
+		$response = new Response( '' );
+
+		$api = $this->make( API::class, [
+			'get_new_request' => $request,
+			'perform_request' => $response,
+		] );
+
+		// assert that perform_request() was called
+		$this->assertSame( $response, $api->update_product_group( '1234', $product_group_data ) );
+	}
+
 }


### PR DESCRIPTION
# Summary

This PR implements the `API::update_product_group()` method.

### Story: [CH 54758](https://app.clubhouse.io/skyverge/story/54758/add-an-api-method-to-update-a-product-group)
### Release: #1277

## QA

- [x] `vendor codecept run tests/integration/APITest.php` pass