### PR TITLE
Create a response for the Product Item object

### DIFF
--- a/includes/API/Catalog/Product_Item/Response.php
+++ b/includes/API/Catalog/Product_Item/Response.php
@@ -31,13 +31,13 @@ class Response extends Framework\SV_WC_API_JSON_Response {
 	 */
 	public function get_group_id() {
 
-		$product_group = '';
+		$product_group_id = '';
 
 		if ( isset( $this->response_data->product_group->id ) ) {
-			$product_group = $this->response_data->product_group->id;
+			$product_group_id = $this->response_data->product_group->id;
 		}
 
-		return $product_group;
+		return $product_group_id;
 	}
 
 

--- a/includes/API/Catalog/Product_Item/Response.php
+++ b/includes/API/Catalog/Product_Item/Response.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+
+/**
+ * Response object for API requests that return a Product Item.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Response extends Framework\SV_WC_API_JSON_Response {
+
+
+	/**
+	 * Gets the Product Item group ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_group_id() {
+
+		$product_group = '';
+
+		if ( isset( $this->response_data->product_group->id ) ) {
+			$product_group = $this->response_data->product_group->id;
+		}
+
+		return $product_group;
+	}
+
+
+}

--- a/tests/integration/API/Catalog/Product_Item/ResponseTest.php
+++ b/tests/integration/API/Catalog/Product_Item/ResponseTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Catalog\Product_Item;
+
+use SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Response;
+
+/**
+ * Tests the Connection class.
+ */
+class ResponseTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		require_once 'includes/API/Catalog/Product_Item/Response.php';
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see Response::get_group_id()
+	 *
+	 * @param string $raw_response JSON encoded response
+	 * @param string $product_group_id expected product group ID
+	 *
+	 * @dataProvider provider_get_group_id()
+	 */
+	public function test_get_group_id( $raw_response, $product_group_id ) {
+
+		$response = new Response( $raw_response );
+
+		$this->assertEquals( $product_group_id, $response->get_group_id() );
+	}
+
+
+	public function provider_get_group_id() {
+
+		return [
+			[ json_encode( [ 'product_group' => [ 'id' => '1234' ] ] ), '1234' ],
+			[ json_encode( [ 'id' => '1234' ] ),                        '' ],
+		];
+	}
+
+
+}

--- a/tests/integration/API/Catalog/Product_Item/ResponseTest.php
+++ b/tests/integration/API/Catalog/Product_Item/ResponseTest.php
@@ -5,7 +5,7 @@ namespace SkyVerge\WooCommerce\Facebook\Tests\API\Catalog\Product_Item;
 use SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Response;
 
 /**
- * Tests the Connection class.
+ * Tests the API\Catalog\Product_Item\Response class.
  */
 class ResponseTest extends \Codeception\TestCase\WPTestCase {
 


### PR DESCRIPTION
# Summary

This PR implements the `API\Catalog\Product_Item\Response` class.

## Details

### Story: [CH 54746](https://app.clubhouse.io/skyverge/story/54746)
### Release: #1277

## QA

- [x] `vendor codecept run integration integration tests/integration/API/Catalog/Product_Item/ResponseTest.php` pass