### PR TITLE
S2S: Handle the ViewContent event

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -237,18 +237,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$event = new \SkyVerge\WooCommerce\Facebook\Events\Event( $event_data );
 
-			try {
+			$this->send_api_event( $event );
 
-				facebook_for_woocommerce()->get_api()->send_pixel_events( facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id(), [ $event ] );
-
-				$event_data['event_id'] = $event->get_id();
-
-			} catch ( \SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Exception $exception ) {
-
-				if ( facebook_for_woocommerce()->get_integration()->is_debug_mode_enabled() ) {
-					facebook_for_woocommerce()->log( 'Could not send Pixel event: ' . $exception->getMessage() );
-				}
-			}
+			$event_data['event_id'] = $event->get_id();
 
 			$this->pixel->inject_event( 'ViewContent', $event_data );
 		}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -219,7 +219,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				$content_type = 'product';
 			}
 
-			$categories = \WC_Facebookcommerce_Utils::get_product_categories( get_the_ID() );
+			$categories = \WC_Facebookcommerce_Utils::get_product_categories( $product->get_id() );
 
 			$event_data = [
 				'event_name'  => 'ViewContent',


### PR DESCRIPTION
# Summary

Updates `::inject_view_content_event()` to call the S2S API for the event.

### Story: [CH 55484](https://app.clubhouse.io/skyverge/story/55484)
### Release: #1375 

## QA

### Setup

- Get set up using the current instructions: https://github.com/skyverge/wc-plugins/wiki/Facebook-for-WooCommerce#s2s-pixel-tracking

1. Visit a product page
    - [x] The JS event is logged correctly
    - [x] The server-side event is logged (may not show up in Business Manager, since it's a duplicate event) 