### PR TITLE
Fix too many visibility updates during product status transitions

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1000,7 +1000,12 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		$product = wc_get_product( $post->ID );
 
-		// bail if this product isn't enabled for sync
+		// bail if we couldn't retrieve a valid product object or the product isn't enabled for sync
+		//
+		// Note that while moving a variable product to the trash, this method is called for each one of the
+		// variations before it gets called with the variable product. As a result, Products::product_should_be_synced()
+		// always returns false for the variable product (since all children are in the trash at that point).
+		// This causes update_fb_visibility() to be called on simple products and product variations only.
 		if ( ! $product instanceof \WC_Product || ! Products::product_should_be_synced( $product ) ) {
 			return;
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1010,7 +1010,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// change from trash status -> publish status
 		// no need to update for change from trash <-> unpublish status
 		if ( ( $old_status === 'publish' && $new_status !== 'publish' ) || ( $old_status === 'trash' && $new_status === 'publish' ) ) {
-			$this->update_fb_visibility( $post->ID, $visibility );
+			$this->update_fb_visibility( $product, $visibility );
 		}
 	}
 
@@ -4353,7 +4353,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		} else {
 			// - product never published to Facebook, new status is not publish
 			// - product new status is not publish but may have been published before
-			$this->update_fb_visibility( $wp_id, $visibility );
+			$this->update_fb_visibility( $product, $visibility );
 		}
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4266,7 +4266,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Helper function to update FB visibility.
 	 *
-	 * @param int $product_id product ID
+	 * @param int|\WC_Product $product_id product ID or product object
 	 * @param string $visibility visibility
 	 */
 	function update_fb_visibility( $product_id, $visibility ) {
@@ -4276,7 +4276,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			return;
 		}
 
-		$product = wc_get_product( $product_id );
+		$product = $product_id instanceof \WC_Product ? $product_id : wc_get_product( $product_id );
 
 		// bail if product isn't found
 		if ( ! $product instanceof \WC_Product ) {

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4289,22 +4289,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		$should_set_visible = $visibility === self::FB_SHOP_PRODUCT_VISIBLE;
 
-		if ( ! $product->is_type( 'variable' ) ) {
-
-			$fb_product_item_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product_id );
-
-			if ( ! $fb_product_item_id ) {
-				\WC_Facebookcommerce_Utils::fblog( $fb_product_item_id . " doesn't exist but underwent a visibility transform.", [], true );
-				 return;
-			}
-
-			$set_visibility = $this->fbgraph->update_product_item( $fb_product_item_id, [ 'visibility' => $visibility ] );
-
-			if ( $this->check_api_result( $set_visibility ) ) {
-				Products::set_product_visibility( $product, $should_set_visible );
-			}
-
-		} else {
+		if ( $product->is_ty( 'variable' ) ) {
 
 			// parent product
 			Products::set_product_visibility( $product, $should_set_visible );
@@ -4330,6 +4315,21 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 			// sync product with all variations
 			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( $product_ids );
+
+		} else {
+
+			$fb_product_item_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product_id );
+
+			if ( ! $fb_product_item_id ) {
+				\WC_Facebookcommerce_Utils::fblog( $fb_product_item_id . " doesn't exist but underwent a visibility transform.", [], true );
+				 return;
+			}
+
+			$set_visibility = $this->fbgraph->update_product_item( $fb_product_item_id, [ 'visibility' => $visibility ] );
+
+			if ( $this->check_api_result( $set_visibility ) ) {
+				Products::set_product_visibility( $product, $should_set_visible );
+			}
 		}
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -991,7 +991,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @param \WP_post $post
 	 */
 	public function fb_change_product_published_status( $new_status, $old_status, $post ) {
-		global $post;
 
 		if ( ! $post ) {
 			return;

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4289,7 +4289,13 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		$should_set_visible = $visibility === self::FB_SHOP_PRODUCT_VISIBLE;
 
-		if ( $product->is_ty( 'variable' ) ) {
+		if ( $product->is_type( 'variation' ) ) {
+
+			Products::set_product_visibility( $product, $should_set_visible );
+
+			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( [ $product->get_id() ] );
+
+		} elseif ( $product->is_type( 'variable' ) ) {
 
 			// parent product
 			Products::set_product_visibility( $product, $should_set_visible );


### PR DESCRIPTION
# Summary

This PR updates `::fb_change_product_published_status()` to use the `$post` parameter instead of the `$post` global variable to access the current product and updates `update_fb_visibility()` to add specific handling for product variations.

## Details

The `::fb_change_product_published_status()` method is called when the status for a product or product variation changes. However, due to the usage of the global variable `$post`, when the method was called for a product variation, all the operations were performed on the parent product, once for every variation defined.

This occurs because when a variable product is being updated, the `$post` parameter passed to the method represents each one of the variations as each one of them is moved to the trash, but the global variable always points to the parent product.

These modifications reduce the number of operations performed during a status transition and should help to prevent timeout errors. We were previously calling `update_fb_visibility()` passing the variable product n times, where n is the number of variations. Then, in `update_fb_visibility()`, we were updating each variation of the variable product another n times, for a total of n x n attempts to update a products visibility.

### Story: [CH 55198](https://app.clubhouse.io/skyverge/story/55198)
### Release: #1277

## QA

## Setup

1. See https://skyverge.slack.com/archives/CR8VDB4G7/p1590167886097600 for details about how to connect using the WooCommerce Connect app, which is now live
1. You can also use a local version of the proxy with a personal Facebook App, as described in https://github.com/skyverge/wc-plugins/wiki/Facebook-for-WooCommerce

## Steps

### Trash a variable product

1. Move to Trash a variable product that has sync enabled
    - [x] One or more batch requests are made to update the products setting the visibility to `staging`