### PR TITLE
Refresh connect data daily

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -260,6 +260,14 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/FBE/Installation/Request.php';
 				}
 
+				if ( ! class_exists( API\FBE\Installation\Read\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/FBE/Installation/Read/Request.php';
+				}
+
+				if ( ! class_exists( API\FBE\Installation\Read\Response::class ) ) {
+					require_once __DIR__ . '/includes/API/FBE/Installation/Read/Response.php';
+				}
+
 				if ( ! class_exists( API\Exceptions\Request_Limit_Reached::class ) ) {
 					require_once __DIR__ . '/includes/API/Exceptions/Request_Limit_Reached.php';
 				}

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -256,6 +256,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Pages/Read/Response.php';
 				}
 
+				if ( ! class_exists( API\FBE\Installation\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/FBE/Installation/Request.php';
+				}
+
 				if ( ! class_exists( API\Exceptions\Request_Limit_Reached::class ) ) {
 					require_once __DIR__ . '/includes/API/Exceptions/Request_Limit_Reached.php';
 				}

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -136,7 +136,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					$this->background_disable_virtual_products_sync = new Background_Disable_Virtual_Products_Sync();
 				}
 
-				$this->connection_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\Connection();
+				$this->connection_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\Connection( $this );
 			}
 		}
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -92,6 +92,25 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Gets the FBE installation IDs.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $external_business_id external business ID
+	 * @return API\FBE\Installation\Read\Response
+	 * @throws Framework\SV_WC_API_Exception
+	 */
+	public function get_installation_ids( $external_business_id ) {
+
+		$request = new API\FBE\Installation\Read\Request( $external_business_id );
+
+		$this->set_response_handler( API\FBE\Installation\Read\Response::class );
+
+		return $this->perform_request( $request );
+	}
+
+
+	/**
 	 * Gets a Page object from Facebook.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/API/FBE/Installation/Read/Request.php
+++ b/includes/API/FBE/Installation/Read/Request.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\FBE\Installation\Read;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API\FBE\Installation;
+
+/**
+ * FBE installation API read request object.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Request extends Installation\Request  {
+
+
+	/**
+	 * API request constructor.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $external_business_id external business_id
+	 */
+	public function __construct( $external_business_id ) {
+
+		parent::__construct( 'fbe_installs', 'GET' );
+
+		$this->params = [
+			'fbe_external_business_id' => $external_business_id,
+		];
+	}
+
+
+}

--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\FBE\Installation\Read;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * FBE Installation API read response object.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Response extends API\Response  {
+
+
+	/**
+	 * Gets the pixel ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_pixel_id() {
+
+		return ! empty( $this->get_data()->pixel_id ) ? $this->get_data()->pixel_id : '';
+	}
+
+
+	/**
+	 * Gets the business manager ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_business_manager_id() {
+
+		return ! empty( $this->get_data()->business_manager_id ) ? $this->get_data()->business_manager_id : '';
+	}
+
+
+	/**
+	 * Gets the catalog ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_catalog_id() {
+
+		return ! empty( $this->get_data()->catalog_id ) ? $this->get_data()->catalog_id : '';
+	}
+
+
+	/**
+	 * Gets the page ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_page_id() {
+
+		$page_id = current( $this->get_profiles() );
+
+		return $page_id ?: '';
+	}
+
+
+	/**
+	 * Gets the profiles.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string[]
+	 */
+	public function get_profiles() {
+
+		return ! empty( $this->get_data()->profiles ) ? $this->get_data()->profiles : [];
+	}
+
+
+	/**
+	 * Gets the response data.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return \stdClass
+	 */
+	public function get_data() {
+
+		$data = ! empty( $this->response_data->data ) && is_array( $this->response_data->data ) ? $this->response_data->data : [];
+
+		return is_object( $data[0] ) ? $data[0] : new \stdClass();
+	}
+
+
+}

--- a/includes/API/FBE/Installation/Request.php
+++ b/includes/API/FBE/Installation/Request.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\FBE\Installation;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * FBE API request object.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Request extends API\Request  {
+
+
+	/**
+	 * API request constructor.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $path desired path
+	 * @param string $method request method
+	 */
+	public function __construct( $path, $method ) {
+
+		parent::__construct( "/fbe_business/{$path}", $method );
+	}
+
+
+}

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -47,13 +47,18 @@ class Connection {
 	/** @var string|null the generated external merchant settings ID */
 	private $external_business_id;
 
+	/** @var \WC_Facebookcommerce */
+	private $plugin;
+
 
 	/**
 	 * Constructs a new Connection.
 	 *
 	 * @since 2.0.0-dev.1
 	 */
-	public function __construct() {
+	public function __construct( \WC_Facebookcommerce $plugin ) {
+
+		$this->plugin = $plugin;
 
 		add_action( 'woocommerce_api_' . self::ACTION_CONNECT, [ $this, 'handle_connect' ] );
 	}
@@ -444,6 +449,19 @@ class Connection {
 	public function is_connected() {
 
 		return (bool) $this->get_access_token();
+	}
+
+
+	/**
+	 * Gets the plugin instance.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return \WC_Facebookcommerce
+	 */
+	public function get_plugin() {
+
+		return $this->plugin;
 	}
 
 

--- a/tests/integration/API/FBE/Installation/Read/RequestTest.php
+++ b/tests/integration/API/FBE/Installation/Read/RequestTest.php
@@ -5,7 +5,7 @@ namespace SkyVerge\WooCommerce\Facebook\Tests\API\FBE\Installation\Read;
 use SkyVerge\WooCommerce\Facebook\API\FBE\Installation\Read\Request;
 
 /**
- * Tests the API\Pages\Read\Request class.
+ * Tests the API\FBE\Installation\Read\Request class.
  */
 class RequestTest extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/integration/API/FBE/Installation/Read/RequestTest.php
+++ b/tests/integration/API/FBE/Installation/Read/RequestTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\FBE\Installation\Read;
+
+use SkyVerge\WooCommerce\Facebook\API\FBE\Installation\Read\Request;
+
+/**
+ * Tests the API\Pages\Read\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Request::class ) ) {
+			require_once 'includes/API/Request.php';
+		}
+
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\FBE\Installation\Request::class ) ) {
+			require_once 'includes/API/FBE/Installation/Request.php';
+		}
+
+		if ( ! class_exists( Request::class ) ) {
+			require_once 'includes/API/FBE/Installation/Read/Request.php';
+		}
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Request::__construct() */
+	public function test_constructor() {
+
+		$request = new Request( '1234' );
+
+		$this->assertStringContainsString( '/fbe_installs', $request->get_path() );
+		$this->assertEquals( 'GET', $request->get_method() );
+		$this->assertEquals( [ 'fbe_external_business_id' => '1234', ], $request->get_params() );
+	}
+
+
+}

--- a/tests/integration/API/FBE/Installation/Read/ResponseTest.php
+++ b/tests/integration/API/FBE/Installation/Read/ResponseTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\FBE\Installation\Read;
+
+use SkyVerge\WooCommerce\Facebook\API\FBE\Installation\Read\Response;
+
+/**
+ * Tests the API\Pages\Read\Response class.
+ */
+class ResponseTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+	protected $data = '{"data":[{"business_manager_id":"1234","pixel_id":"5678","profiles":["123"],"catalog_id":"456"}]}';
+
+
+	public function _before() {
+
+		parent::_before();
+
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Response::class ) ) {
+			require_once 'includes/API/Response.php';
+		}
+
+		if ( ! class_exists( Response::class ) ) {
+			require_once 'includes/API/FBE/Installation/Read/Response.php';
+		}
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Response::get_pixel_id() */
+	public function test_get_pixel_id() {
+
+		$response = new Response( $this->data );
+
+		$this->assertEquals( '5678', $response->get_pixel_id() );
+	}
+
+
+	/** @see Response::get_business_manager_id() */
+	public function test_get_business_manager_id() {
+
+		$response = new Response( $this->data );
+
+		$this->assertEquals( '1234', $response->get_business_manager_id() );
+	}
+
+
+	/** @see Response::get_page_id() */
+	public function test_get_page_id() {
+
+		$response = new Response( $this->data );
+
+		$this->assertEquals( '123', $response->get_page_id() );
+	}
+
+
+	/** @see Response::get_catalog_id() */
+	public function test_get_catalog_id() {
+
+		$response = new Response( $this->data );
+
+		$this->assertEquals( '456', $response->get_catalog_id() );
+	}
+
+
+	/** @see Response::get_data() */
+	public function test_get_data() {
+
+		$response = new Response( $this->data );
+
+		$this->assertIsObject( $response->get_data() );
+	}
+
+
+}

--- a/tests/integration/API/FBE/Installation/Read/ResponseTest.php
+++ b/tests/integration/API/FBE/Installation/Read/ResponseTest.php
@@ -5,7 +5,7 @@ namespace SkyVerge\WooCommerce\Facebook\Tests\API\FBE\Installation\Read;
 use SkyVerge\WooCommerce\Facebook\API\FBE\Installation\Read\Response;
 
 /**
- * Tests the API\Pages\Read\Response class.
+ * Tests the API\FBE\Installation\Read\Response class.
  */
 class ResponseTest extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/integration/API/FBE/Installation/RequestTest.php
+++ b/tests/integration/API/FBE/Installation/RequestTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\FBE\Installation;
+
+use SkyVerge\WooCommerce\Facebook\API\FBE\Installation\Request;
+
+/**
+ * Tests the API\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Request::class ) ) {
+			require_once 'includes/API/Request.php';
+		}
+
+		if ( ! class_exists( Request::class ) ) {
+			require_once 'includes/API/FBE/Installation/Request.php';
+		}
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see Request::__construct()
+	 */
+	public function test_constructor() {
+
+		$path   = 'path';
+		$method = 'GET';
+
+		$request = new Request( $path, $method );
+
+		$this->assertEquals( "/fbe_business/{$path}", $request->get_path() );
+		$this->assertEquals( $method, $request->get_method() );
+	}
+
+
+}

--- a/tests/integration/API/FBE/Installation/RequestTest.php
+++ b/tests/integration/API/FBE/Installation/RequestTest.php
@@ -5,7 +5,7 @@ namespace SkyVerge\WooCommerce\Facebook\Tests\API\FBE\Installation;
 use SkyVerge\WooCommerce\Facebook\API\FBE\Installation\Request;
 
 /**
- * Tests the API\Request class.
+ * Tests the API\FBE\Installation\Request class.
  */
 class RequestTest extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -187,6 +187,28 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see API::get_installation_ids() */
+	public function test_get_installation_ids() {
+
+		$external_business_id = '123456';
+
+		// test will fail if do_remote_request() is not called once
+		$api = $this->make( API::class, [
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
+		] );
+
+		$api->get_installation_ids( $external_business_id );
+
+		$this->assertInstanceOf( API\FBE\Installation\Read\Request::class, $api->get_request() );
+		$this->assertEquals( 'GET', $api->get_request()->get_method() );
+		$this->assertEquals( '/fbe_business/fbe_installs', $api->get_request()->get_path() );
+		$this->assertEquals( [ 'fbe_external_business_id' => $external_business_id, ], $api->get_request()->get_params() );
+		$this->assertEquals( [], $api->get_request()->get_data() );
+
+		$this->assertInstanceOf( API\FBE\Installation\Read\Response::class, $api->get_response() );
+	}
+
+
 	/** @see API::send_item_updates() */
 	public function test_send_item_updates() {
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -401,7 +401,7 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	private function get_connection() {
 
-		return new Connection();
+		return new Connection( facebook_for_woocommerce() );
 	}
 
 


### PR DESCRIPTION
# Summary

Adds a routine to pull the latest business connection data daily.

### Story: [CH 55191](https://app.clubhouse.io/skyverge/story/55191)
### Release: #1277 

## Details

This is in the event that the FBE installation's config changes outside of the normal plugin flow, the site will keep up-to-date information

## UI Changes

N/A

## QA

- [x] Integration tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version