### PR TITLE
Init revamped settings screens

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -48,6 +48,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var \SkyVerge\WooCommerce\Facebook\Admin admin handler instance */
 		private $admin;
 
+		/** @var \SkyVerge\WooCommerce\Facebook\Admin\Settings */
+		private $admin_settings;
+
 		/** @var \SkyVerge\WooCommerce\Facebook\AJAX Ajax handler instance */
 		private $ajax;
 
@@ -137,6 +140,15 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				}
 
 				$this->connection_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\Connection();
+
+				// load admin handlers, before admin_init
+				if ( is_admin() ) {
+
+					require_once __DIR__ . '/includes/Admin/Settings.php';
+					require_once __DIR__ . '/includes/Admin/Abstract_Settings_Screen.php';
+
+					$this->admin_settings = new \SkyVerge\WooCommerce\Facebook\Admin\Settings();
+				}
 			}
 		}
 
@@ -151,8 +163,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		public function init_admin() {
 
 			require_once __DIR__ . '/includes/Admin.php';
-			require_once __DIR__ . '/includes/Admin/Settings.php';
-			require_once __DIR__ . '/includes/Admin/Abstract_Settings_Screen.php';
 
 			$this->admin = new \SkyVerge\WooCommerce\Facebook\Admin();
 		}

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -410,7 +410,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		 */
 		public function get_settings_url( $plugin_id = null ) {
 
-			return admin_url( 'admin.php?page=' . \SkyVerge\WooCommerce\Facebook\Admin\Settings::PAGE_ID );
+			return admin_url( 'admin.php?page=wc-facebook' );
 		}
 
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -491,11 +491,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		 */
 		public function is_plugin_settings() {
 
-			$page    = Framework\SV_WC_Helper::get_requested_value( 'page' );
-			$tab     = Framework\SV_WC_Helper::get_requested_value( 'tab' );
-			$section = Framework\SV_WC_Helper::get_requested_value( 'section' );
-
-			return is_admin() && 'wc-settings' === $page && 'integration' === $tab && self::INTEGRATION_ID === $section;
+			return is_admin() && \SkyVerge\WooCommerce\Facebook\Admin\Settings::PAGE_ID === Framework\SV_WC_Helper::get_requested_value( 'page' );
 		}
 
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -410,7 +410,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		 */
 		public function get_settings_url( $plugin_id = null ) {
 
-			return admin_url( 'admin.php?page=wc-settings&tab=integration&section=' . self::INTEGRATION_ID );
+			return admin_url( 'admin.php?page=' . \SkyVerge\WooCommerce\Facebook\Admin\Settings::PAGE_ID );
 		}
 
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -151,6 +151,8 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		public function init_admin() {
 
 			require_once __DIR__ . '/includes/Admin.php';
+			require_once __DIR__ . '/includes/Admin/Settings.php';
+			require_once __DIR__ . '/includes/Admin/Abstract_Settings_Screen.php';
 
 			$this->admin = new \SkyVerge\WooCommerce\Facebook\Admin();
 		}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -157,6 +157,8 @@ class Admin {
 						'feed_upload_error'             => esc_html__( 'Something went wrong while uploading the product information, please try again.', 'facebook-for-woocommerce' ),
 					],
 				] );
+				wp_enqueue_style( 'woocommerce_admin_styles' );
+				wp_enqueue_script( 'wc-enhanced-select' );
 			}
 		}
 	}
@@ -1016,7 +1018,7 @@ class Admin {
 		global $current_screen;
 
 		// bail if not on the products, product edit, or settings screen
-		if ( ! $current_screen || ! in_array( $current_screen->id, [ 'edit-product', 'product', 'woocommerce_page_wc-settings' ], true ) ) {
+		if ( ! $current_screen || ! in_array( $current_screen->id, [ 'edit-product', 'product', 'woocommerce_page_wc-facebook' ], true ) ) {
 			return;
 		}
 

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -31,6 +31,46 @@ abstract class Abstract_Settings_Screen {
 	protected $description;
 
 
+	/**
+	 * Renders the screen.
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function render() {
+
+		/**
+		 * Filters the screen settings.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param array $settings settings
+		 */
+		$settings = (array) apply_filters( 'wc_facebook_admin_' . $this->get_id() . '_settings', $this->get_settings(), $this );
+
+		if ( empty( $settings ) ) {
+			return;
+		}
+
+		?>
+
+		<?php if ( $this->get_disconnected_message() && ! facebook_for_woocommerce()->get_connection_handler()->is_connected() ) : ?>
+			<div class="notice notice-info"><?php echo wp_kses_post( $this->get_disconnected_message() ); ?></div>
+		<?php endif; ?>
+
+		<form method="post" id="mainform" action="" enctype="multipart/form-data">
+
+			<?php woocommerce_admin_fields( $settings ); ?>
+
+			<input type="hidden" name="screen_id" value="<?php echo esc_attr( $this->get_id() ); ?>">
+			<?php wp_nonce_field( 'wc_facebook_admin_save_' . $this->get_id() . '_settings' ); ?>
+			<?php submit_button( __( 'Save changes', 'facebook-for-woocommerce' ), 'primary', 'save_' . $this->get_id() . '_settings' ); ?>
+
+		</form>
+
+		<?php
+	}
+
+
 	/** Getter methods ************************************************************************************************/
 
 

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -63,9 +63,11 @@ abstract class Abstract_Settings_Screen {
 
 			<?php woocommerce_admin_fields( $settings ); ?>
 
-			<input type="hidden" name="screen_id" value="<?php echo esc_attr( $this->get_id() ); ?>">
-			<?php wp_nonce_field( 'wc_facebook_admin_save_' . $this->get_id() . '_settings' ); ?>
-			<?php submit_button( __( 'Save changes', 'facebook-for-woocommerce' ), 'primary', 'save_' . $this->get_id() . '_settings' ); ?>
+			<?php if ( $is_connected ) : ?>
+				<input type="hidden" name="screen_id" value="<?php echo esc_attr( $this->get_id() ); ?>">
+				<?php wp_nonce_field( 'wc_facebook_admin_save_' . $this->get_id() . '_settings' ); ?>
+				<?php submit_button( __( 'Save changes', 'facebook-for-woocommerce' ), 'primary', 'save_' . $this->get_id() . '_settings' ); ?>
+			<?php endif; ?>
 
 		</form>
 

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Admin;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * The base settings screen object.
+ */
+abstract class Abstract_Settings_Screen {
+
+
+	/** @var string screen ID */
+	private $id;
+
+	/** @var string screen label, for display */
+	private $label;
+
+	/** @var string screen title, for display */
+	private $title;
+
+	/** @var string screen description, for display */
+	private $description;
+
+
+	/** Getter methods ************************************************************************************************/
+
+
+	/**
+	 * Gets the settings.
+	 *
+	 * Should return a multi-dimensional array of settings in the format expected by \WC_Admin_Settings
+	 * @return array
+	 */
+	abstract public function get_settings();
+
+
+	/**
+	 * Gets the message to display when the plugin is disconnected.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_disconnected_message() {
+
+		return '';
+	}
+
+
+	/**
+	 * Gets the screen ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+
+		return $this->id;
+	}
+
+
+	/**
+	 * Gets the screen label.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+
+		/**
+		 * Filters the screen label.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param string $label screen label, for display
+		 */
+		return (string) apply_filters( 'wc_facebook_admin_settings_' . $this->get_id() . '_screen_label', $this->label, $this );
+	}
+
+
+	/**
+	 * Gets the screen title.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+
+		/**
+		 * Filters the screen title.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param string $title screen title, for display
+		 */
+		return (string) apply_filters( 'wc_facebook_admin_settings_' . $this->get_id() . '_screen_title', $this->title, $this );
+	}
+
+
+	/**
+	 * Gets the screen description.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+
+		/**
+		 * Filters the screen description.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param string $description screen description, for display
+		 */
+		return (string) apply_filters( 'wc_facebook_admin_settings_' . $this->get_id() . '_screen_description', $this->description, $this );
+	}
+
+
+}

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -51,13 +51,15 @@ abstract class Abstract_Settings_Screen {
 			return;
 		}
 
+		$is_connected = facebook_for_woocommerce()->get_connection_handler()->is_connected();
+
 		?>
 
-		<?php if ( $this->get_disconnected_message() && ! facebook_for_woocommerce()->get_connection_handler()->is_connected() ) : ?>
+		<?php if ( $this->get_disconnected_message() && ! $is_connected ) : ?>
 			<div class="notice notice-info"><?php echo wp_kses_post( $this->get_disconnected_message() ); ?></div>
 		<?php endif; ?>
 
-		<form method="post" id="mainform" action="" enctype="multipart/form-data">
+		<form class="wc-facebook-settings <?php echo $is_connected ? 'connected' : 'disconnected'; ?>" method="post" id="mainform" action="" enctype="multipart/form-data">
 
 			<?php woocommerce_admin_fields( $settings ); ?>
 

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -55,8 +55,8 @@ abstract class Abstract_Settings_Screen {
 
 		?>
 
-		<?php if ( $this->get_disconnected_message() && ! $is_connected ) : ?>
-			<div class="notice notice-info"><?php echo wp_kses_post( $this->get_disconnected_message() ); ?></div>
+		<?php if ( ! $is_connected && $this->get_disconnected_message() ) : ?>
+			<div class="notice notice-info"><p><?php echo wp_kses_post( $this->get_disconnected_message() ); ?></p></div>
 		<?php endif; ?>
 
 		<form class="wc-facebook-settings <?php echo $is_connected ? 'connected' : 'disconnected'; ?>" method="post" id="mainform" action="" enctype="multipart/form-data">

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -71,6 +71,17 @@ abstract class Abstract_Settings_Screen {
 	}
 
 
+	/**
+	 * Saves the settings.
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function save() {
+
+		woocommerce_update_options( $this->get_settings() );
+	}
+
+
 	/** Getter methods ************************************************************************************************/
 
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -34,6 +34,8 @@ class Settings {
 	public function __construct() {
 
 		add_action( 'admin_menu', [ $this, 'add_menu_item' ] );
+
+		add_action( 'wp_loaded', [ $this, 'save' ] );
 	}
 
 
@@ -98,7 +100,30 @@ class Settings {
 	 *
 	 * @since 2.0.0-dev.1
 	 */
-	public function save() {}
+	public function save() {
+
+		if ( ! is_admin() || SV_WC_Helper::get_requested_value( 'page' ) !== self::PAGE_ID ) {
+			return;
+		}
+
+		$screen = $this->get_screen( SV_WC_Helper::get_posted_value( 'screen_id' ) );
+
+		if ( ! $screen ) {
+			return;
+		}
+
+		if ( ! SV_WC_Helper::get_posted_value( 'save_' . $screen->get_id() . '_settings' ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_die( __( 'You do not have permission to save these settings.', 'facebook-for-woocommerce' ) );
+		}
+
+		check_admin_referer( 'wc_facebook_admin_save_' . $screen->get_id() . '_settings' );
+
+		$screen->save();
+	}
 
 
 	/**

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -26,12 +26,19 @@ class Settings {
 	const PAGE_ID = 'wc-facebook';
 
 
+	/** @var Abstract_Settings_Screen[] */
+	private $screens;
+
+
 	/**
 	 * Settings constructor.
 	 *
 	 * @since 2.0.0-dev.1
 	 */
 	public function __construct() {
+
+		$this->screens = [
+		];
 
 		add_action( 'admin_menu', [ $this, 'add_menu_item' ] );
 
@@ -151,9 +158,6 @@ class Settings {
 	 */
 	public function get_screens() {
 
-		$screens = [
-		];
-
 		/**
 		 * Filters the admin settings screens.
 		 *
@@ -161,7 +165,7 @@ class Settings {
 		 *
 		 * @param array $screens available screen objects
 		 */
-		$screens = (array) apply_filters( 'wc_facebook_admin_settings_screens', $screens, $this );
+		$screens = (array) apply_filters( 'wc_facebook_admin_settings_screens', $this->screens, $this );
 
 		// ensure no bogus values are added via filter
 		$screens = array_filter( $screens, function( $value ) {

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -58,6 +58,22 @@ class Settings {
 
 
 	/**
+	 * Gets a settings screen object based on ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $screen_id desired screen ID
+	 * @return Abstract_Settings_Screen|null
+	 */
+	private function get_screen( $screen_id ) {
+
+		$screens = $this->get_screens();
+
+		return ! empty( $screens[ $screen_id ] ) ? $screens[ $screen_id ] : null;
+	}
+
+
+	/**
 	 * Gets the available screens.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -130,6 +130,8 @@ class Settings {
 		check_admin_referer( 'wc_facebook_admin_save_' . $screen->get_id() . '_settings' );
 
 		$screen->save();
+
+		facebook_for_woocommerce()->get_message_handler()->add_message( __( 'Your settings have been saved.', 'facebook-for-woocommerce' ) );
 	}
 
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -82,6 +82,9 @@ class Settings {
 	 */
 	public function get_screens() {
 
+		$screens = [
+		];
+
 		/**
 		 * Filters the admin settings screens.
 		 *
@@ -89,7 +92,7 @@ class Settings {
 		 *
 		 * @param array $screens available screen objects
 		 */
-		$screens = (array) apply_filters( 'wc_facebook_admin_settings_screens', [], $this );
+		$screens = (array) apply_filters( 'wc_facebook_admin_settings_screens', $screens, $this );
 
 		// ensure no bogus values are added via filter
 		$screens = array_filter( $screens, function( $value ) {
@@ -111,6 +114,12 @@ class Settings {
 	 */
 	public function get_tabs() {
 
+		$tabs = [];
+
+		foreach ( $this->get_screens() as $screen_id => $screen ) {
+			$tabs[ $screen_id ] = $screen->get_label();
+		}
+
 		/**
 		 * Filters the admin settings tabs.
 		 *
@@ -118,7 +127,7 @@ class Settings {
 		 *
 		 * @param array $tabs tab data, as $id => $label
 		 */
-		return (array) apply_filters( 'wc_facebook_admin_settings_tabs', [], $this );
+		return (array) apply_filters( 'wc_facebook_admin_settings_tabs', $tabs, $this );
 	}
 
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Admin;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * Admin settings handler.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Settings {
+
+
+	/**
+	 * Settings constructor.
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function __construct() {
+
+	}
+
+
+	/**
+	 * Adds the Facebook menu item.
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function add_menu_item() {
+
+
+	}
+
+
+	/**
+	 * Renders the settings page.
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function render() {}
+
+
+	/**
+	 * Saves the settings page.
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function save() {}
+
+
+	/**
+	 * Gets the tabs.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return array
+	 */
+	private function get_tabs() {
+
+		/**
+		 * Filters the admin settings tabs.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param array $tabs tab data, as $id => $label
+		 */
+		return (array) apply_filters( 'wc_facebook_admin_settings_tabs', [], $this );
+	}
+
+
+}

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -69,7 +69,7 @@ class Settings {
 
 		$screens = $this->get_screens();
 
-		return ! empty( $screens[ $screen_id ] ) ? $screens[ $screen_id ] : null;
+		return ! empty( $screens[ $screen_id ] ) && $screens[ $screen_id ] instanceof Abstract_Settings_Screen ? $screens[ $screen_id ] : null;
 	}
 
 
@@ -89,7 +89,16 @@ class Settings {
 		 *
 		 * @param array $screens available screen objects
 		 */
-		return (array) apply_filters( 'wc_facebook_admin_settings_screens', [], $this );
+		$screens = (array) apply_filters( 'wc_facebook_admin_settings_screens', [], $this );
+
+		// ensure no bogus values are added via filter
+		$screens = array_filter( $screens, function( $value ) {
+
+			return $value instanceof Abstract_Settings_Screen;
+
+		} );
+
+		return $screens;
 	}
 
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -58,6 +58,26 @@ class Settings {
 
 
 	/**
+	 * Gets the available screens.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return Abstract_Settings_Screen[]
+	 */
+	private function get_screens() {
+
+		/**
+		 * Filters the admin settings screens.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param array $screens available screen objects
+		 */
+		return (array) apply_filters( 'wc_facebook_admin_settings_screens', [], $this );
+	}
+
+
+	/**
 	 * Gets the tabs.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -10,6 +10,8 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Admin;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper;
+
 defined( 'ABSPATH' ) or exit;
 
 /**
@@ -51,7 +53,44 @@ class Settings {
 	 *
 	 * @since 2.0.0-dev.1
 	 */
-	public function render() {}
+	public function render() {
+
+		$tabs        = $this->get_tabs();
+		$current_tab = SV_WC_Helper::get_requested_value( 'tab' );
+
+		if ( ! $current_tab ) {
+			$current_tab = current( array_keys( $tabs ) );
+		}
+
+		$screen = $this->get_screen( $current_tab );
+
+		?>
+
+		<div class="wrap woocommerce">
+
+			<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
+
+				<?php foreach ( $tabs as $id => $label ) : ?>
+					<a href="<?php echo esc_html( admin_url( 'admin.php?page=' . self::PAGE_ID . '&tab=' . esc_attr( $id ) ) ); ?>" class="nav-tab <?php echo $current_tab === $id ? 'nav-tab-active' : ''; ?>"><?php echo esc_html( $label ); ?></a>
+				<?php endforeach; ?>
+
+			</nav>
+
+			<?php facebook_for_woocommerce()->get_message_handler()->show_messages(); ?>
+
+			<?php if ( $screen ) : ?>
+
+				<h1 class="screen-reader-text"><?php echo esc_html( $screen->get_title() ); ?></h1>
+				<p><?php echo wp_kses_post( $screen->get_description() ); ?></p>
+
+				<?php $screen->render(); ?>
+
+			<?php endif; ?>
+
+		</div>
+
+		<?php
+	}
 
 
 	/**

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -20,6 +20,10 @@ defined( 'ABSPATH' ) or exit;
 class Settings {
 
 
+	/** @var string base settings page ID */
+	const PAGE_ID = 'wc-facebook';
+
+
 	/**
 	 * Settings constructor.
 	 *
@@ -27,6 +31,7 @@ class Settings {
 	 */
 	public function __construct() {
 
+		add_action( 'admin_menu', [ $this, 'add_menu_item' ] );
 	}
 
 
@@ -37,7 +42,7 @@ class Settings {
 	 */
 	public function add_menu_item() {
 
-
+		add_submenu_page( 'woocommerce', __( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ), __( 'Facebook', 'facebook-for-woocommerce' ), 'manage_woocommerce', self::PAGE_ID, [ $this, 'render' ], 5 );
 	}
 
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -65,7 +65,7 @@ class Settings {
 	 * @param string $screen_id desired screen ID
 	 * @return Abstract_Settings_Screen|null
 	 */
-	private function get_screen( $screen_id ) {
+	public function get_screen( $screen_id ) {
 
 		$screens = $this->get_screens();
 
@@ -80,7 +80,7 @@ class Settings {
 	 *
 	 * @return Abstract_Settings_Screen[]
 	 */
-	private function get_screens() {
+	public function get_screens() {
 
 		/**
 		 * Filters the admin settings screens.
@@ -100,7 +100,7 @@ class Settings {
 	 *
 	 * @return array
 	 */
-	private function get_tabs() {
+	public function get_tabs() {
 
 		/**
 		 * Filters the admin settings tabs.

--- a/tests/integration/Admin/SettingsTest.php
+++ b/tests/integration/Admin/SettingsTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Admin;
+
+/**
+ * Tests the Admin\Settings class.
+ */
+class SettingsTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+		require_once 'includes/Admin/Settings.php';
+		require_once 'includes/Admin/Abstract_Settings_Screen.php';
+	}
+
+
+	/**
+	 * Runs after each test.
+	 */
+	protected function _after() {
+
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see Admin\Settings::get_screen()
+	 *
+	 * @param string $screen_id
+	 * @param Admin\Abstract_Settings_Screen|null $expected
+	 *
+	 * @dataProvider provider_get_screen
+	 */
+	public function test_get_screen( $screen_id, $expected ) {
+
+		$this->assertSame( $expected, $this->get_setting_handler()->get_screen( $screen_id ) );
+	}
+
+
+	/** @see test_get_screen */
+	public function provider_get_screen() {
+
+		return [
+			[ 'non-existent', null ],
+		];
+	}
+
+
+	/** @see Admin\Settings::get_screens() */
+	public function test_get_screens() {
+
+		$this->assertSame( [], $this->get_setting_handler()->get_screens() );
+	}
+
+
+	/** @see Admin\Settings::get_screens() */
+	public function test_get_screens_filter() {
+
+		add_filter( 'wc_facebook_admin_settings_screens', function( $screens ) {
+
+			$screens['custom-screen'] = $this->getMockForAbstractClass( Admin\Abstract_Settings_Screen::class );;
+
+			return $screens;
+
+		} );
+
+		$screens = $this->get_setting_handler()->get_screens();
+
+		$this->assertArrayHasKey( 'custom-screen', $screens );
+		$this->assertInstanceOf( Admin\Abstract_Settings_Screen::class, $screens['custom-screen'] );
+	}
+
+
+	/**
+	 * Tests that the screens filter removes invalid screen values.
+	 *
+	 * @see Admin\Settings::get_screens()
+	 */
+	public function test_get_screens_filter_invalid_screen() {
+
+		add_filter( 'wc_facebook_admin_settings_screens', function( $screens ) {
+
+			$screens['bogus_screen'] = 'Nope!';
+
+			return $screens;
+
+		} );
+
+		$this->assertArrayNotHasKey( 'bogus_screen', $this->get_setting_handler()->get_screens() );
+	}
+
+
+	/** @see Admin\Settings::get_tabs() */
+	public function test_get_tabs() {
+
+		$this->assertSame( [], $this->get_setting_handler()->get_tabs() );
+	}
+
+
+	/** @see Admin\Settings::get_tabs() */
+	public function test_get_tabs_filter() {
+
+		add_filter( 'wc_facebook_admin_settings_tabs', function( $tabs ) {
+
+			$tabs['added-tab'] = 'Hello!';
+
+			return $tabs;
+
+		} );
+
+		$tabs = $this->get_setting_handler()->get_tabs();
+
+		$this->assertArrayHasKey( 'added-tab', $tabs );
+		$this->assertSame( 'Hello!', $tabs['added-tab'] );
+	}
+
+
+	/** Utility methods ***********************************************************************************************/
+
+
+	/**
+	 * Gets a settings handler instance.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return Admin\Settings
+	 */
+	private function get_setting_handler() {
+
+		return new Admin\Settings();
+	}
+
+
+}


### PR DESCRIPTION
# Summary

Adds the base handlers for a revamped set of settings screens.

### Story: [CH 55195](https://app.clubhouse.io/skyverge/story/55195)
### Release: #1345 

## UI Changes

Nothing visible yet in this PR.

## QA

- [ ] Integration tests pass

_TODO_ for individual screens

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version