### PR TITLE
Add an API method to send item updates

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -70,12 +70,22 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
+	 * @param string $catalog_id catalog ID
 	 * @param array $requests array of prefixed product IDs to create, update or remove
-	 * @param bool $allow_upsert
+	 * @param bool $allow_upsert whether to allow updates to insert new items
+	 * @return Response
+	 * @throws Framework\SV_WC_API_Exception
 	 */
-	public function send_item_updates( $requests, $allow_upsert ) {
+	public function send_item_updates( $catalog_id, $requests, $allow_upsert ) {
 
-		// TODO: Implement send_item_updates() method.
+		$request = new \SkyVerge\WooCommerce\Facebook\API\Catalog\Send_Item_Updates\Request( $catalog_id );
+
+		$request->set_requests( $requests );
+		$request->set_allow_upsert( $allow_upsert );
+
+		$this->set_response_handler( \SkyVerge\WooCommerce\Facebook\API\Catalog\Send_Item_Updates\Response::class );
+
+		return $this->perform_request( $request );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -180,22 +180,23 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::update_product_item() */
 	public function test_update_product_item() {
 
-		$product_data = [ 'test' => 'test' ];
+		$product_item_id = '123456';
+		$product_data    = [ 'test' => 'test' ];
 
-		// test will fail if Request::set_data() is not called once
-		$request = $this->make( Request::class, [
-			'set_data' => \Codeception\Stub\Expected::once( $product_data ),
-		] );
-
-		$response = new Response( '' );
-
+		// test will fail if do_remote_request() is not called once
 		$api = $this->make( API::class, [
-			'get_new_request' => $request,
-			'perform_request' => $response,
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
 		] );
 
-		// assert that perform_request() was called
-		$this->assertSame( $response, $api->update_product_item( '123456', $product_data ) );
+		$api->update_product_item( $product_item_id, $product_data );
+
+		$this->assertInstanceOf( Request::class, $api->get_request() );
+		$this->assertEquals( 'POST', $api->get_request()->get_method() );
+		$this->assertEquals( "/{$product_item_id}", $api->get_request()->get_path() );
+		$this->assertEquals( [], $api->get_request()->get_params() );
+		$this->assertEquals( $product_data, $api->get_request()->get_data() );
+
+		$this->assertInstanceOf( Response::class, $api->get_response() );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -105,22 +105,23 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::update_product_group() */
 	public function test_update_product_group() {
 
+		$product_group_id   = '1234';
 		$product_group_data = [ 'test' => 'test' ];
 
-		// test will fail if Request::set_data() is not called once
-		$request = $this->make( Request::class, [
-			'set_data' => \Codeception\Stub\Expected::once( $product_group_data ),
-		] );
-
-		$response = new Response( '' );
-
+		// test will fail if do_remote_request() is not called once
 		$api = $this->make( API::class, [
-			'get_new_request' => $request,
-			'perform_request' => $response,
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
 		] );
 
-		// assert that perform_request() was called
-		$this->assertSame( $response, $api->update_product_group( '1234', $product_group_data ) );
+		$api->update_product_group( $product_group_id, $product_group_data );
+
+		$this->assertInstanceOf( Request::class, $api->get_request() );
+		$this->assertEquals( 'POST', $api->get_request()->get_method() );
+		$this->assertEquals( "/{$product_group_id}", $api->get_request()->get_path() );
+		$this->assertEquals( [], $api->get_request()->get_params() );
+		$this->assertEquals( $product_group_data, $api->get_request()->get_data() );
+
+		$this->assertInstanceOf( Response::class, $api->get_response() );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -128,14 +128,22 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::delete_product_group() */
 	public function test_delete_product_group() {
 
-		$response = new Response( '' );
+		$product_group_id = '1234';
 
+		// test will fail if do_remote_request() is not called once
 		$api = $this->make( API::class, [
-			'perform_request' => $response,
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
 		] );
 
-		// assert that perform_request() was called
-		$this->assertSame( $response, $api->delete_product_group( '1234' ) );
+		$api->delete_product_group( $product_group_id );
+
+		$this->assertInstanceOf( Request::class, $api->get_request() );
+		$this->assertEquals( 'DELETE', $api->get_request()->get_method() );
+		$this->assertEquals( "/{$product_group_id}", $api->get_request()->get_path() );
+		$this->assertEquals( [], $api->get_request()->get_params() );
+		$this->assertEquals( [], $api->get_request()->get_data() );
+
+		$this->assertInstanceOf( Response::class, $api->get_response() );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -203,14 +203,22 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::delete_product_item() */
 	public function test_delete_product_item() {
 
-		$response = new Response( '' );
+		$product_item_id = '123456';
 
+		// test will fail if do_remote_request() is not called once
 		$api = $this->make( API::class, [
-			'perform_request' => $response,
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
 		] );
 
-		// assert that perform_request() was called
-		$this->assertSame( $response, $api->delete_product_item( '123456' ) );
+		$api->delete_product_item( $product_item_id );
+
+		$this->assertInstanceOf( Request::class, $api->get_request() );
+		$this->assertEquals( 'DELETE', $api->get_request()->get_method() );
+		$this->assertEquals( "/{$product_item_id}", $api->get_request()->get_path() );
+		$this->assertEquals( [], $api->get_request()->get_params() );
+		$this->assertEquals( [], $api->get_request()->get_data() );
+
+		$this->assertInstanceOf( Response::class, $api->get_response() );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -157,22 +157,23 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::create_product_item() */
 	public function test_create_product_item() {
 
-		$product_data = [ 'test' => 'test' ];
+		$product_group_id = '123456';
+		$product_data     = [ 'test' => 'test' ];
 
-		// test will fail if Request::set_data() is not called once
-		$request = $this->make( Request::class, [
-			'set_data' => \Codeception\Stub\Expected::once( $product_data ),
-		] );
-
-		$response = new Response( '' );
-
+		// test will fail if do_remote_request() is not called once
 		$api = $this->make( API::class, [
-			'get_new_request' => $request,
-			'perform_request' => $response,
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
 		] );
 
-		// assert that perform_request() was called
-		$this->assertSame( $response, $api->create_product_item( '123456', $product_data ) );
+		$api->create_product_item( $product_group_id, $product_data );
+
+		$this->assertInstanceOf( Request::class, $api->get_request() );
+		$this->assertEquals( 'POST', $api->get_request()->get_method() );
+		$this->assertEquals( "/{$product_group_id}/products", $api->get_request()->get_path() );
+		$this->assertEquals( [], $api->get_request()->get_params() );
+		$this->assertEquals( $product_data, $api->get_request()->get_data() );
+
+		$this->assertInstanceOf( Response::class, $api->get_response() );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -82,22 +82,23 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::create_product_group() */
 	public function test_create_product_group() {
 
+		$catalog_id         = '123456';
 		$product_group_data = [ 'test' => 'test' ];
 
-		// test will fail if Request::set_data() is not called once
-		$request = $this->make( Request::class, [
-			'set_data' => \Codeception\Stub\Expected::once( $product_group_data ),
-		] );
-
-		$response = new Response( '' );
-
+		// test will fail if do_remote_request() is not called once
 		$api = $this->make( API::class, [
-			'get_new_request' => $request,
-			'perform_request' => $response,
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
 		] );
 
-		// assert that perform_request() was called
-		$this->assertSame( $response, $api->create_product_group( '123456', $product_group_data ) );
+		$api->create_product_group( '123456', $product_group_data );
+
+		$this->assertInstanceOf( Request::class, $api->get_request() );
+		$this->assertEquals( 'POST', $api->get_request()->get_method() );
+		$this->assertEquals( "/{$catalog_id}/product_groups", $api->get_request()->get_path() );
+		$this->assertEquals( [], $api->get_request()->get_params() );
+		$this->assertEquals( $product_group_data, $api->get_request()->get_data() );
+
+		$this->assertInstanceOf( Response::class, $api->get_response() );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR implements the `API::send_item_updates()` method.

### Story: [CH 54715](https://app.clubhouse.io/skyverge/story/54715/add-an-api-method-to-send-item-updates)
### Release: #1277

## QA

- [x] `vendor codecept run tests/integration/APITest.php` pass