### PR TITLE
Add an API method to create a Product Item

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -129,12 +129,20 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param string $product_group_id
-	 * @param array $data
+	 * @param string $product_group_id parent product ID
+	 * @param array $data product data
+	 * @return Response
+	 * @throws Framework\SV_WC_API_Exception
 	 */
 	public function create_product_item( $product_group_id, $data ) {
 
-		// TODO: Implement create_product_item() method.
+		$request = $this->get_new_request( [ $product_group_id, '/products', 'POST' ] );
+
+		$request->set_data( $data );
+
+		$this->set_response_handler( Response::class );
+
+		return $this->perform_request( $request );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -81,11 +81,28 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 		// TODO
 	}
 
+
 	/** @see API::create_product_item() */
 	public function test_create_product_item() {
 
-		// TODO
+		$product_data = [ 'test' => 'test' ];
+
+		// test will fail if Request::set_data() is not called once
+		$request = $this->make( Request::class, [
+			'set_data' => \Codeception\Stub\Expected::once( $product_data ),
+		] );
+
+		$response = new Response( '' );
+
+		$api = $this->make( API::class, [
+			'get_new_request' => $request,
+			'perform_request' => $response,
+		] );
+
+		// assert that perform_request() was called
+		$this->assertSame( $response, $api->create_product_item( '123456', $product_data ) );
 	}
+
 
 	/** @see API::update_product_item() */
 	public function test_update_product_item() {


### PR DESCRIPTION
# Summary

This PR implements the `API::create_product_item()` method.

### Story: [CH 54771](https://app.clubhouse.io/skyverge/story/54771/add-an-api-method-to-create-a-product-item)
### Release: #1277

## QA

- [ ] `vendor codecept run tests/integration/APITest.php` pass