### PR TITLE
Add an API method to retrieve page info

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -100,8 +100,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once $this->get_framework_path() . '/utilities/class-sv-wp-async-request.php';
 				require_once $this->get_framework_path() . '/utilities/class-sv-wp-background-job-handler.php';
 
-				require_once __DIR__ . '/includes/API/Response.php';
-				require_once __DIR__ . '/includes/API/Catalog/Send_Item_Updates/Response.php';
 				require_once __DIR__ . '/includes/Handlers/Connection.php';
 				require_once __DIR__ . '/includes/Integrations/Integrations.php';
 				require_once __DIR__ . '/includes/Products.php';
@@ -233,6 +231,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 				if ( ! class_exists( API\Response::class ) ) {
 					require_once __DIR__ . '/includes/API/Response.php';
+				}
+
+				if ( ! class_exists( API\Catalog\Send_Item_Updates\Response::class ) ) {
+					require_once __DIR__ . '/includes/API/Catalog/Send_Item_Updates/Response.php';
 				}
 
 				if ( ! class_exists( API\Pages\Read\Request::class ) ) {

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -235,6 +235,14 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Response.php';
 				}
 
+				if ( ! class_exists( API\Pages\Read\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Pages/Read/Request.php';
+				}
+
+				if ( ! class_exists( API\Pages\Read\Response::class ) ) {
+					require_once __DIR__ . '/includes/API/Pages/Read/Response.php';
+				}
+
 				$this->api = new SkyVerge\WooCommerce\Facebook\API( $this->get_connection_handler()->get_access_token() );
 			}
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -59,7 +59,11 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function get_page( $page_id ) {
 
-		// TODO: Implement get_page() method.
+		$request = new API\Pages\Read\Request( $page_id );
+
+		$this->set_response_handler( API\Pages\Read\Response::class );
+
+		return $this->perform_request( $request );
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -55,7 +55,7 @@ class API extends Framework\SV_WC_API_Base {
 	 * @since 2.0.0-dev.1
 	 *
 	 * @param $page_id page ID
-	 * @return
+	 * @return API\Pages\Read\Response
 	 */
 	public function get_page( $page_id ) {
 

--- a/includes/API/Pages/Read/Request.php
+++ b/includes/API/Pages/Read/Request.php
@@ -31,7 +31,7 @@ class Request extends API\Request  {
 	 */
 	public function __construct( $page_id ) {
 
-		parent::__construct( $page_id, 'GET' );
+		parent::__construct( "/{$page_id}", 'GET' );
 	}
 
 

--- a/tests/integration/API/Catalog/Send_Item_Updates/ResponseTest.php
+++ b/tests/integration/API/Catalog/Send_Item_Updates/ResponseTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use Codeception\Stub;
-use SkyVerge\WooCommerce\Facebook\API\Catalog\Send_Item_Updates\Response;
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Catalog\Send_Item_Updates;
+
+use SkyVerge\WooCommerce\Facebook\API;
 
 /**
  * Tests the API\Catalog\Send_Item_Updates\Response class.
@@ -18,9 +19,17 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 
 	public function test_get_handles() {
 
+		if ( ! class_exists( API\Response::class ) ) {
+			require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/API/Response.php';
+		}
+
+		if ( ! class_exists( API\Catalog\Send_Item_Updates\Response::class ) ) {
+			require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/API/Catalog/Send_Item_Updates/Response.php';
+		}
+
 		$handles  = [ '1', '2', '3' ];
 		$raw_json = json_encode( [ 'handles' => $handles ] );
-		$response = new Response( $raw_json );
+		$response = new API\Catalog\Send_Item_Updates\Response( $raw_json );
 
 		$this->assertEquals( $handles, $response->get_handles() );
 	}

--- a/tests/integration/API/Pages/Read/RequestTest.php
+++ b/tests/integration/API/Pages/Read/RequestTest.php
@@ -34,7 +34,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Request::__construct() */
 	public function test_constructor() {
 
-		$request = new Request( '/1234', 'GET' );
+		$request = new Request( '1234' );
 
 		$this->assertEquals( '/1234', $request->get_path() );
 		$this->assertEquals( 'GET', $request->get_method() );
@@ -44,7 +44,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Request::get_params() */
 	public function test_get_params() {
 
-		$request = new Request( '/1234', null );
+		$request = new Request( '1234' );
 
 		$this->assertEquals( [ 'fields' => 'name,link' ], $request->get_params() );
 	}

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -26,6 +26,12 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+
 		if ( ! class_exists( API::class ) ) {
 			require_once 'includes/API.php';
 		}
@@ -45,6 +51,28 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 
 
 	/** Test methods **************************************************************************************************/
+
+
+	/** @see API::get_page() */
+	public function test_get_page() {
+
+		$page_id   = '123456';
+
+		// test will fail if do_remote_request() is not called once
+		$api = $this->make( API::class, [
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
+		] );
+
+		$api->get_page( $page_id );
+
+		$this->assertInstanceOf( API\Pages\Read\Request::class, $api->get_request() );
+		$this->assertEquals( 'GET', $api->get_request()->get_method() );
+		$this->assertEquals( "/{$page_id}", $api->get_request()->get_path() );
+		$this->assertEquals( [ 'fields' => 'name,link' ], $api->get_request()->get_params() );
+		$this->assertEquals( [], $api->get_request()->get_data() );
+
+		$this->assertInstanceOf( API\Pages\Read\Response::class, $api->get_response() );
+	}
 
 
 	/** @see API::send_item_updates() */


### PR DESCRIPTION

# Summary

This PR implements the `API::get_oage()` method.

### Story: [CH 54785](https://app.clubhouse.io/skyverge/story/54785)
### Release: #1277

## QA

- [x] `vendor codecept run integration tests/integration/APITest.php` pass