### PR TITLE
S2S: Handle the AddToCart event

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -253,6 +253,19 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
+			$event_data = [
+				'event_name'  => 'AddToCart',
+				'custom_data' => [
+					'content_ids'  => $this->get_cart_content_ids(),
+					'content_type' => 'product',
+					'contents'     => $this->get_cart_contents(),
+					'value'        => $this->get_cart_total(),
+					'currency'     => get_woocommerce_currency(),
+				],
+			];
+
+			$event = new SkyVerge\WooCommerce\Facebook\Events\Event( $event_data );
+
 			$this->pixel->inject_event( 'AddToCart', [
 				'content_ids'  => $this->get_cart_content_ids(),
 				'content_type' => 'product',

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -317,6 +317,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			if ( self::$isEnabled ) {
 
+				// TODO: make sure this won't create duplicated events, since the event_id is not sent
 				$script = $this->pixel->get_event_script( 'AddToCart', [
 					'content_ids'  => $this->get_cart_content_ids(),
 					'content_type' => 'product',
@@ -373,6 +374,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					'currency'     => get_woocommerce_currency(),
 				];
 
+				// TODO: make sure this won't create duplicated events, since the event_id is not sent
 				$script = $this->pixel->get_conditional_one_time_event_script( 'AddToCart', $params, 'added_to_cart' );
 
 				$fragments['div.wc-facebook-pixel-event-placeholder'] = '<div class="wc-facebook-pixel-event-placeholder">' . $script . '</div>';

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -326,20 +326,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				],
 			];
 
-			$event    = new SkyVerge\WooCommerce\Facebook\Events\Event( $event_data );
-			$pixel_id = facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id();
+			$event = new SkyVerge\WooCommerce\Facebook\Events\Event( $event_data );
 
-			// send the event S2S
-			try {
-
-				facebook_for_woocommerce()->get_api()->send_pixel_events( $pixel_id, [ $event ] );
-
-			} catch ( \SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Exception $exception ) {
-
-				if ( facebook_for_woocommerce()->get_integration()->is_debug_mode_enabled() ) {
-					facebook_for_woocommerce()->log( 'Could not send Pixel event: ' . $exception->getMessage() );
-				}
-			}
+			$this->send_api_event( $event );
 
 			// send the event ID to prevent duplication
 			$event_data['event_id'] = $event->get_id();

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -279,13 +279,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				}
 			}
 
-			$this->pixel->inject_event( 'AddToCart', [
-				'content_ids'  => $this->get_cart_content_ids(),
-				'content_type' => 'product',
-				'contents'     => $this->get_cart_contents(),
-				'value'        => $this->get_cart_total(),
-				'currency'     => get_woocommerce_currency(),
-			] );
+			// add the event ID to prevent duplication
+			$event_data['event_id'] = $event->get_id();
+
+			$this->pixel->inject_event( 'AddToCart', $event_data );
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -283,7 +283,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$event_data['event_id'] = $event->get_id();
 
 			// store the ID in the session to be sent in AJAX JS event tracking as well
-			WC()->session->set( 'add_to_cart_event_id', $event->get_id() );
+			WC()->session->set( 'facebook_for_woocommerce_add_to_cart_event_id', $event->get_id() );
 
 			$this->pixel->inject_event( 'AddToCart', $event_data );
 		}
@@ -329,7 +329,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				];
 
 				// send the event ID to prevent duplication
-				if ( ! empty ( $event_id = WC()->session->get( 'add_to_cart_event_id' ) ) ) {
+				if ( ! empty ( $event_id = WC()->session->get( 'facebook_for_woocommerce_add_to_cart_event_id' ) ) ) {
 
 					$params['event_id'] = $event_id;
 				}
@@ -385,7 +385,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				];
 
 				// send the event ID to prevent duplication
-				if ( ! empty ( $event_id = WC()->session->get( 'add_to_cart_event_id' ) ) ) {
+				if ( ! empty ( $event_id = WC()->session->get( 'facebook_for_woocommerce_add_to_cart_event_id' ) ) ) {
 
 					$params['event_id'] = $event_id;
 				}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -264,7 +264,20 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				],
 			];
 
-			$event = new SkyVerge\WooCommerce\Facebook\Events\Event( $event_data );
+			$event    = new SkyVerge\WooCommerce\Facebook\Events\Event( $event_data );
+			$pixel_id = facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id();
+
+			// send the event S2S
+			try {
+
+				facebook_for_woocommerce()->get_api()->send_pixel_events( $pixel_id, [ $event ] );
+
+			} catch ( \SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Exception $exception ) {
+
+				if ( facebook_for_woocommerce()->get_integration()->is_debug_mode_enabled() ) {
+					facebook_for_woocommerce()->log( 'Could not send Pixel event: ' . $exception->getMessage() );
+				}
+			}
 
 			$this->pixel->inject_event( 'AddToCart', [
 				'content_ids'  => $this->get_cart_content_ids(),

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -319,6 +319,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'event_name'  => 'AddToCart',
 				'custom_data' => [
 					'content_ids'  => $this->get_cart_content_ids(),
+					'content_name' => $this->get_cart_content_names(),
 					'content_type' => 'product',
 					'contents'     => $this->get_cart_contents(),
 					'value'        => $this->get_cart_total(),
@@ -373,6 +374,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 				$params = [
 					'content_ids'  => $this->get_cart_content_ids(),
+					'content_name' => $this->get_cart_content_names(),
 					'content_type' => 'product',
 					'contents'     => $this->get_cart_contents(),
 					'value'        => $this->get_cart_total(),
@@ -429,6 +431,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 				$params = [
 					'content_ids'  => $this->get_cart_content_ids(),
+					'content_name' => $this->get_cart_content_names(),
 					'content_type' => 'product',
 					'contents'     => $this->get_cart_contents(),
 					'value'        => $this->get_cart_total(),
@@ -770,6 +773,32 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			}
 
 			return wp_json_encode( array_unique( array_merge( ... $product_ids ) ) );
+		}
+
+
+		/**
+		 * Gets all content names from cart.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @return string JSON data
+		 */
+		private function get_cart_content_names() {
+
+			$product_names = [];
+
+			if ( $cart = WC()->cart ) {
+
+				foreach ( $cart->get_cart() as $item ) {
+
+					if ( isset( $item['data'] ) && $item['data'] instanceof \WC_Product ) {
+
+						$product_names[] = $item['data']->get_name();
+					}
+				}
+			}
+
+			return wp_json_encode( array_unique( $product_names ) );
 		}
 
 


### PR DESCRIPTION
# Summary

This PRs updates the `WC_Facebookcommerce_EventsTracker::inject_add_to_cart_event` method to send the event server-side and add the event ID to the JS script.

### Story: [CH 55398](https://app.clubhouse.io/skyverge/story/55398/handle-the-addtocart-event)
### Release: #1369

## QA

### Setup

- Enable the Facebook Pixel Helper extension
- Click Troubleshoot Pixel and start listening to Pixel events
- Enable logging for the plugin

### Regular add to cart

1. Navigate to a product page
1. Click Add to cart
    - [x] An API call is made with an event ID
    - [x] The JS event is triggered with the same event ID (check in the Events Manager) 

### AJAX add to cart

1. Enable AJAX add to cart, if needed
1. Navigate to the Shop page
1. Click Add to cart on a product
    - [x] An API call is made with an event ID
    - [x] The JS event is triggered with the same event ID (check in the Events Manager) 