### PR TITLE
Add an API method to delete a Product Group

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -107,6 +107,8 @@ class API extends Framework\SV_WC_API_Base {
 	public function delete_product_group( $product_group_id ) {
 
 		$request = $this->get_new_request( [ $product_group_id, '', 'DELETE' ] );
+
+		$this->set_response_handler( Response::class );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -106,7 +106,7 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function delete_product_group( $product_group_id ) {
 
-		// TODO: Implement delete_product_group() method.
+		$request = $this->get_new_request( [ $product_group_id, '', 'DELETE' ] );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -103,12 +103,16 @@ class API extends Framework\SV_WC_API_Base {
 	 * @since 2.0.0-dev.1
 	 *
 	 * @param string $product_group_id
+	 * @return Response
+	 * @throws Framework\SV_WC_API_Exception
 	 */
 	public function delete_product_group( $product_group_id ) {
 
 		$request = $this->get_new_request( [ $product_group_id, '', 'DELETE' ] );
 
 		$this->set_response_handler( Response::class );
+
+		return $this->perform_request( $request );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -69,11 +69,20 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 		// TODO
 	}
 
+
 	/** @see API::delete_product_group() */
 	public function test_delete_product_group() {
 
-		// TODO
+		$response = new Response( '' );
+
+		$api = $this->make( API::class, [
+			'perform_request' => $response,
+		] );
+
+		// assert that perform_request() was called
+		$this->assertSame( $response, $api->delete_product_group( '1234' ) );
 	}
+
 
 	/** @see API::find_product_item() */
 	public function test_find_product_item() {


### PR DESCRIPTION
# Summary

This PR implements the `API::delete_product_group()` method.

### Story: [CH 54763](https://app.clubhouse.io/skyverge/story/54763/add-an-api-method-to-delete-a-product-group)
### Release: #1277

## QA

- [ ] `vendor codecept run tests/integration/APITest.php` pass