### PR TITLE
Fix background sync delete

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -4276,6 +4276,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		if ( $product_group_id ) {
 
+			// TODO: replace with a call to API::delete_product_group() {WV 2020-05-26}
 			$pg_result = $this->fbgraph->delete_product_group( $product_group_id );
 
 			\WC_Facebookcommerce_Utils::log( $pg_result );

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -959,9 +959,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		} elseif ( $product->is_type( 'variable' ) ) {
 
-			$product_ids = array_merge( [ $product_id ], $product->get_children() );
-
-			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( $product_ids );
+			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( $product->get_children() );
 
 		} else {
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -954,12 +954,25 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		if ( $product->is_type( 'variation' ) ) {
 
+			$retailer_id = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product );
+
 			// enqueue variation to be deleted in the background
-			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( [ $product->get_id() ] );
+			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( [ $retailer_id ] );
 
 		} elseif ( $product->is_type( 'variable' ) ) {
 
-			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( $product->get_children() );
+			$retailer_ids = [];
+
+			foreach ( $product->get_children() as $variation_id ) {
+
+				$variation = wc_get_product( $variation_id );
+
+				if ( $variation instanceof \WC_Product ) {
+					$retailer_ids[] = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $variation );
+				}
+			}
+
+			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( $retailer_ids );
 
 			$this->delete_product_group( $product_id );
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -952,7 +952,12 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			return;
 		}
 
-		if ( $product->is_type( 'variable' ) ) {
+		if ( $product->is_type( 'variation' ) ) {
+
+			// enqueue variation to be deleted in the background
+			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( [ $product->get_id() ] );
+
+		} elseif ( $product->is_type( 'variable' ) ) {
 
 			$product_ids = array_merge( [ $product_id ], $product->get_children() );
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -970,15 +970,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			}
 		}
 
-
-		$fb_product_group_id = $this->get_product_fbid( self::FB_PRODUCT_GROUP_ID, $product_id );
-
-		if ( $fb_product_group_id ) {
-
-			$pg_result = $this->fbgraph->delete_product_group( $fb_product_group_id );
-
-			\WC_Facebookcommerce_Utils::log( $pg_result );
-		}
+		$this->delete_product_group( $product_id );
 
 		$this->enable_product_sync_delay_admin_notice();
 	}
@@ -4258,6 +4250,27 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			WC_Facebookcommerce_Utils::log( $pi_result );
 		}
 	}
+
+
+	/**
+	 * Uses the Graph API to delete the Product Group associated with the given product.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param int $product_id product ID
+	 */
+	private function delete_product_group( $product_id ) {
+
+		$product_group_id = $this->get_product_fbid( self::FB_PRODUCT_GROUP_ID, $product_id );
+
+		if ( $product_group_id ) {
+
+			$pg_result = $this->fbgraph->delete_product_group( $product_group_id );
+
+			\WC_Facebookcommerce_Utils::log( $pg_result );
+		}
+	}
+
 
 	function fb_duplicate_product_reset_meta( $to_delete ) {
 		array_push( $to_delete, self::FB_PRODUCT_ITEM_ID );

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -952,19 +952,19 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			return;
 		}
 
-		if ( ! $product->is_type( 'variable' ) ) {
+		if ( $product->is_type( 'variable' ) ) {
+
+			$product_ids = array_merge( [ $product_id ], $product->get_children() );
+
+			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( $product_ids );
+
+		} else {
 
 			$fb_product_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product_id );
 
 			if ( $fb_product_id ) {
 				$this->delete_product_item( $product_id );
 			}
-
-		} else {
-
-			$product_ids = array_merge( [ $product_id ], $product->get_children() );
-
-			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( $product_ids );
 		}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -961,6 +961,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( $product->get_children() );
 
+			$this->delete_product_group( $product_id );
+
 		} else {
 
 			$fb_product_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product_id );
@@ -968,9 +970,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			if ( $fb_product_id ) {
 				$this->delete_product_item( $product_id );
 			}
-		}
 
-		$this->delete_product_group( $product_id );
+			$this->delete_product_group( $product_id );
+		}
 
 		$this->enable_product_sync_delay_admin_notice();
 	}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -972,6 +972,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				}
 			}
 
+			// enqueue variations to be deleted in the background
 			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( $retailer_ids );
 
 			$this->delete_product_group( $product_id );

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -965,12 +965,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		} else {
 
-			$fb_product_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product_id );
-
-			if ( $fb_product_id ) {
-				$this->delete_product_item( $product_id );
-			}
-
+			$this->delete_product_item( $product_id );
 			$this->delete_product_group( $product_id );
 		}
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -74,16 +74,16 @@ class Sync {
 
 
 	/**
-	 * Adds the given product IDs to the requests array to be deleted.
+	 * Adds the given retailer IDs to the requests array to be deleted.
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param int[] $product_ids
+	 * @param int[] $retailer retailer IDs to delete
 	 */
-	public function delete_products( array $product_ids ) {
+	public function delete_products( array $retailer_ids ) {
 
-		foreach ( $product_ids as $product_id ) {
-			$this->requests[ $this->get_product_index( $product_id ) ] = self::ACTION_DELETE;
+		foreach ( $retailer_ids as $retailer_id ) {
+			$this->requests[ $retailer_id ] = self::ACTION_DELETE;
 		}
 	}
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -111,13 +111,11 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 		$processed = 0;
 		$requests  = [];
 
-		foreach ( $data as $prefixed_product_id => $method ) {
-
-			$product_id = (int) str_replace( Sync::PRODUCT_INDEX_PREFIX, '', $prefixed_product_id );
+		foreach ( $data as $item_id => $method ) {
 
 			try {
 
-				$requests[] = $this->process_item( [ $product_id, $method ], $job );
+				$requests[] = $this->process_item( [ $item_id, $method ], $job );
 
 			} catch ( Framework\SV_WC_Plugin_Exception $e )	{
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -169,22 +169,16 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 */
 	public function process_item( $item, $job ) {
 
-		list( $product_id, $method ) = $item;
-
-		$product = wc_get_product( $product_id );
-
-		if ( ! $product instanceof \WC_Product ) {
-			throw new Framework\SV_WC_Plugin_Exception( "No product found with ID equal to {$product_id}." );
-		}
+		list( $item_id, $method ) = $item;
 
 		if ( ! in_array( $method, [ Sync::ACTION_UPDATE, Sync::ACTION_DELETE ], true ) ) {
 			throw new Framework\SV_WC_Plugin_Exception( "Invalid sync request method: {$method}." );
 		}
 
 		if ( Sync::ACTION_UPDATE === $method ) {
-			$request = $this->process_item_update( $product );
+			$request = $this->process_item_update( $item_id );
 		} else {
-			$request = $this->process_item_delete( $product );
+			$request = $this->process_item_delete( $item_id );
 		}
 
 		return $request;

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -196,11 +196,18 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param \WC_Product $product product object
+	 * @param string $prefixed_product_id prefixed product ID
 	 * @return array
 	 * @throws Framework\SV_WC_Plugin_Exception
 	 */
-	private function process_item_update( $product ) {
+	private function process_item_update( $prefixed_product_id ) {
+
+		$product_id = (int) str_replace( Sync::PRODUCT_INDEX_PREFIX, '', $prefixed_product_id );
+		$product    = wc_get_product( $product_id );
+
+		if ( ! $product instanceof \WC_Product ) {
+			throw new Framework\SV_WC_Plugin_Exception( "No product found with ID equal to {$product_id}." );
+		}
 
 		if ( $product->is_type( 'variation' ) ) {
 			$product_data = $this->prepare_product_variation_data( $product );

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -320,12 +320,12 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param \WC_Product $product product object
+	 * @param string $retailer product retailer ID
 	 */
-	private function process_item_delete( $product ) {
+	private function process_item_delete( $retailer_id ) {
 
 		$request = [
-			'retailer_id' => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
+			'retailer_id' => $retailer_id,
 			'method'      => Sync::ACTION_DELETE,
 		];
 
@@ -335,9 +335,9 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 		 * @since 2.0.0-dev.1
 		 *
 		 * @param array $request request data
-		 * @param \WC_Product $product product object
+		 * @param string $retailer product retailer ID
 		 */
-		return apply_filters( 'wc_facebook_sync_background_item_delete_request', $request, $product );
+		return apply_filters( 'wc_facebook_sync_background_item_delete_request', $request, $retailer_id );
 	}
 
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -42,27 +42,22 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
      *
      * @dataProvider provider_delete_products()
      */
-    public function test_delete_products( $product_ids ) {
-
-        // TODO: remove when this file is included in the main plugin class {WV 2020-05-19}
-	    if ( ! class_exists( Sync::class ) ) {
-            require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/Products/Sync.php';
-	    }
+    public function test_delete_products( $retailer_ids ) {
 
         $sync = new Sync();
 
-        $sync->delete_products( $product_ids );
+        $sync->delete_products( $retailer_ids );
 
         $requests_property = new ReflectionProperty( Sync::class, 'requests' );
         $requests_property->setAccessible( true );
 
         $requests = $requests_property->getValue( $sync );
 
-        foreach ( $product_ids as $product_id ) {
-            $this->assertEquals( Sync::ACTION_DELETE, $requests["p-{$product_id}"] );
+        foreach ( $retailer_ids as $retailer_id ) {
+            $this->assertEquals( Sync::ACTION_DELETE, $requests[ $retailer_id ] );
         }
 
-        $this->assertEquals( count( $requests ), count( $product_ids ) );
+        $this->assertEquals( count( $requests ), count( $retailer_ids ) );
     }
 
 
@@ -71,7 +66,7 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 
         return [
             [ [] ],
-            [ [ 1, 2, 3, 4 ] ],
+            [ [ "wc_post_id_1", "wc_post_id_2", "sku_3" ] ],
         ];
 	}
 


### PR DESCRIPTION
# Summary

This PRs updates the Sync Background handler to expect the retailer ID instead of the product ID for product delete requests.

## Details

Additionally, this PR updates `::on_product_delete` to give specal treatment to product variations. If a variable product is deleted, the method is called both for the product variations and the variable product. We were previously treating each variation as a simple product: trying to delete then while the page was being processed, using an API request for each variation.

### Story: [CH 55206](https://app.clubhouse.io/skyverge/story/55206)
### Release: #1277

## QA

## Setup

1. See https://skyverge.slack.com/archives/CR8VDB4G7/p1590167886097600 for details about how to connect using the WooCommerce Connect app, which is now live
1. You can also use a local version of the proxy with a personal Facebook App, as described in https://github.com/skyverge/wc-plugins/wiki/Facebook-for-WooCommerce

## Steps

### Trash a variable product

1. Move to Trash a variable product that is synced
    - [x] One or more batch requests are made to update the products setting the visibility to `staging`
1. Delete the variable product permanently
    - [x] One or more batch requests are made to delete the products