### PR TITLE
Add an API method to delete a Product Item

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -157,11 +157,17 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param string $product_group_id
+	 * @param string $product_item_id product item ID
+	 * @return Response
+	 * @throws Framework\SV_WC_API_Exception
 	 */
-	public function delete_product_item( $product_group_id ) {
+	public function delete_product_item( $product_item_id ) {
 
-		// TODO: Implement delete_product_item() method.
+		$request = $this->get_new_request( [ $product_item_id, '', 'DELETE' ] );
+
+		$this->set_response_handler( Response::class );
+
+		return $this->perform_request( $request );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -93,11 +93,20 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 		// TODO
 	}
 
+
 	/** @see API::delete_product_item() */
 	public function test_delete_product_item() {
 
-		// TODO
+		$response = new Response( '' );
+
+		$api = $this->make( API::class, [
+			'perform_request' => $response,
+		] );
+
+		// assert that perform_request() was called
+		$this->assertSame( $response, $api->delete_product_item( '123456' ) );
 	}
+
 
 	/** @see API::set_rate_limit_delay() */
 	public function test_set_rate_limit_delay() {


### PR DESCRIPTION
# Summary

This PR implements the `API::delete_product_item()` method.

### Story: [CH 54781](https://app.clubhouse.io/skyverge/story/54781/add-an-api-method-to-delete-a-product-item)
### Release: #1277

## QA

- [ ] `vendor codecept run tests/integration/APITest.php` pass