### PR TITLE
Create a response for the Page object

### DIFF
--- a/includes/API/Pages/Read/Response.php
+++ b/includes/API/Pages/Read/Response.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Pages\Read;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Page API response object.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Response extends API\Response  {
+
+
+}

--- a/includes/API/Pages/Read/Response.php
+++ b/includes/API/Pages/Read/Response.php
@@ -35,4 +35,17 @@ class Response extends API\Response  {
 	}
 
 
+	/**
+	 * Gets the page URL.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string|null
+	 */
+	public function get_url() {
+
+		return $this->link;
+	}
+
+
 }

--- a/includes/API/Pages/Read/Response.php
+++ b/includes/API/Pages/Read/Response.php
@@ -22,4 +22,17 @@ use SkyVerge\WooCommerce\Facebook\API;
 class Response extends API\Response  {
 
 
+	/**
+	 * Gets the page name.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string|null
+	 */
+	public function get_name() {
+
+		return $this->name;
+	}
+
+
 }

--- a/tests/integration/API/Pages/Read/ResponseTest.php
+++ b/tests/integration/API/Pages/Read/ResponseTest.php
@@ -26,13 +26,29 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
-	/** @see Response::get_name() */
-	public function test_get_name() {
+	/**
+	 * @see Response::get_name()
+	 *
+	 * @param array $response_body response body
+	 * @param string|null $page_name expected page name
+	 *
+	 * @dataProvider provider_get_name
+	 */
+	public function test_get_name( $response_body, $page_name ) {
 
-		$raw_response = json_encode( [ 'name' => 'Test Page', 'link' => 'https://example.org' ] );
-		$request      = new Response( $raw_response );
+		$response = new Response( json_encode( $response_body ) );
 
-		$this->assertEquals( 'Test Page', $request->get_name() );
+		$this->assertSame( $page_name, $response->get_name() );
+	}
+
+
+	/** @see test_get_name() */
+	public function provider_get_name() {
+
+		return [
+			[ [ 'name' => 'Test Page', 'link' => 'https://example.org' ], 'Test Page' ],
+			[ [ 'error' => [ 'type' => 'OAuthException', 'code' => 100 ] ], null ],
+		];
 	}
 
 

--- a/tests/integration/API/Pages/Read/ResponseTest.php
+++ b/tests/integration/API/Pages/Read/ResponseTest.php
@@ -7,7 +7,7 @@ use SkyVerge\WooCommerce\Facebook\API\Pages\Read\Response;
 /**
  * Tests the API\Pages\Read\Response class.
  */
-class RequestTest extends \Codeception\TestCase\WPTestCase {
+class ResponseTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @var \IntegrationTester */

--- a/tests/integration/API/Pages/Read/ResponseTest.php
+++ b/tests/integration/API/Pages/Read/ResponseTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Pages\Read;
+
+use SkyVerge\WooCommerce\Facebook\API\Pages\Read\Response;
+
+/**
+ * Tests the API\Pages\Read\Response class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		require_once 'includes/API/Response.php';
+		require_once 'includes/API/Pages/Read/Response.php';
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Response::get_name() */
+	public function test_get_name() {
+
+		$raw_response = json_encode( [ 'name' => 'Test Page', 'link' => 'https://example.org' ] );
+		$request      = new Response( $raw_response );
+
+		$this->assertEquals( 'Test Page', $request->get_name() );
+	}
+
+
+	/** @see Response::get_url() */
+	public function test_get_url() {
+
+		$raw_response = json_encode( [ 'name' => 'Test Page', 'link' => 'https://example.org' ] );
+		$request      = new Response( $raw_response );
+
+		$this->assertEquals( 'https://example.org', $request->get_url() );
+	}
+
+
+}

--- a/tests/integration/API/Pages/Read/ResponseTest.php
+++ b/tests/integration/API/Pages/Read/ResponseTest.php
@@ -52,13 +52,29 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Response::get_url() */
-	public function test_get_url() {
+	/**
+	 * @see Response::get_url()
+	 *
+	 * @param array $response_body response body
+	 * @param string|null $page_url expected page url
+	 *
+	 * @dataProvider provider_get_url
+	 */
+	public function test_get_url( $response_body, $page_url ) {
 
-		$raw_response = json_encode( [ 'name' => 'Test Page', 'link' => 'https://example.org' ] );
-		$request      = new Response( $raw_response );
+		$response = new Response( json_encode( $response_body ) );
 
-		$this->assertEquals( 'https://example.org', $request->get_url() );
+		$this->assertSame( $page_url, $response->get_url() );
+	}
+
+
+	/** @see test_get_url() */
+	public function provider_get_url() {
+
+		return [
+			[ [ 'name' => 'Test Page', 'link' => 'https://example.org' ], 'https://example.org' ],
+			[ [ 'error' => [ 'type' => 'OAuthException', 'code' => 100 ] ], null ],
+		];
 	}
 
 


### PR DESCRIPTION
# Summary

This PR implements the `API\Pages\Read\Response` class.

### Story: [CH 54749](https://app.clubhouse.io/skyverge/story/54749)
### Release: #1277

## QA

- [x] `codecept run integration tests/integration/API/Pages/Read/ResponseTest.php` pass
