### PR TITLE
Use fewer requests to find product item IDs of variations in the Edit Product screen

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -264,6 +264,14 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Catalog/Product_Group/Products/Read/Response.php';
 				}
 
+				if ( ! class_exists( API\Catalog\Product_Item\Response::class ) ) {
+					require_once __DIR__ . '/includes/API/Catalog/Product_Item/Response.php';
+				}
+
+				if ( ! class_exists( API\Catalog\Product_Item\Find\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Catalog/Product_Item/Find/Request.php';
+				}
+
 				if ( ! class_exists( API\Pages\Read\Request::class ) ) {
 					require_once __DIR__ . '/includes/API/Pages/Read/Request.php';
 				}

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -236,6 +236,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API.php';
 				}
 
+				if ( ! trait_exists( API\Traits\Paginated_Response::class, false ) ) {
+					require_once __DIR__ . '/includes/API/Traits/Paginated_Response.php';
+				}
+
 				if ( ! class_exists( API\Request::class ) ) {
 					require_once __DIR__ . '/includes/API/Request.php';
 				}

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -256,6 +256,14 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Catalog/Send_Item_Updates/Response.php';
 				}
 
+				if ( ! class_exists( API\Catalog\Product_Group\Products\Read\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Catalog/Product_Group/Products/Read/Request.php';
+				}
+
+				if ( ! class_exists( API\Catalog\Product_Group\Products\Read\Response::class ) ) {
+					require_once __DIR__ . '/includes/API/Catalog/Product_Group/Products/Read/Response.php';
+				}
+
 				if ( ! class_exists( API\Pages\Read\Request::class ) ) {
 					require_once __DIR__ . '/includes/API/Pages/Read/Request.php';
 				}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -617,7 +617,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 			<?php echo esc_html__( 'Facebook ID:', 'facebook-for-woocommerce' ); ?> <a href="https://facebook.com/<?php echo esc_attr( $fb_product_group_id ); ?>"
 			                                                                           target="_blank"><?php echo esc_html( $fb_product_group_id ); ?></a>
-			<p/>
 
 			<?php if ( WC_Facebookcommerce_Utils::is_variable_type( $woo_product->get_type() ) ) : ?>
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -614,44 +614,30 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( $fb_product_group_id ) {
 
 			?>
-				<?php echo esc_html__( 'Facebook ID:', 'facebook-for-woocommerce' ); ?>
-				<a href="https://facebook.com/<?php echo esc_attr( $fb_product_group_id ); ?>"
-				target="_blank">
-					<?php echo esc_html( $fb_product_group_id ); ?>
-				</a>
-				<p/>
-			<?php
 
-			if ( WC_Facebookcommerce_Utils::is_variable_type( $woo_product->get_type() ) ) {
+			<?php echo esc_html__( 'Facebook ID:', 'facebook-for-woocommerce' ); ?> <a href="https://facebook.com/<?php echo esc_attr( $fb_product_group_id ); ?>"
+			                                                                           target="_blank"><?php echo esc_html( $fb_product_group_id ); ?></a>
+			<p/>
 
-				?>
-					<p><?php echo esc_html__( 'Variant IDs:', 'facebook-for-woocommerce' ); ?><br/>
-				<?php
+			<?php if ( WC_Facebookcommerce_Utils::is_variable_type( $woo_product->get_type() ) ) : ?>
 
-				$children = $woo_product->get_children();
+				<?php if ( $product_item_ids_by_variation_id = $this->get_variation_product_item_ids( $woo_product, $fb_product_group_id ) ) : ?>
 
-				foreach ( $children as $child_id ) {
+					<p>
+						<?php echo esc_html__( 'Variant IDs:', 'facebook-for-woocommerce' ); ?><br/>
 
-					$fb_product_item_id = $this->get_product_fbid(
-						self::FB_PRODUCT_ITEM_ID,
-						$child_id
-					);
+						<?php foreach ( $product_item_ids_by_variation_id as $variation_id => $product_item_id ) : ?>
 
-					?>
-						<?php echo esc_html( $child_id ); ?>:
-						<a href="https://facebook.com/<?php echo esc_attr( $fb_product_item_id ); ?>"
-						target="_blank">
-							<?php echo esc_html( $fb_product_item_id ); ?>
-						</a><br/>
-					<?php
-				}
+							<?php echo esc_html( $variation_id ); ?>: <a href="https://facebook.com/<?php echo esc_attr( $product_item_id ); ?>"
+							                                             target="_blank"><?php echo esc_html( $product_item_id ); ?></a><br/>
 
-				?>
+						<?php endforeach; ?>
 					</p>
-				<?php
-			}
 
-			?>
+				<?php endif; ?>
+
+			<?php endif; ?>
+
 				<?php /* ?>
 				<?php echo esc_html__( 'Visible:', 'facebook-for-woocommerce' ); ?>
 				<input name="<?php echo esc_attr( Products::VISIBILITY_META_KEY ); ?>"

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -689,6 +689,40 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 
 	/**
+	 * Uses the Graph API to return a list of Product Item IDs indexed by the variation's retailer ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $product_group_id product group ID
+	 * @return array
+	 */
+	private function find_variation_product_item_ids( $product_group_id ) {
+
+		$product_item_ids = [];
+
+		try {
+
+			$response = facebook_for_woocommerce()->get_api()->get_product_group_products( $product_group_id );
+
+			do {
+
+				$product_item_ids = array_merge( $product_item_ids, $response->get_product_item_ids() );
+
+			// get up to two additional pages of results
+			} while ( $response = facebook_for_woocommerce()->get_api()->next( $response, 2 ) );
+
+		} catch ( Framework\SV_WC_API_Exception $e ) {
+
+			$message = sprintf( 'There was an error trying to find the IDs for Product Items in the Product Group %s: %s', $product_group_id, $e->getMessage() );
+
+			facebook_for_woocommerce()->log( $message );
+		}
+
+		return $product_item_ids;
+	}
+
+
+	/**
 	 * Gets the total of published products.
 	 *
 	 * @return int

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -746,7 +746,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 			do {
 
-				$product_item_ids = array_merge( $product_item_ids, $response->get_product_item_ids() );
+				$product_item_ids = array_merge( $product_item_ids, $response->get_ids() );
 
 			// get up to two additional pages of results
 			} while ( $response = facebook_for_woocommerce()->get_api()->next( $response, 2 ) );

--- a/includes/API.php
+++ b/includes/API.php
@@ -169,8 +169,8 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param string $product_group_id
-	 * @param array $data
+	 * @param string $product_group_id product group ID
+	 * @param array $data product group data
 	 * @return Response
 	 * @throws Framework\SV_WC_API_Exception
 	 */

--- a/includes/API.php
+++ b/includes/API.php
@@ -412,7 +412,7 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 *     @type string $path request path
 	 *     @type string $method request method
-	 *     @type array  $params request parameters
+	 *     @type array $params request parameters
 	 * }
 	 * @return Request
 	 */

--- a/includes/API.php
+++ b/includes/API.php
@@ -212,6 +212,26 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Gets a list of Product Items in the given Product Group.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $product_group_id product group ID
+	 * @param int $limit max number of results returned per page of data
+	 * @return API\Catalog\Product_Group\Products\Read\Response
+	 * @throws Framework\SV_WC_API_Exception
+	 */
+	public function get_product_group_products( $product_group_id, $limit = 1000 ) {
+
+		$request = new API\Catalog\Product_Group\Products\Read\Request( $product_group_id, $limit );
+
+		$this->set_response_handler( API\Catalog\Product_Group\Products\Read\Response::class );
+
+		return $this->perform_request( $request );
+	}
+
+
+	/**
 	 * Finds a Product Item using the Catalog ID and the Retailer ID of the product or product variation.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/API.php
+++ b/includes/API.php
@@ -355,6 +355,7 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 *     @type string $path request path
 	 *     @type string $method request method
+	 *     @type array  $params request parameters
 	 * }
 	 * @return Request
 	 */
@@ -363,11 +364,17 @@ class API extends Framework\SV_WC_API_Base {
 		$defaults = [
 			'path'   => '/',
 			'method' => 'GET',
+			'params' => [],
 		];
 
-		$args = wp_parse_args( $args, $defaults );
+		$args    = wp_parse_args( $args, $defaults );
+		$request = new Request( $args['path'], $args['method'] );
 
-		return new Request( $args['path'], $args['method'] );
+		if ( $args['params'] ) {
+			$request->set_params( $args['params'] );
+		}
+
+		return $request;
 	}
 
 

--- a/includes/API/Catalog/Product_Group/Products/Read/Request.php
+++ b/includes/API/Catalog/Product_Group/Products/Read/Request.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Group\Products\Read;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Request object for the API endpoint that returns a list of Product Items in a particular Product Group.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Request extends API\Request {
+
+
+	/**
+	 * Constructor for the Product Group Products read request.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $product_group_id product group ID
+	 * @param int $limit max number of results returned
+	 */
+	public function __construct( $product_group_id, $limit ) {
+
+		parent::__construct( "/{$product_group_id}/products", 'GET' );
+
+		$this->set_params( [
+			'fields' => 'id,retailer_id',
+			'limit'  => $limit,
+		] );
+	}
+
+
+}

--- a/includes/API/Catalog/Product_Group/Products/Read/Response.php
+++ b/includes/API/Catalog/Product_Group/Products/Read/Response.php
@@ -32,7 +32,7 @@ class Response extends API\Response {
 	 *
 	 * @return array
 	 */
-	public function get_product_item_ids() {
+	public function get_ids() {
 
 		$product_item_ids = [];
 

--- a/includes/API/Catalog/Product_Group/Products/Read/Response.php
+++ b/includes/API/Catalog/Product_Group/Products/Read/Response.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Group\Products\Read;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Response object for the API endpoint that returns a list of Product Items in a particular Product Group.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Response extends API\Response {
+
+
+	use API\Traits\Paginated_Response;
+
+
+	/**
+	 * Gets the Product Item IDs indexed by the retailer ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_product_item_ids() {
+
+		$product_item_ids = [];
+
+		foreach ( $this->get_data() as $entry ) {
+			$product_item_ids[ $entry->retailer_id ] = $entry->id;
+		}
+
+		return $product_item_ids;
+	}
+
+
+}

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -38,6 +38,19 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 
 
 	/**
+	 * Sets the request parameters.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param array $params request parameters
+	 */
+	public function set_params( $params ) {
+
+		$this->params = $params;
+	}
+
+
+	/**
 	 * Sets the request data.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -55,7 +55,7 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param array $data
+	 * @param array $data request data
 	 */
 	public function set_data( $data ) {
 

--- a/includes/API/Traits/Paginated_Response.php
+++ b/includes/API/Traits/Paginated_Response.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Traits;
+
+defined( 'ABSPATH' ) or exit;
+
+
+/**
+ * Helper methods to traverse Graph API paged results.
+ *
+ * @link https://developers.facebook.com/docs/graph-api/using-graph-api/#paging
+ *
+ * @since 2.0.0-dev.1
+ */
+trait Paginated_Response {
+
+
+	/** @var string number of pages retrieved from this response */
+	private $pages_retrieved = 1;
+
+	/** @var mixed decoded response data */
+	public $response_data;
+
+
+	/**
+	 * Sets the number of pages retrieved from this response.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param int $pages_retrieved
+	 */
+	public function set_pages_retrieved( $pages_retrieved ) {
+
+		$this->pages_retrieved = $pages_retrieved;
+	}
+
+
+	/**
+	 * Gets the number of pages retrieved from this response.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return int
+	 */
+	public function get_pages_retrieved() {
+
+		return $this->pages_retrieved;
+	}
+
+
+	/**
+	 * Gets the response data.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+
+		return ! empty( $this->response_data->data ) ? $this->response_data->data : [];
+	}
+
+
+	/**
+	 * Gets the pagination data.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return object
+	 */
+	public function get_pagination_data() {
+
+		return ! empty( $this->response_data->paging ) ? $this->response_data->paging : new \stdClass();
+	}
+
+
+	/**
+	 * Gets the API endpoint for the next page of results.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_next_page_endpoint() {
+
+		return ! empty( $this->get_pagination_data()->next ) ? $this->get_pagination_data()->next : '';
+	}
+
+
+	/**
+	 * Gets the API endpoint for the previous page of results.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string
+	 */
+	public function get_previous_page_endpoint() {
+
+		return ! empty( $this->get_pagination_data()->previous ) ? $this->get_pagination_data()->previous : '';
+	}
+
+
+}

--- a/tests/_support/IntegrationTester.php
+++ b/tests/_support/IntegrationTester.php
@@ -1,5 +1,6 @@
 <?php
 
+use SkyVerge\WooCommerce\Facebook\API;
 
 /**
  * Inherited Methods
@@ -68,6 +69,20 @@ class IntegrationTester extends \Codeception\Actor {
 		$product->save();
 
 		return $product;
+	}
+
+
+	/**
+	 * Gets an instance of an anonymous API\Response subclass that uses the API\Traits\Paginated_Response trait.
+	 *
+	 * @return API\Response
+	 */
+	public function get_paginated_response( $response_data = [] ) {
+
+		return new class( json_encode( $response_data ) ) extends API\Response {
+
+			use API\Traits\Paginated_Response;
+		};
 	}
 
 

--- a/tests/integration/API/Catalog/Product_Group/Products/Read/RequestTest.php
+++ b/tests/integration/API/Catalog/Product_Group/Products/Read/RequestTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Catalog\Product_Group\Products\Read;
+
+use SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Group\Products\Read\Request;
+
+/**
+ * Tests the API\Catalog\Product_Group\Products\Read\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+		parent::_before();
+
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Request::class ) ) {
+			require_once 'includes/API/Request.php';
+		}
+
+		if ( ! class_exists( Request::class ) ) {
+			require_once 'includes/API/Catalog/Product_Group/Products/Read/Request.php';
+		}
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Request::__construct() */
+	public function test_constructor() {
+
+		$product_group_id = '165835951532406';
+		$limit            = 100;
+
+		$expected_params = [
+			'fields' => 'id,retailer_id',
+			'limit'  => 100,
+		];
+
+		$request = new Request( $product_group_id, $limit );
+
+		$this->assertInstanceOf( Request::class, $request );
+		$this->assertEquals( "/165835951532406/products", $request->get_path() );
+		$this->assertEquals( 'GET', $request->get_method() );
+		$this->assertEquals( $expected_params, $request->get_params() );
+	}
+
+
+}

--- a/tests/integration/API/Catalog/Product_Group/Products/Read/ResponseTest.php
+++ b/tests/integration/API/Catalog/Product_Group/Products/Read/ResponseTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Catalog\Product_Group\Products\Read;
+
+use SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Group\Products\Read\Response;
+
+/**
+ * Tests the API\Catalog\Product_Group\Products\Read\Response class.
+ */
+class ResponseTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+		parent::_before();
+
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Response::class ) ) {
+			require_once 'includes/API/Response.php';
+		}
+
+		if ( ! trait_exists( \SkyVerge\WooCommerce\Facebook\API\Traits\Paginated_Response::class, false ) ) {
+			require_once 'includes/API/Traits/Paginated_Response.php';
+		}
+
+		if ( ! class_exists( Response::class ) ) {
+			require_once 'includes/API/Catalog/Product_Group/Products/Read/Response.php';
+		}
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see Response::get_ids()
+	 *
+	 * @param array $response_data test response data
+	 * @param array $product_item_ids expected return value
+	 *
+	 * @dataProvider provider_get_ids()
+	 */
+	public function test_get_ids( $response_data, $product_item_ids ) {
+
+		$response = new Response( json_encode( $response_data ) );
+
+		$this->assertEquals( $product_item_ids, $response->get_ids() );
+	}
+
+
+	/** @see test_get_ids() */
+	public function provider_get_ids() {
+
+		$response_data = [
+			'data' => [
+				[
+					'id' => '4567',
+					'retailer_id' => 'wc_post_id_1234',
+				],
+			],
+		];
+
+		$product_item_ids = [
+			'wc_post_id_1234' => '4567',
+		];
+
+		return [
+			[ $response_data, $product_item_ids ],
+			[ [], [] ],
+		];
+	}
+
+
+}

--- a/tests/integration/API/RequestTest.php
+++ b/tests/integration/API/RequestTest.php
@@ -56,6 +56,18 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Request::set_params() */
+	public function test_set_params() {
+
+		$request = new Request( null, null, null );
+		$params  = [ 'fields' => 'id' ];
+
+		$request->set_params( $params );
+
+		$this->assertEquals( $params, $request->get_params() );
+	}
+
+
 	/** @see Request::set_data() */
 	public function test_set_data() {
 

--- a/tests/integration/API/Traits/PaginatedResponseTest.php
+++ b/tests/integration/API/Traits/PaginatedResponseTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Traits;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Tests the API\Traits\Paginated_Response trait.
+ */
+class PaginatedResponseTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+	/** @var array test data */
+	protected $data = [
+		'data' => [
+			[ 'id' => '1234' ],
+		],
+		'paging' => [
+			'next'     => 'next page',
+			'previous' => 'previous page',
+		],
+	];
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+		parent::_before();
+
+		if ( ! class_exists( API\Response::class ) ) {
+			require_once 'includes/API/Response.php';
+		}
+
+		if ( ! trait_exists( API\Traits\Paginated_Response::class, false ) ) {
+			require_once 'includes/API/Traits/Paginated_Response.php';
+		}
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see API\Traits\Paginated_Response::set_pages_retrieved()
+	 * @see API\Traits\Paginated_Response::get_pages_retrieved()
+	 */
+	public function test_pages_retrieved() {
+
+		$response = $this->tester->get_paginated_response();
+
+		$response->set_pages_retrieved( 5 );
+
+		$this->assertEquals( 5, $response->get_pages_retrieved() );
+	}
+
+
+	/** @see API\Traits\Paginated_Response::get_pages_retrieved() */
+	public function test_get_pages_retrieved_default_value() {
+
+		$response = $this->tester->get_paginated_response( $this->data );
+
+		$this->assertEquals( 1, $response->get_pages_retrieved() );
+	}
+
+
+	/** @see API\Traits\Paginated_Response::get_data() */
+	public function test_get_data() {
+
+		$response = $this->tester->get_paginated_response( $this->data );
+
+		$this->assertEquals( [ (object) [ 'id' => '1234' ] ], $response->get_data() );
+	}
+
+
+	/** @see API\Traits\Paginated_Response::get_pagination_data() */
+	public function test_get_pagination_data() {
+
+		$response = $this->tester->get_paginated_response( $this->data );
+
+		$pagination_data = (object) [ 'next' => 'next page', 'previous' => 'previous page' ];
+
+		$this->assertEquals( $pagination_data, $response->get_pagination_data() );
+	}
+
+
+	/** @see API\Traits\Paginated_Response::get_next_page_endpoint() */
+	public function test_get_next_page_endpoint() {
+
+		$response = $this->tester->get_paginated_response( $this->data );
+
+		$this->assertEquals( 'next page', $response->get_next_page_endpoint() );
+	}
+
+
+	/** @see API\Traits\Paginated_Response::get_previous_page_endpoint() */
+	public function test_get_previous_page_endpoint() {
+
+		$response = $this->tester->get_paginated_response( $this->data );
+
+		$this->assertEquals( 'previous page', $response->get_previous_page_endpoint() );
+	}
+
+
+}

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -432,8 +432,8 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 			],
 		];
 
-		$response      = $this->get_paginated_response( $response_data );
-		$next_response = $this->get_paginated_response( [] );
+		$response      = $this->tester->get_paginated_response( $response_data );
+		$next_response = $this->tester->get_paginated_response();
 
 		$api = $this->make( API::class, [
 			'perform_request' => function( API\Request $request ) use ( $request_args, $next_response ) {
@@ -454,7 +454,7 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::next() */
 	public function test_next_when_there_is_no_next_page() {
 
-		$response = $this->get_paginated_response( [] );
+		$response = $this->tester->get_paginated_response();
 
 		$api = $this->make( API::class, [
 			'perform_request' => Codeception\Stub\Expected::never(),
@@ -476,7 +476,7 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 		$additional_pages = 2;
 		$pages_retrieved  = 3; // the first page from the original response and two more using next()
 
-		$response = $this->get_paginated_response( $response_data );
+		$response = $this->tester->get_paginated_response( $response_data );
 		$response->set_pages_retrieved( $pages_retrieved );
 
 		$api = $this->make( API::class, [
@@ -551,23 +551,6 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 			[ [ 'method' => 'DELETE' ], '/', 'DELETE' ],
 			[ [], '/', 'GET' ],
 		];
-	}
-
-
-	/** Helper methods **************************************************************************************************/
-
-
-	/**
-	 * Gets an instance of an anonymous Response class that uses the API\Traits\Paginated_Response trait.
-	 *
-	 * @return API\Response
-	 */
-	private function get_paginated_response( $response_data ) {
-
-		return new class( json_encode( $response_data ) ) extends API\Response {
-
-			use API\Traits\Paginated_Response;
-		};
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -294,6 +294,34 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see API::get_product_group_products() */
+	public function test_get_product_group_products() {
+
+		$product_group_id = '1234';
+		$limit            = 42;
+
+		$request_params   = [
+			'fields' => 'id,retailer_id',
+			'limit'  => $limit,
+		];
+
+		// test will fail if do_remote_request() is not called once
+		$api = $this->make( API::class, [
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
+		] );
+
+		$api->get_product_group_products( $product_group_id, $limit );
+
+		$this->assertInstanceOf( API\Catalog\Product_Group\Products\Read\Request::class, $api->get_request() );
+		$this->assertEquals( 'GET', $api->get_request()->get_method() );
+		$this->assertEquals( "/{$product_group_id}/products", $api->get_request()->get_path() );
+		$this->assertEquals( $request_params, $api->get_request()->get_params() );
+		$this->assertEquals( [], $api->get_request()->get_data() );
+
+		$this->assertInstanceOf( API\Catalog\Product_Group\Products\Read\Response::class, $api->get_response() );
+	}
+
+
 	/** @see API::find_product_item() */
 	public function test_find_product_item() {
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -325,14 +325,6 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::find_product_item() */
 	public function test_find_product_item() {
 
-		if ( ! class_exists( API\Catalog\Product_Item\Find\Request::class ) ) {
-			require_once 'includes/API/Catalog/Product_Item/Find/Request.php';
-		}
-
-		if ( ! class_exists( API\Catalog\Product_Item\Response::class ) ) {
-			require_once 'includes/API/Catalog/Product_Item/Response.php';
-		}
-
 		$catalog_id  = '123456';
 		$retailer_id = '456';
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -509,14 +509,15 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @see API::get_new_request()
 	 *
-	 * @param array $args
-	 * @param string $expected_path
-	 * @param string $expected_method
+	 * @param array $args test case
+	 * @param string $expected_path expected request path
+	 * @param string $expected_method expected request method
+	 * @param string $expected_params optional array of expected requested parameters
 	 * @throws ReflectionException
 	 *
 	 * @dataProvider provider_get_new_request
 	 */
-	public function test_get_new_request( $args, $expected_path, $expected_method ) {
+	public function test_get_new_request( $args, $expected_path, $expected_method, $expected_params = [] ) {
 
 		$api = new API( 'fake-token' );
 
@@ -529,13 +530,20 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $expected_path, $request->get_path() );
 		$this->assertEquals( $expected_method, $request->get_method() );
+		$this->assertEquals( $expected_params, $request->get_params() );
 	}
 
 
 	/** @see test_get_new_request() */
 	public function provider_get_new_request() {
 
+		$params = [
+			'fields' => 'id',
+			'limit'  => 100,
+		];
+
 		return [
+			[ [ 'path' => '/me', 'method' => 'GET', 'params' => $params ], '/me', 'GET', $params ],
 			[ [ 'path' => '/me', 'method' => 'GET' ], '/me', 'GET' ],
 			[ [ 'path' => '/1234/products', 'method' => 'GET' ], '/1234/products', 'GET' ],
 			[ [ 'path' => '/1234/batch', 'method' => 'POST' ], '/1234/batch', 'POST' ],


### PR DESCRIPTION
# Summary

When we use the background job to sync products, we don't get the Facebook ID of the product item in the response. As a result, the plugin currently tries to find the ID of every product and variation when you visit the Edit Product screen.

This PR updates `WC_Facebookcommerce_Integration::fb_product_meta_box_html()` to use no more than three API requests to get as many Product Item IDs as possible.

## Details

I added a new api method `API::get_product_group_products()` to make request a list of a the product items associated with a given product group using the [Product Group Products endpoint](https://developers.facebook.com/docs/marketing-api/reference/product-group/products/). The method will retrieve up to 1000 product item IDs in a single request, which should be enough for a large portion of variable products, replacing one request for each variation, with a single request.

The Product Group Products endpoint is a [paginated endpoint](https://developers.facebook.com/docs/graph-api/using-graph-api/#paging), so if a product has more than 1000 variations, we would need to request the next page of results in order to get access to the missing IDs. To help with that, this PR also introduces the `API::next()` method that takes a response that has paginated data and performs the request to get the next page of results.

`WC_Facebookcommerce_Integration::fb_product_meta_box_html()` will now attempt to get up to three pages of product item IDs results, but will stop earlier if one of the responses in the chain indicate that there are no more results.

### Story: [CH 55198](https://app.clubhouse.io/skyverge/story/55198)
### Release: #1277

## QA

## Setup

1. See https://skyverge.slack.com/archives/CR8VDB4G7/p1590167886097600 for details about how to connect using the WooCommerce Connect app, which is now live
1. You can also use a local version of the proxy with a personal Facebook App, as described in https://github.com/skyverge/wc-plugins/wiki/Facebook-for-WooCommerce

## Steps

### Edit a variable product

1. Enable debug logging
1. Create a variable product with several variations
1. Make sure each variation has a price and Include in Facebook sync is enabled
1. Click Publish/Update
    - [x] The logs include one or two requests to `https://graph.facebook.com/v7.0/{product_group_id}/products?fields=id%2Cretailer_id&limit=1000`
    - [x] The plugin doesn't initiate a individual request to get the product item ID of each variation

    The variation may show up without an ID when the page loads the first time. That's because the request to get the product item IDs was made before the background job send the product information.
1. Reloading the page should have the same effect:
    - [ ] The logs include one or two requests to `https://graph.facebook.com/v7.0/{product_group_id}/products?fields=id%2Cretailer_id&limit=1000`
    - [ ] The plugin doesn't initiate a individual request to get the product item ID of each variation
1. Once all variations have an ID, if you load the page again:
    - [x] The logs **don't** include requests to `https://graph.facebook.com/v7.0/{product_group_id}/products?fields=id%2Cretailer_id&limit=1000`
    - [x] The plugin doesn't initiate a individual request to get the product item ID of each variation

**Note:** if one of the variations is not synced (disabled from the setting or is virtual), the plugin will continue to make one or two requests when the Edit Product page loads, trying to find the ID of that variation. That's also the behavior of the plugin before this PR or FBE 2.0 modifications, and it was not part of the scope 

### Tests

- [x] `vendor codecept run integration` pass