### PR TITLE
Get page name and URL in a single request

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4106,13 +4106,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function get_page_url() {
 
-		if ( $this->is_configured() ) {
-			$page_url = $this->fbgraph->get_page_url( $this->get_facebook_page_id() );
-		} else {
-			$page_url = '';
-		}
+		$page = $this->get_page();
 
-		return is_string( $page_url ) ? $page_url : '';
+		return isset( $page['url'] ) ? $page['url'] : '';
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -123,6 +123,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var bool|null whether the feed has been migrated from FBE 1 to FBE 1.5 */
 	private $feed_migrated;
 
+	/** @var array the page name and url */
+	private $page;
+
 
 	/** Legacy properties *********************************************************************************************/
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4091,13 +4091,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	public function get_page_name() {
 
-		if ( $this->is_configured() ) {
-			$page_name = $this->fbgraph->get_page_name( $this->get_facebook_page_id() );
-		} else {
-			$page_name = '';
-		}
+		$page = $this->get_page();
 
-		return is_string( $page_name ) ? $page_name : '';
+		return isset( $page['name'] ) ? $page['name'] : '';
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4072,6 +4072,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 			} catch ( Framework\SV_WC_API_Exception $e ) {
 
+				// we intentionally set $this->page to an empty array if an error occurs to avoid additional API requests
+				// it's unlikely that we will get a different result if the exception was caused by an expired token, incorrect page ID, or rate limiting error
 				$this->page = [];
 
 				$message = sprintf( __( 'There was an error trying to retrieve information about the Facebook page: %s' ), $e->getMessage() );

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4051,6 +4051,40 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 
 	/**
+	 * Gets the array that holds the name and url of the configured Facebook page.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return array
+	 */
+	private function get_page() {
+
+		if ( ! is_array( $this->page ) && $this->is_configured() ) {
+
+			try {
+
+				$response = facebook_for_woocommerce()->get_api()->get_page( $this->get_facebook_page_id() );
+
+				$this->page = [
+					'name' => $response->get_name(),
+					'url'  => $response->get_url(),
+				];
+
+			} catch ( Framework\SV_WC_API_Exception $e ) {
+
+				$this->page = [];
+
+				$message = sprintf( __( 'There was an error trying to retrieve information about the Facebook page: %s' ), $e->getMessage() );
+
+				facebook_for_woocommerce()->log( $message );
+			}
+		}
+
+		return is_array( $this->page ) ? $this->page : [];
+	}
+
+
+	/**
 	 * Gets the name of the configured Facebook page.
 	 *
 	 * @return string

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -687,13 +687,13 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	 *
 	 * @dataProvider provider_get_page_url
 	 */
-	public function test_get_page_url( $page, $page_name ) {
+	public function test_get_page_url( $page, $page_url ) {
 
 		$property = new ReflectionProperty( \WC_Facebookcommerce_Integration::class, 'page' );
 		$property->setAccessible( true );
 		$property->setValue( $this->integration, $page );
 
-		$this->assertEquals( $page_name, $this->integration->get_page_url() );
+		$this->assertEquals( $page_url, $this->integration->get_page_url() );
 	}
 
 

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -635,6 +635,22 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	}
 
 
+	/** @see \WC_Facebookcommerce_Integration::get_page() */
+	public function test_get_page_if_plugin_is_not_configured() {
+
+		// irrelevant because the API wont be used
+		$api = null;
+
+		// remove the access token to prevent the plugin from trying to use the API to retrieve page information
+		$access_token = null;
+
+		// it should return an empty array if there is no page information available
+		$expected_result = [];
+
+		$this->check_get_page( $api, $access_token, $expected_result );
+	}
+
+
 	/**
 	 * @see \WC_Facebookcommerce_Integration::is_configured()
 	 *

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -1,6 +1,7 @@
 <?php
 
 use SkyVerge\WooCommerce\Facebook\API;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 /**
  * Tests the integration class.
@@ -613,6 +614,24 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 		$method->setAccessible( true );
 
 		$this->assertEquals( $expected_result, $method->invoke( $this->integration ) );
+	}
+
+
+	/** @see \WC_Facebookcommerce_Integration::get_page() */
+	public function test_get_page_with_exception() {
+
+		if ( ! class_exists( API::class ) ) {
+			require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/API.php';
+		}
+
+		$api = $this->make( API::class, [ 'get_page' => static function() {
+			throw new Framework\SV_WC_API_Exception();
+		} ] );
+
+		// it should return an empty array if no page information can't be retrieved
+		$expected_result = [];
+
+		$this->check_get_page( $api, 'access_token', $expected_result );
 	}
 
 

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -652,6 +652,34 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 
 
 	/**
+	 * @see \WC_Facebookcommerce_Integration::get_page_name()
+	 *
+	 * @param array $page stored page information
+	 * @param string $page_name expected page name
+	 *
+	 * @dataProvider provider_get_page_name
+	 */
+	public function test_get_page_name( $page, $page_name ) {
+
+		$property = new ReflectionProperty( \WC_Facebookcommerce_Integration::class, 'page' );
+		$property->setAccessible( true );
+		$property->setValue( $this->integration, $page );
+
+		$this->assertEquals( $page_name, $this->integration->get_page_name() );
+	}
+
+
+	/** @see test_get_page_name() */
+	public function provider_get_page_name() {
+
+		return [
+			[ [ 'name' => 'Test Page', 'url' => 'https://example.org' ], 'Test Page' ],
+			[ [], '' ],
+		];
+	}
+
+
+	/**
 	 * @see \WC_Facebookcommerce_Integration::is_configured()
 	 *
 	 * @param string $access_token Facebook access token

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -680,6 +680,34 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 
 
 	/**
+	 * @see \WC_Facebookcommerce_Integration::get_page_url()
+	 *
+	 * @param array $page stored page information
+	 * @param string $page_url expected page URL
+	 *
+	 * @dataProvider provider_get_page_url
+	 */
+	public function test_get_page_url( $page, $page_name ) {
+
+		$property = new ReflectionProperty( \WC_Facebookcommerce_Integration::class, 'page' );
+		$property->setAccessible( true );
+		$property->setValue( $this->integration, $page );
+
+		$this->assertEquals( $page_name, $this->integration->get_page_url() );
+	}
+
+
+	/** @see test_get_page_url() */
+	public function provider_get_page_url() {
+
+		return [
+			[ [ 'name' => 'Test Page', 'url' => 'https://example.org' ], 'https://example.org' ],
+			[ [], '' ],
+		];
+	}
+
+
+	/**
 	 * @see \WC_Facebookcommerce_Integration::is_configured()
 	 *
 	 * @param string $access_token Facebook access token


### PR DESCRIPTION
# Summary

This PR updates the `WC_Facebookcommerce_Integration::get_page_name()` and `::get_page_url()` to retrieve the name and the URL of the configured page with a single API request.

### Story: [CH 54793](https://app.clubhouse.io/skyverge/story/54793)
### Release: #1277

## QA

- [x] `vendor codecept run integration` pass