### PR TITLE
S2S: Update the build_event method

### DIFF
--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -398,8 +398,14 @@ if ( ! class_exists( 'WC_Facebookcommerce_Pixel' ) ) :
 		 */
 		public static function build_event( $event_name, $params, $method = 'track' ) {
 
+			// do not send the event name in the params
 			if ( isset( $params['event_name'] ) ) {
 				unset( $params['event_name'] );
+			}
+
+			// if custom data is set, send only the custom data
+			if ( isset( $params['custom_data'] ) ) {
+				$params = $params['custom_data'];
 			}
 
 			return sprintf(

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -403,19 +403,42 @@ if ( ! class_exists( 'WC_Facebookcommerce_Pixel' ) ) :
 				unset( $params['event_name'] );
 			}
 
+			// if possible, send the event ID to avoid duplication
+			// @see https://developers.facebook.com/docs/marketing-api/server-side-api/deduplicate-pixel-and-server-side-events#deduplication-best-practices
+			if ( isset( $params['event_id'] ) ) {
+				$event_id = $params['event_id'];
+			}
+
 			// if custom data is set, send only the custom data
 			if ( isset( $params['custom_data'] ) ) {
 				$params = $params['custom_data'];
 			}
 
-			return sprintf(
-				"/* %s Facebook Integration Event Tracking */\n" .
-				"fbq('%s', '%s', %s);",
-				WC_Facebookcommerce_Utils::getIntegrationName(),
-				esc_js( $method ),
-				esc_js( $event_name ),
-				json_encode( self::build_params( $params, $event_name ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
-			);
+			if ( ! empty( $event_id ) ) {
+
+				$event = sprintf(
+					"/* %s Facebook Integration Event Tracking */\n" .
+					"fbq('%s', '%s', %s, %s);",
+					WC_Facebookcommerce_Utils::getIntegrationName(),
+					esc_js( $method ),
+					esc_js( $event_name ),
+					json_encode( self::build_params( $params, $event_name ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ),
+					json_encode( [ 'eventID' => $event_id ], JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
+				);
+
+			} else {
+
+				$event = sprintf(
+					"/* %s Facebook Integration Event Tracking */\n" .
+					"fbq('%s', '%s', %s);",
+					WC_Facebookcommerce_Utils::getIntegrationName(),
+					esc_js( $method ),
+					esc_js( $event_name ),
+					json_encode( self::build_params( $params, $event_name ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
+				);
+			}
+
+			return $event;
 		}
 
 

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -398,6 +398,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_Pixel' ) ) :
 		 */
 		public static function build_event( $event_name, $params, $method = 'track' ) {
 
+			if ( isset( $params['event_name'] ) ) {
+				unset( $params['event_name'] );
+			}
+
 			return sprintf(
 				"/* %s Facebook Integration Event Tracking */\n" .
 				"fbq('%s', '%s', %s);",

--- a/tests/integration/WC_Facebookcommerce_Pixel_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Pixel_Test.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * Tests the WC_Facebookcommerce_Pixel class.
+ */
+class WC_Facebookcommerce_Pixel_Test extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+
+	}
+
+
+	/**
+	 * Runs after each test.
+	 */
+	protected function _after() {
+
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see \WC_Facebookcommerce_Pixel::build_event()
+	 *
+	 * @param string $event_name event name
+	 * @param array $params event params
+	 * @param array $contains set of strings the event is expected to contain
+	 * @param array $does_not_contain set of strings the event is expected not to contain
+	 *
+	 * @dataProvider provider_build_event
+	 */
+	public function test_build_event( $event_name, $params, $contains, $does_not_contain ) {
+
+		$event = WC_Facebookcommerce_Pixel::build_event( $event_name, $params );
+
+		foreach ( $contains as $string ) {
+			$this->assertStringContainsString( $string, $event );
+		}
+
+		foreach ( $does_not_contain as $string ) {
+			$this->assertStringNotContainsString( $string, $event );
+		}
+	}
+
+
+	/** @see test_build_event */
+	public function provider_build_event() {
+
+		return [
+			'old_format'  => [
+				'AddToCart',
+				[
+					'source'       => 'woocommerce',
+					'version'      => '4.1.1',
+					'content_ids'  => [ 'wc_post_id_5518' ],
+					'content_type' => 'product',
+					'contents'     => [ 'id' => 'wc_post_id_5518', 'quantity' => 5 ],
+					'value'        => '70.00',
+					'currency'     => 'CAD',
+				],
+				[
+					'/* WooCommerce Facebook Integration Event Tracking */',
+					'fbq(\'track\', \'AddToCart\', {',
+					'"source": "woocommerce",',
+					'"version": "4.1.1",',
+					'"pluginVersion": "2.0.0-dev.1",',
+					'"content_ids": {',
+					'"content_type": "product",',
+					'"contents": {',
+					'"id": "wc_post_id_5518",',
+					'"quantity": 5',
+				],
+				[],
+			],
+			'event_name'  => [
+				'AddToCart',
+				[
+					'event_name'   => 'Name',
+					'source'       => 'woocommerce',
+					'version'      => '4.1.1',
+					'content_ids'  => [ 'wc_post_id_5518' ],
+					'content_type' => 'product',
+					'contents'     => [ 'id' => 'wc_post_id_5518', 'quantity' => 5 ],
+					'value'        => '70.00',
+					'currency'     => 'CAD',
+				],
+				[
+					'/* WooCommerce Facebook Integration Event Tracking */',
+					'fbq(\'track\', \'AddToCart\', {',
+					'"source": "woocommerce",',
+					'"version": "4.1.1",',
+					'"pluginVersion": "2.0.0-dev.1",',
+					'"content_ids": {',
+					'"content_type": "product",',
+					'"contents": {',
+					'"id": "wc_post_id_5518",',
+					'"quantity": 5',
+				],
+				[
+					'Name',
+				],
+			],
+			'event_id'    => [
+				'AddToCart',
+				[
+					'event_id'     => '123456',
+					'source'       => 'woocommerce',
+					'version'      => '4.1.1',
+					'content_ids'  => [ 'wc_post_id_5518' ],
+					'content_type' => 'product',
+					'contents'     => [ 'id' => 'wc_post_id_5518', 'quantity' => 5 ],
+					'value'        => '70.00',
+					'currency'     => 'CAD',
+				],
+				[
+					'/* WooCommerce Facebook Integration Event Tracking */',
+					'fbq(\'track\', \'AddToCart\', {',
+					'"source": "woocommerce",',
+					'"version": "4.1.1",',
+					'"pluginVersion": "2.0.0-dev.1",',
+					'"content_ids": {',
+					'"content_type": "product",',
+					'"contents": {',
+					'"id": "wc_post_id_5518",',
+					'"quantity": 5',
+					'"eventID": "123456"'
+				],
+				[],
+			],
+			'custom_data' => [
+				'AddToCart',
+				[
+					'other'       => 'data',
+					'custom_data' => [
+						'source'       => 'woocommerce',
+						'version'      => '4.1.1',
+						'content_ids'  => [ 'wc_post_id_5518' ],
+						'content_type' => 'product',
+						'contents'     => [ 'id' => 'wc_post_id_5518', 'quantity' => 5 ],
+						'value'        => '70.00',
+						'currency'     => 'CAD',
+					],
+				],
+				[
+					'/* WooCommerce Facebook Integration Event Tracking */',
+					'fbq(\'track\', \'AddToCart\', {',
+					'"source": "woocommerce",',
+					'"version": "4.1.1",',
+					'"pluginVersion": "2.0.0-dev.1",',
+					'"content_ids": {',
+					'"content_type": "product",',
+					'"contents": {',
+					'"id": "wc_post_id_5518",',
+					'"quantity": 5',
+				],
+				[
+					'custom_data',
+					'other',
+				],
+			],
+		];
+	}
+
+
+}
+


### PR DESCRIPTION
# Summary

This PRs updates the build_event method.

### Story: [CH 55402](https://app.clubhouse.io/skyverge/story/55402/update-the-build-event-method)
### Release: #1369

## Details

Updates the build_event method to:
- unset the `$params['event_name']` if needed
- send the `$params['custom_data']` if provided
- send the `$params['event_id']` if provided

## Open questions

- [ ] Can the `event_name` and `event_id` be sent inside the `custom_data` element as well? Right now the code only accounts for it outside of the `custom_data` element.

## QA

- [ ] Integration tests pass