### PR TITLE
Add a method to get the API instance

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -209,11 +209,16 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		 *
 		 * @since 2.0.0-dev.1
 		 *
-		 * @return SkyVerge\WooCommerce\Facebook\API
+		 * @return \SkyVerge\WooCommerce\Facebook\API
+		 * @throws Framework\SV_WC_API_Exception
 		 */
 		public function get_api() {
 
 			if ( ! is_object( $this->api ) ) {
+
+				if ( ! $this->get_connection_handler()->get_access_token() ) {
+					throw new Framework\SV_WC_API_Exception( __( 'Cannot create the API instance because the access token is missing.', 'facebook-for-woocommerce' ) );
+				}
 
 				require_once __DIR__ . '/includes/API.php';
 				require_once __DIR__ . '/includes/API/Request.php';

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -37,6 +37,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var \WC_Facebookcommerce singleton instance */
 		protected static $instance;
 
+		/** @var SkyVerge\WooCommerce\Facebook\API instance */
+		private $api;
+
 		/** @var \WC_Facebookcommerce_Integration instance */
 		private $integration;
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -205,6 +205,28 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 
 		/**
+		 * Gets the API instance.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @return SkyVerge\WooCommerce\Facebook\API
+		 */
+		public function get_api() {
+
+			if ( ! is_object( $this->api ) ) {
+
+				require_once __DIR__ . '/includes/API.php';
+				require_once __DIR__ . '/includes/API/Request.php';
+				require_once __DIR__ . '/includes/API/Response.php';
+
+				$this->api = new SkyVerge\WooCommerce\Facebook\API( $this->get_connection_handler()->get_access_token() );
+			}
+
+			return $this->api;
+		}
+
+
+		/**
 		 * Gets the admin handler instance.
 		 *
 		 * @since 1.10.0

--- a/includes/API.php
+++ b/includes/API.php
@@ -38,6 +38,10 @@ class API extends Framework\SV_WC_API_Base {
 	public function __construct( $access_token ) {
 
 		$this->access_token = $access_token;
+
+		$this->request_headers = [
+			'Authorization' => "Bearer {$access_token}",
+		];
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -28,6 +28,17 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Constructor.
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function __construct( $access_token ) {
+
+		$this->access_token = $access_token;
+	}
+
+
+	/**
 	 * Gets a Page object from Facebook.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/API.php
+++ b/includes/API.php
@@ -23,6 +23,9 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 class API extends Framework\SV_WC_API_Base {
 
 
+	/** @var string URI used for the request */
+	protected $request_uri = 'https://graph.facebook.com/v7.0';
+
 	/** @var string the configured access token */
 	protected $access_token;
 

--- a/includes/API/Response.php
+++ b/includes/API/Response.php
@@ -26,9 +26,12 @@ class Response extends Framework\SV_WC_API_JSON_Response {
 	 * Gets the response ID.
 	 *
 	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
 	 */
 	public function get_id() {
-		// TODO
+
+		return $this->id;
 	}
 
 

--- a/tests/integration/API/ResponseTest.php
+++ b/tests/integration/API/ResponseTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API;
+
+use SkyVerge\WooCommerce\Facebook\API\Response;
+
+/**
+ * Tests the API\Response class.
+ */
+class ResponseTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		require_once 'includes/API/Response.php';
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Response::get_id() */
+	public function test_get_id() {
+
+		$raw_response = json_encode( [ 'id' => '1234' ] );
+		$response     = new Response( $raw_response );
+
+		$this->assertEquals( '1234', $response->get_id() );
+	}
+
+
+}

--- a/tests/integration/WC_Facebookcommerce_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Test.php
@@ -1,5 +1,6 @@
 <?php
 
+use SkyVerge\WooCommerce\Facebook\API;
 use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
 use SkyVerge\WooCommerce\Facebook\Products\Sync;
 use SkyVerge\WooCommerce\Facebook\Products\Sync\Background;
@@ -15,6 +16,13 @@ class WC_Facebookcommerce_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/** Test methods **************************************************************************************************/
+
+
+	/** @see \WC_Facebookcommerce::get_api() */
+	public function test_get_api() {
+
+		$this->assertInstanceOf( API::class, facebook_for_woocommerce()->get_api() );
+	}
 
 
 	/** @see \WC_Facebookcommerce::get_connection_handler() */

--- a/tests/integration/WC_Facebookcommerce_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Test.php
@@ -4,6 +4,7 @@ use SkyVerge\WooCommerce\Facebook\API;
 use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
 use SkyVerge\WooCommerce\Facebook\Products\Sync;
 use SkyVerge\WooCommerce\Facebook\Products\Sync\Background;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 /**
  * Tests the WC_Facebookcommerce class.
@@ -21,7 +22,27 @@ class WC_Facebookcommerce_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see \WC_Facebookcommerce::get_api() */
 	public function test_get_api() {
 
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( '1234' );
+
 		$this->assertInstanceOf( API::class, facebook_for_woocommerce()->get_api() );
+	}
+
+
+	/** @see \WC_Facebookcommerce::get_api() */
+	public function test_get_api_exception() {
+
+		$this->expectException( Framework\SV_WC_API_Exception::class );
+
+		$plugin = facebook_for_woocommerce();
+
+		$plugin->get_connection_handler()->update_access_token( null );
+
+		// remove existing instances to make sure the methods attempts to create a new one
+		$instance = new ReflectionProperty( WC_Facebookcommerce::class, 'api' );
+		$instance->setAccessible( true );
+		$instance->setValue( $plugin, null );
+
+		$this->assertInstanceOf( API::class, $plugin->get_api() );
 	}
 
 

--- a/tests/integration/WC_Facebookcommerce_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Test.php
@@ -37,7 +37,7 @@ class WC_Facebookcommerce_Test extends \Codeception\TestCase\WPTestCase {
 
 		$plugin->get_connection_handler()->update_access_token( null );
 
-		// remove existing instances to make sure the methods attempts to create a new one
+		// remove existing instances to make sure the method attempts to create a new one
 		$instance = new ReflectionProperty( WC_Facebookcommerce::class, 'api' );
 		$instance->setAccessible( true );
 		$instance->setValue( $plugin, null );


### PR DESCRIPTION
# Summary

This PR adds a getter for the API instance, defines the `request_uri` and `request_headers` of the API class, and adds the implementation for the `API\Response::get_id()` method.

### Story: [CH 55024](https://app.clubhouse.io/skyverge/story/55024)
### Release: #1277

## Details

The items above are missing pieces that I failed to define as tasks on the associated stories.

## QA

- [x] `codecept run integration tests/integration/WC_Facebookcommerce_Test.php` pass
- [x] `codecept run integration tests/integration/API/ResponseTest.php` pass