### PR TITLE
Do not log an error when product is null on add to cart redirect

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -386,8 +386,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			if ( $product instanceof \WC_Product ) {
 				WC()->session->set( 'facebook_for_woocommerce_last_product_added_to_cart', $product->get_id() );
-			} else {
-				facebook_for_woocommerce()->log( 'Cannot record AddToCart event because the product cannot be determined. Backtrace: ' . print_r( wp_debug_backtrace_summary(), true ) );
+			} elseif ( isset( $_GET['add-to-cart'] ) && is_numeric( $_GET['add-to-cart'] ) ) {
+				WC()->session->set( 'facebook_for_woocommerce_last_product_added_to_cart', (int) $_GET['add-to-cart'] );
 			}
 
 			return $redirect;


### PR DESCRIPTION
## Summary

Removes logging an error when a `WC_Product` is `null` while adding to cart upon redirect.

## Story:

- [ch55122](https://app.clubhouse.io/skyverge/story/55122/woocommerce-filter-is-causing-huge-amount-of-logging-6)

## Additional details

 [This filter](https://github.com/woocommerce/woocommerce/blob/f2cce7f03780b2843f6b1b0e798dd952d51afb53/includes/class-wc-frontend-scripts.php#L559-L559) may pass `null` in some circumstances. As fallback we can look for the `$_GET` value `add-to-cart` which carries the product ID. We can safely remove logging for now.

Targeting `master` as not part of v2.0 release.

## QA

- n/a