### PR TITLE
S2S: Create the event API request object

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -274,6 +274,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Response.php';
 				}
 
+				if ( ! class_exists( API\Pixel\Events\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Pixel/Events/Request.php';
+				}
+
 				if ( ! class_exists( API\Business_Manager\Request::class ) ) {
 					require_once __DIR__ . '/includes/API/Business_Manager/Request.php';
 				}

--- a/includes/API.php
+++ b/includes/API.php
@@ -407,9 +407,13 @@ class API extends Framework\SV_WC_API_Base {
 	 * @return Response
 	 * @throws Framework\SV_WC_API_Exception
 	 */
-	public function send_pixel_events( $pixel_id, $events ) {
+	public function send_pixel_events( $pixel_id, array $events ) {
 
-		// TODO: implement send_pixel_events
+		$request = new API\Pixel\Events\Request( $pixel_id, $events );
+
+		$this->set_response_handler( Response::class );
+
+		return $this->perform_request( $request );
 	}
 
 

--- a/includes/API/Pixel/Events/Request.php
+++ b/includes/API/Pixel/Events/Request.php
@@ -60,7 +60,23 @@ class Request extends API\Request {
 				continue;
 			}
 
-			$data['data'][] = $event->get_data();
+			$event_data = $event->get_data();
+
+			if ( isset( $event_data['user_data']['click_id'] ) ) {
+
+				$event_data['user_data']['fbc'] = $event_data['user_data']['click_id'];
+
+				unset( $event_data['user_data']['click_id'] );
+			}
+
+			if ( isset( $event_data['user_data']['browser_id'] ) ) {
+
+				$event_data['user_data']['fbp'] = $event_data['user_data']['browser_id'];
+
+				unset( $event_data['user_data']['browser_id'] );
+			}
+
+			$data['data'][] = array_filter( $event_data );
 		}
 
 		return $data;

--- a/includes/API/Pixel/Events/Request.php
+++ b/includes/API/Pixel/Events/Request.php
@@ -79,7 +79,15 @@ class Request extends API\Request {
 			$data['data'][] = array_filter( $event_data );
 		}
 
-		return $data;
+		/**
+		 * Filters the Pixel event API request data.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param array $data request data
+		 * @param Request $request request object
+		 */
+		return apply_filters( 'wc_facebook_api_pixel_event_request_data', $data, $this);
 	}
 
 

--- a/includes/API/Pixel/Events/Request.php
+++ b/includes/API/Pixel/Events/Request.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Pixel\Events;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+use SkyVerge\WooCommerce\Facebook\Events\Event;
+
+/**
+ * Base S2S API request object.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Request extends API\Request {
+
+
+	/** @var Event[] events to send */
+	private $events;
+
+
+	/**
+	 * Request constructor.
+	 *
+	 * @param string $pixel_id
+	 * @param Event[] $events events to send
+	 */
+	public function __construct( $pixel_id, array $events ) {
+
+		$this->events = $events;
+
+		parent::__construct( "/{$pixel_id}/events", 'POST' );
+	}
+
+
+	/**
+	 * Gets the request data.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+
+		$data = [
+			'data' => [],
+		];
+
+		foreach ( $this->events as $event ) {
+
+			if ( ! $event instanceof Event ) {
+				continue;
+			}
+
+			$data['data'][] = $event->get_data();
+		}
+
+		return $data;
+	}
+
+
+}

--- a/tests/integration/API/Pixel/Events/RequestTest.php
+++ b/tests/integration/API/Pixel/Events/RequestTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Pixel\Events;
+
+use SkyVerge\WooCommerce\Facebook\API\Pixel\Events\Request;
+use SkyVerge\WooCommerce\Facebook\Events\Event;
+
+/**
+ * Tests the Pixel events API request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		require_once 'includes/Events/Event.php';
+
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Request::class ) ) {
+			require_once 'includes/API/Request.php';
+		}
+
+		if ( ! class_exists( Request::class ) ) {
+			require_once 'includes/API/Pixel/Events/Request.php';
+		}
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Request::__construct() */
+	public function test_constructor() {
+
+		$event = new Event( [
+			'event_name' => 'Test',
+		] );
+
+		$request = new Request( '1234', [ $event ] );
+
+		$this->assertEquals( '/1234/events', $request->get_path() );
+		$this->assertEquals( 'POST', $request->get_method() );
+	}
+
+
+	/** @see Request::get_data() */
+	public function test_get_data() {
+
+		$event = new Event( [
+			'event_name' => 'Test',
+		] );
+
+		$request = new Request( '1234', [ $event ] );
+		$data    = $request->get_data();
+
+		$this->assertArrayHasKey( 'data', $data );
+		$this->assertIsArray( $data['data'] );
+		$this->assertNotEmpty( $data['data'] );
+		$this->assertArrayHasKey( 'event_name', $data['data'][0] );
+	}
+
+
+}

--- a/tests/integration/API/Pixel/Events/RequestTest.php
+++ b/tests/integration/API/Pixel/Events/RequestTest.php
@@ -19,7 +19,9 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		require_once 'includes/Events/Event.php';
+		if ( ! class_exists( Event::class ) ) {
+			require_once 'includes/Events/Event.php';
+		}
 
 		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Request::class ) ) {
 			require_once 'includes/API/Request.php';

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -482,7 +482,25 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @see API::send_pixel_events() */
 	public function test_send_pixel_events() {
 
-		// TODO: implement
+		$pixel_id = '123456';
+
+		$events = [
+			new \SkyVerge\WooCommerce\Facebook\Events\Event( [ 'event_name' => 'Test' ] ),
+		];
+
+		// test will fail if do_remote_request() is not called once
+		$api = $this->make( API::class, [
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
+		] );
+
+		$api->send_pixel_events( $pixel_id, $events );
+
+		$this->assertInstanceOf( SkyVerge\WooCommerce\Facebook\API\Pixel\Events\Request::class, $api->get_request() );
+		$this->assertEquals( 'POST', $api->get_request()->get_method() );
+		$this->assertEquals( "/{$pixel_id}/events", $api->get_request()->get_path() );
+		$this->assertArrayHasKey( 'data', $api->get_request()->get_data() );
+
+		$this->assertInstanceOf( Response::class, $api->get_response() );
 	}
 
 


### PR DESCRIPTION
# Summary

Implements the objects needed to make S2S API requests.

### Story: [CH 55392](https://app.clubhouse.io/skyverge/story/55392)
### Release: #1369 

## UI Changes

N/A

## QA

- [x] `codecept run integration` tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version