### PR TITLE
Add a notice for invalid connections

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -188,6 +188,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			if ( get_transient( 'wc_facebook_connection_invalid' ) && $this->get_connection_handler()->is_connected() ) {
 
 				$message = sprintf(
+					/* translators: Placeholders: %1$s - <strong> tag, %2$s - </strong> tag, %3$s - <a> tag, %4$s - </a> tag */
 					__( '%1$sHeads up!%2$s Your connection to Facebook is no longer valid. Please %3$sclick here%4$s to securely reconnect your account and continue syncing products.', 'facebook-for-woocommerce' ),
 					'<strong>', '</strong>',
 					'<a href="' . esc_url( $this->get_connection_handler()->get_connect_url() ) . '">', '</a>'

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -183,6 +183,20 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					'notice_class' => 'notice-info wc-facebook-migrate-notice',
 				] );
 			}
+
+			// if the connection is otherwise invalid, but there is an access token
+			if ( get_transient( 'wc_facebook_connection_invalid' ) && $this->get_connection_handler()->is_connected() ) {
+
+				$message = sprintf(
+					__( '%1$sHeads up!%2$s Your connection to Facebook is no longer valid. Please %3$sclick here%4$s to securely reconnect your account and continue syncing products.', 'facebook-for-woocommerce' ),
+					'<strong>', '</strong>',
+					'<a href="' . esc_url( $this->get_connection_handler()->get_connect_url() ) . '">', '</a>'
+				);
+
+				$this->get_admin_notice_handler()->add_admin_notice( $message, 'connection_invalid', [
+					'notice_class' => 'notice-error',
+				] );
+			}
 		}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -64,6 +64,7 @@ class API extends Framework\SV_WC_API_Base {
 
 		if ( $response && $response->has_api_error() ) {
 
+			$code    = $response->get_api_error_code();
 			$message = sprintf( '%s: %s', $response->get_api_error_type(), $response->get_api_error_message() );
 
 			/**
@@ -82,8 +83,8 @@ class API extends Framework\SV_WC_API_Base {
 			 * @link https://developers.facebook.com/docs/graph-api/using-graph-api/error-handling#rate-limiting-error-codes
 			 * @link https://developers.facebook.com/docs/marketing-api/reference/product-catalog/batch/#validation-rules
 			 */
-			if ( in_array( $response->get_api_error_code(), [ 4, 17, 32, 613, 80004 ], true ) ) {
-				throw new API\Exceptions\Request_Limit_Reached( $message, $response->get_api_error_code() );
+			if ( in_array( $code, [ 4, 17, 32, 613, 80004 ], true ) ) {
+				throw new API\Exceptions\Request_Limit_Reached( $message, $code );
 			}
 
 			/**
@@ -91,14 +92,14 @@ class API extends Framework\SV_WC_API_Base {
 			 *
 			 * @link https://developers.facebook.com/docs/graph-api/using-graph-api/error-handling#errorcodes
 			 */
-			if ( in_array( $response->get_api_error_code(), [ 10, 102, 190 ], false ) ) {
+			if ( ( $code >= 200 && $code < 300 ) || in_array( $code, [ 10, 102, 190 ], false ) ) {
 				set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
 			} else {
 				// this was an unrelated error, so the OAuth connection may still be valid
 				delete_transient( 'wc_facebook_connection_invalid' );
 			}
 
-			throw new Framework\SV_WC_API_Exception( $message, $response->get_api_error_code() );
+			throw new Framework\SV_WC_API_Exception( $message, $code );
 		}
 
 		// if we get this far we're connected, so delete any invalid connection flag

--- a/includes/API.php
+++ b/includes/API.php
@@ -86,8 +86,23 @@ class API extends Framework\SV_WC_API_Base {
 				throw new API\Exceptions\Request_Limit_Reached( $message, $response->get_api_error_code() );
 			}
 
+			/**
+			 * Handle invalid token errors
+			 *
+			 * @link https://developers.facebook.com/docs/graph-api/using-graph-api/error-handling#errorcodes
+			 */
+			if ( in_array( $response->get_api_error_code(), [ 10, 102, 190 ], false ) ) {
+				set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
+			} else {
+				// this was an unrelated error, so the OAuth connection may still be valid
+				delete_transient( 'wc_facebook_connection_invalid' );
+			}
+
 			throw new Framework\SV_WC_API_Exception( $message, $response->get_api_error_code() );
 		}
+
+		// if we get this far we're connected, so delete any invalid connection flag
+		delete_transient( 'wc_facebook_connection_invalid' );
 	}
 
 

--- a/tests/acceptance/Admin/NoticesCest.php
+++ b/tests/acceptance/Admin/NoticesCest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Tests for standalone admin notices.
+ */
+class NoticesCest {
+
+
+	/**
+	 * Runs before each test.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 * @throws \Codeception\Exception\ModuleException
+	 */
+	public function _before( AcceptanceTester $I ) {
+
+		$I->loginAsAdmin();
+	}
+
+
+	/**
+	 * @see \SkyVerge\WooCommerce\Facebook\API::do_post_parse_response_validation()
+	 * @see \WC_Facebookcommerce::add_admin_notices()
+	 */
+	public function try_invalid_connection_notice_with_token( AcceptanceTester $I ) {
+
+		$I->haveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_ACCESS_TOKEN, '12345' );
+		$I->haveTransientInDatabase( 'wc_facebook_connection_invalid', time() );
+
+		$I->amOnPluginsPage();
+
+		$I->see( 'Your connection to Facebook is no longer valid', '.notice' );
+	}
+
+
+	/**
+	 * @see \SkyVerge\WooCommerce\Facebook\API::do_post_parse_response_validation()
+	 * @see \WC_Facebookcommerce::add_admin_notices()
+	 */
+	public function try_invalid_connection_notice_without_token( AcceptanceTester $I ) {
+
+		$I->haveTransientInDatabase( 'wc_facebook_connection_invalid', time() );
+
+		$I->amOnPluginsPage();
+
+		$I->dontSee( 'Your connection to Facebook is no longer valid', '.notice' );
+	}
+
+
+	/**
+	 * @see \SkyVerge\WooCommerce\Facebook\API::do_post_parse_response_validation()
+	 * @see \WC_Facebookcommerce::add_admin_notices()
+	 */
+	public function try_invalid_connection_notice_valid_connection( AcceptanceTester $I ) {
+
+		$I->haveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_ACCESS_TOKEN, '12345' );
+
+		$I->amOnPluginsPage();
+
+		$I->dontSee( 'Your connection to Facebook is no longer valid', '.notice' );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

Adds a notice whenever the Facebook API returns an error code that determines the access token is invalid.

### Story: [CH 55193](https://app.clubhouse.io/skyverge/story/55193)
### Release: #1277 

## Details

Whenever an API request returns an error with a code that [requires a new access token](https://developers.facebook.com/docs/graph-api/using-graph-api/error-handling#errorcodes), we set a transient to use as a flag.

When the transient is present, display a notice to prompt reconnection.

Whenever the API returns an error code that _isn't_ OAuth related, the transient is deleted since the connection isn't the problem. Likewise, whenever an API request succeeds, the transient is deleted.

## UI Changes

- New notice: https://cloud.skyver.ge/04uPXQlx

## QA

- [ ] Acceptance tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version