### PR TITLE
Update `API\Request` constructor to accept a path and a method only

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -8,6 +8,7 @@
  * @package FacebookCommerce
  */
 
+use SkyVerge\WooCommerce\Facebook\API;
 use SkyVerge\WooCommerce\Facebook\Lifecycle;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
@@ -217,9 +218,17 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 			if ( ! is_object( $this->api ) ) {
 
-				require_once __DIR__ . '/includes/API.php';
-				require_once __DIR__ . '/includes/API/Request.php';
-				require_once __DIR__ . '/includes/API/Response.php';
+				if ( ! class_exists( API::class ) ) {
+					require_once __DIR__ . '/includes/API.php';
+				}
+
+				if ( ! class_exists( API\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Request.php';
+				}
+
+				if ( ! class_exists( API\Response::class ) ) {
+					require_once __DIR__ . '/includes/API/Response.php';
+				}
 
 				$this->api = new SkyVerge\WooCommerce\Facebook\API( $this->get_connection_handler()->get_access_token() );
 			}

--- a/includes/API.php
+++ b/includes/API.php
@@ -101,7 +101,7 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function create_product_group( $catalog_id, $data ) {
 
-		$request = $this->get_new_request( [ $catalog_id, '/product_groups', 'POST' ] );
+		$request = $this->get_new_request( [ "/{$catalog_id}/product_groups", 'POST' ] );
 
 		$request->set_data( $data );
 
@@ -123,7 +123,7 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function update_product_group( $product_group_id, $data ) {
 
-		$request = $this->get_new_request( [ $product_group_id, '', 'POST' ] );
+		$request = $this->get_new_request( [ "/{$product_group_id}", 'POST' ] );
 
 		$request->set_data( $data );
 
@@ -144,7 +144,7 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function delete_product_group( $product_group_id ) {
 
-		$request = $this->get_new_request( [ $product_group_id, '', 'DELETE' ] );
+		$request = $this->get_new_request( [ "/{$product_group_id}", 'DELETE' ] );
 
 		$this->set_response_handler( Response::class );
 
@@ -184,7 +184,7 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function create_product_item( $product_group_id, $data ) {
 
-		$request = $this->get_new_request( [ $product_group_id, '/products', 'POST' ] );
+		$request = $this->get_new_request( [ "/{$product_group_id}/products", 'POST' ] );
 
 		$request->set_data( $data );
 
@@ -206,7 +206,7 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function update_product_item( $product_item_id, $data ) {
 
-		$request = $this->get_new_request( [ $product_item_id, '', 'POST' ] );
+		$request = $this->get_new_request( [ "/{$product_item_id}", 'POST' ] );
 
 		$request->set_data( $data );
 
@@ -227,7 +227,7 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function delete_product_item( $product_item_id ) {
 
-		$request = $this->get_new_request( [ $product_item_id, '', 'DELETE' ] );
+		$request = $this->get_new_request( [ "/{$product_item_id}", 'DELETE' ] );
 
 		$this->set_response_handler( Response::class );
 
@@ -287,9 +287,9 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	protected function get_new_request( $args = [] ) {
 
-		list( $object_id, $path, $method ) = $args;
+		list( $path, $method ) = $args;
 
-		return new Request( $object_id ?: null, $path ?: null, $method ?: null );
+		return new Request( $path ?: null, $method ?: null );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -101,7 +101,10 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function create_product_group( $catalog_id, $data ) {
 
-		$request = $this->get_new_request( [ "/{$catalog_id}/product_groups", 'POST' ] );
+		$request = $this->get_new_request( [
+			'path'   => "/{$catalog_id}/product_groups",
+			'method' => 'POST',
+		] );
 
 		$request->set_data( $data );
 
@@ -123,7 +126,10 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function update_product_group( $product_group_id, $data ) {
 
-		$request = $this->get_new_request( [ "/{$product_group_id}", 'POST' ] );
+		$request = $this->get_new_request( [
+			'path'   => "/{$product_group_id}",
+			'method' => 'POST',
+		] );
 
 		$request->set_data( $data );
 
@@ -144,7 +150,10 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function delete_product_group( $product_group_id ) {
 
-		$request = $this->get_new_request( [ "/{$product_group_id}", 'DELETE' ] );
+		$request = $this->get_new_request( [
+			'path'   => "/{$product_group_id}",
+			'method' => 'DELETE',
+		] );
 
 		$this->set_response_handler( Response::class );
 
@@ -184,7 +193,10 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function create_product_item( $product_group_id, $data ) {
 
-		$request = $this->get_new_request( [ "/{$product_group_id}/products", 'POST' ] );
+		$request = $this->get_new_request( [
+			'path'   => "/{$product_group_id}/products",
+			'method' => 'POST',
+		] );
 
 		$request->set_data( $data );
 
@@ -206,7 +218,10 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function update_product_item( $product_item_id, $data ) {
 
-		$request = $this->get_new_request( [ "/{$product_item_id}", 'POST' ] );
+		$request = $this->get_new_request( [
+			'path'   => "/{$product_item_id}",
+			'method' => 'POST',
+		] );
 
 		$request->set_data( $data );
 
@@ -227,7 +242,10 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function delete_product_item( $product_item_id ) {
 
-		$request = $this->get_new_request( [ "/{$product_item_id}", 'DELETE' ] );
+		$request = $this->get_new_request( [
+			'path'   => "/{$product_item_id}",
+			'method' => 'DELETE',
+		] );
 
 		$this->set_response_handler( Response::class );
 
@@ -282,14 +300,17 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param array $args optional request arguments
+	 * @param array $args {
+	 *     Optional. An array of request arguments.
+	 *
+	 *     @type string $path request path
+	 *     @type string $method request method
+	 * }
 	 * @return Request
 	 */
 	protected function get_new_request( $args = [] ) {
 
-		list( $path, $method ) = $args;
-
-		return new Request( $path ?: null, $method ?: null );
+		return new Request( $args['path'] ?: '/', $args['method'] ?: 'GET' );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -310,7 +310,14 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	protected function get_new_request( $args = [] ) {
 
-		return new Request( $args['path'] ?: '/', $args['method'] ?: 'GET' );
+		$defaults = [
+			'path'   => '/',
+			'method' => 'GET',
+		];
+
+		$args = wp_parse_args( $args, $defaults );
+
+		return new Request( $args['path'], $args['method'] );
 	}
 
 

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -45,9 +45,7 @@ class Request extends API\Request {
 	 */
 	public function __construct( $catalog_id, $retailer_id ) {
 
-		parent::__construct( null, null, 'GET' );
-
-		$this->path = "catalog:{$catalog_id}:" . base64_encode( $retailer_id );
+		parent::__construct( "catalog:{$catalog_id}:" . base64_encode( $retailer_id ), 'GET' );
 	}
 
 

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -51,7 +51,7 @@ class Request extends API\Request  {
 	 */
 	public function __construct( $catalog_id ) {
 
-		parent::__construct( $catalog_id, '/batch', 'POST' );
+		parent::__construct( "/{$catalog_id}/batch", 'POST' );
 	}
 
 

--- a/includes/API/Pages/Read/Request.php
+++ b/includes/API/Pages/Read/Request.php
@@ -23,6 +23,19 @@ class Request extends API\Request  {
 
 
 	/**
+	 * API request constructor.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $page_id page ID
+	 */
+	public function __construct( $page_id ) {
+
+		parent::__construct( $page_id, 'GET' );
+	}
+
+
+	/**
 	 * Gets the request parameters.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -27,14 +27,13 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param string $object_id object ID
 	 * @param string $path endpoint route
 	 * @param string $method HTTP method
 	 */
-	public function __construct( $object_id, $path, $method ) {
+	public function __construct( $path, $method ) {
 
 		$this->method = $method;
-		$this->path   = $path ? sprintf( '/%s/%s', $object_id, trim( $path, '/' ) ) : "/{$object_id}";
+		$this->path   = $path;
 	}
 
 

--- a/tests/integration/AJAX_Test.php
+++ b/tests/integration/AJAX_Test.php
@@ -39,7 +39,9 @@ class AJAX_Test extends \Codeception\TestCase\WPTestCase {
 	 */
 	protected function _before() {
 
-		require_once 'includes/AJAX.php';
+		if ( ! class_exists( AJAX::class ) ) {
+			require_once 'includes/AJAX.php';
+		}
 
 		$this->integration = facebook_for_woocommerce()->get_integration();
 

--- a/tests/integration/API/Catalog/Product_Item/Find/RequestTest.php
+++ b/tests/integration/API/Catalog/Product_Item/Find/RequestTest.php
@@ -19,8 +19,13 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		require_once 'includes/API/Request.php';
-		require_once 'includes/API/Catalog/Product_Item/Find/Request.php';
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Request::class ) ) {
+			require_once 'includes/API/Request.php';
+		}
+
+		if ( ! class_exists( Request::class ) ) {
+			require_once 'includes/API/Catalog/Product_Item/Find/Request.php';
+		}
 	}
 
 

--- a/tests/integration/API/Catalog/Product_Item/ResponseTest.php
+++ b/tests/integration/API/Catalog/Product_Item/ResponseTest.php
@@ -18,7 +18,9 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		require_once 'includes/API/Catalog/Product_Item/Response.php';
+		if ( ! class_exists( Response::class ) ) {
+			require_once 'includes/API/Catalog/Product_Item/Response.php';
+		}
 	}
 
 

--- a/tests/integration/API/Catalog/Send_Item_Updates/RequestTest.php
+++ b/tests/integration/API/Catalog/Send_Item_Updates/RequestTest.php
@@ -19,8 +19,13 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		require_once 'includes/API/Request.php';
-		require_once 'includes/API/Catalog/Send_Item_Updates/Request.php';
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Request::class ) ) {
+			require_once 'includes/API/Request.php';
+		}
+
+		if ( ! class_exists( Request::class ) ) {
+			require_once 'includes/API/Catalog/Send_Item_Updates/Request.php';
+		}
 	}
 
 

--- a/tests/integration/API/Pages/Read/RequestTest.php
+++ b/tests/integration/API/Pages/Read/RequestTest.php
@@ -18,8 +18,13 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		require_once 'includes/API/Request.php';
-		require_once 'includes/API/Pages/Read/Request.php';
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Request::class ) ) {
+			require_once 'includes/API/Request.php';
+		}
+
+		if ( ! class_exists( Request::class ) ) {
+			require_once 'includes/API/Pages/Read/Request.php';
+		}
 	}
 
 

--- a/tests/integration/API/Pages/Read/RequestTest.php
+++ b/tests/integration/API/Pages/Read/RequestTest.php
@@ -34,7 +34,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Request::__construct() */
 	public function test_constructor() {
 
-		$request = new Request( '1234', null, 'GET' );
+		$request = new Request( '/1234', 'GET' );
 
 		$this->assertEquals( '/1234', $request->get_path() );
 		$this->assertEquals( 'GET', $request->get_method() );
@@ -44,7 +44,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Request::get_params() */
 	public function test_get_params() {
 
-		$request = new Request( '1234', null, null );
+		$request = new Request( '/1234', null );
 
 		$this->assertEquals( [ 'fields' => 'name,link' ], $request->get_params() );
 	}

--- a/tests/integration/API/Pages/Read/ResponseTest.php
+++ b/tests/integration/API/Pages/Read/ResponseTest.php
@@ -18,8 +18,13 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		require_once 'includes/API/Response.php';
-		require_once 'includes/API/Pages/Read/Response.php';
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Response::class ) ) {
+			require_once 'includes/API/Response.php';
+		}
+
+		if ( ! class_exists( Response::class ) ) {
+			require_once 'includes/API/Pages/Read/Response.php';
+		}
 	}
 
 

--- a/tests/integration/API/RequestTest.php
+++ b/tests/integration/API/RequestTest.php
@@ -18,7 +18,9 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		require_once 'includes/API/Request.php';
+		if ( ! class_exists( Request::class ) ) {
+			require_once 'includes/API/Request.php';
+		}
 	}
 
 

--- a/tests/integration/API/RequestTest.php
+++ b/tests/integration/API/RequestTest.php
@@ -30,18 +30,16 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @see Request::__construct()
 	 *
-	 * @param string $object_id object ID
 	 * @param string $path endpoint route
 	 * @param string $method HTTP method
-	 * @param string $expected_path expected request path
 	 *
 	 * @dataProvider provider_constructor
 	 */
-	public function test_constructor( $object_id, $path, $method, $expected_path ) {
+	public function test_constructor( $path, $method ) {
 
-		$request = new Request( $object_id, $path, $method );
+		$request = new Request( $path, $method );
 
-		$this->assertEquals( $expected_path, $request->get_path() );
+		$this->assertEquals( $path, $request->get_path() );
 		$this->assertEquals( $method, $request->get_method() );
 	}
 
@@ -49,12 +47,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	public function provider_constructor( $requests ) {
 
 		return [
-			[ 'me', '', 'GET', '/me' ],
-			[ '1234', '/products', 'GET', '/1234/products' ],
+			[ '/me', 'GET' ],
+			[ '/1234/products', 'GET' ],
 
-			[ '1234', 'batch', 'POST', '/1234/batch' ],
-			[ '1234', '/batch/', 'POST', '/1234/batch' ],
-			[ '1234', '', 'POST', '/1234' ],
+			[ '/1234/batch', 'POST' ],
+			[ '/1234', 'POST' ],
 		];
 	}
 

--- a/tests/integration/API/ResponseTest.php
+++ b/tests/integration/API/ResponseTest.php
@@ -18,7 +18,9 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		require_once 'includes/API/Response.php';
+		if ( ! class_exists( Response::class ) ) {
+			require_once 'includes/API/Response.php';
+		}
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -272,4 +272,33 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * @see API::get_new_request()
+	 *
+	 * @param array $args
+	 * @param string $expected_path
+	 * @param string $expected_method
+	 *
+	 * @dataProvider provider_get_new_request
+	 */
+	public function test_get_new_request( $args, $expected_path, $expected_method ) {
+
+		// TODO
+	}
+
+
+	/** @see test_get_new_request() */
+	public function provider_get_new_request() {
+
+		return [
+			[ [ 'path' => '/me', 'method' => 'GET' ], '/me', 'GET' ],
+			[ [ 'path' => '/1234/products', 'method' => 'GET' ], '/1234/products', 'GET' ],
+			[ [ 'path' => '/1234/batch', 'method' => 'POST' ], '/1234/batch', 'POST' ],
+			[ [ 'path' => '/1234/batch' ], '/1234/batch', 'GET' ],
+			[ [ 'method' => 'DELETE' ], '/', 'DELETE' ],
+			[ [], '/', 'GET' ],
+		];
+	}
+
+
 }

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -278,12 +278,23 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	 * @param array $args
 	 * @param string $expected_path
 	 * @param string $expected_method
+	 * @throws ReflectionException
 	 *
 	 * @dataProvider provider_get_new_request
 	 */
 	public function test_get_new_request( $args, $expected_path, $expected_method ) {
 
-		// TODO
+		$api = new API( 'fake-token' );
+
+		$reflection = new \ReflectionClass( $api );
+		$method     = $reflection->getMethod( 'get_new_request' );
+
+		$method->setAccessible( true );
+
+		$request = $method->invokeArgs( $api, [ $args ] );
+
+		$this->assertEquals( $expected_path, $request->get_path() );
+		$this->assertEquals( $expected_method, $request->get_method() );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -26,8 +26,13 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		require_once 'includes/API.php';
-		require_once 'includes/API/Request.php';
+		if ( ! class_exists( API::class ) ) {
+			require_once 'includes/API.php';
+		}
+
+		if ( ! class_exists( Request::class ) ) {
+			require_once 'includes/API/Request.php';
+		}
 	}
 
 
@@ -45,7 +50,9 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::send_item_updates() */
 	public function test_send_item_updates() {
 
-		require_once 'includes/API/Catalog/Send_Item_Updates/Request.php';
+		if ( ! class_exists( API\Catalog\Send_Item_Updates\Request::class ) ) {
+			require_once 'includes/API/Catalog/Send_Item_Updates/Request.php';
+		}
 
 		$catalog_id   = '123456';
 		$requests     = [
@@ -150,8 +157,13 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::find_product_item() */
 	public function test_find_product_item() {
 
-		require_once 'includes/API/Catalog/Product_Item/Find/Request.php';
-		require_once 'includes/API/Catalog/Product_Item/Response.php';
+		if ( ! class_exists( API\Catalog\Product_Item\Find\Request::class ) ) {
+			require_once 'includes/API/Catalog/Product_Item/Find/Request.php';
+		}
+
+		if ( ! class_exists( API\Catalog\Product_Item\Response::class ) ) {
+			require_once 'includes/API/Catalog/Product_Item/Response.php';
+		}
 
 		$catalog_id  = '123456';
 		$retailer_id = '456';

--- a/tests/integration/Admin_Test.php
+++ b/tests/integration/Admin_Test.php
@@ -1,6 +1,7 @@
 <?php
 
 use SkyVerge\WooCommerce\Facebook;
+use SkyVerge\WooCommerce\Facebook\Admin;
 
 /**
  * Tests the Admin class.
@@ -11,7 +12,7 @@ class Admin_Test extends \Codeception\TestCase\WPTestCase {
 	/** @var \IntegrationTester */
 	protected $tester;
 
-	/** @var \SkyVerge\WooCommerce\Facebook\Admin */
+	/** @var Admin */
 	protected $admin;
 
 	/** @var \WC_Facebookcommerce_Integration */
@@ -23,7 +24,9 @@ class Admin_Test extends \Codeception\TestCase\WPTestCase {
 	 */
 	protected function _before() {
 
-		require_once 'includes/Admin.php';
+		if ( ! class_exists( Admin::class ) ) {
+			require_once 'includes/Admin.php';
+		}
 
 		$this->integration = facebook_for_woocommerce()->get_integration();
 
@@ -31,7 +34,7 @@ class Admin_Test extends \Codeception\TestCase\WPTestCase {
 		facebook_for_woocommerce()->get_connection_handler()->update_access_token( '1234' );
 		$this->integration->update_product_catalog_id( '1234' );
 
-		$this->admin = new \SkyVerge\WooCommerce\Facebook\Admin();
+		$this->admin = new Admin();
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -16,7 +16,9 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		require_once 'includes/Handlers/Connection.php';
+		if ( ! class_exists( Connection::class ) ) {
+			require_once 'includes/Handlers/Connection.php';
+		}
 	}
 
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -45,7 +45,9 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
     public function test_delete_products( $product_ids ) {
 
         // TODO: remove when this file is included in the main plugin class {WV 2020-05-19}
-        require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/Products/Sync.php';
+	    if ( ! class_exists( Sync::class ) ) {
+            require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/Products/Sync.php';
+	    }
 
         $sync = new Sync();
 

--- a/tests/integration/WC_Facebookcommerce_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Test.php
@@ -15,6 +15,16 @@ class WC_Facebookcommerce_Test extends \Codeception\TestCase\WPTestCase {
 	protected $tester;
 
 
+	public function _before() {
+
+		parent::_before();
+
+		if ( ! class_exists( API::class ) ) {
+			require_once 'includes/API.php';
+		}
+	}
+
+
 	/** Test methods **************************************************************************************************/
 
 


### PR DESCRIPTION
# Summary

This PR updates the request constructor to expect only a path and a method, as a keyed array.

### Story: [CH 55036](https://app.clubhouse.io/skyverge/story/55036/update-api-request-constructor-to-accept-a-path-and-a-method-only)
### Release: #1277

## Details

All usages of the constructor were updated.

## QA

- [ ] `vendor codecept run integration` pass