### PR TITLE
S2S: Handle the ViewCategory event

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -113,7 +113,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_view_category_event() {
 			global $wp_query;
-			if ( ! self::$isEnabled ) {
+
+			if ( ! self::$isEnabled || ! is_product_category() ) {
 				return;
 			}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -143,19 +143,26 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				}
 			}
 
-			$categories =
-			WC_Facebookcommerce_Utils::get_product_categories( get_the_ID() );
+			$categories = WC_Facebookcommerce_Utils::get_product_categories( get_the_ID() );
 
-			$this->pixel->inject_event(
-				'ViewCategory',
-				array(
+			$event_name = 'ViewCategory';
+			$event_data = [
+				'event_name' => $event_name,
+				'custom_data' => [
 					'content_name'     => $categories['name'],
 					'content_category' => $categories['categories'],
 					'content_ids'      => json_encode( array_slice( $product_ids, 0, 10 ) ),
 					'content_type'     => $content_type,
-				),
-				'trackCustom'
-			);
+				],
+			];
+
+			$event = new Event( $event_data );
+
+			$this->send_api_event( $event );
+
+			$event_data['event_id'] = $event->get_id();
+
+			$this->pixel->inject_event( $event_name, $event_data, 'trackCustom' );
 		}
 
 		/**


### PR DESCRIPTION
# Summary

Updates `::inject_view_category_event()` to call the S2S API for the event.

### Story: [CH 55504](https://app.clubhouse.io/skyverge/story/55504)
### Release: #1375 

## QA

### Setup

- Get set up using the current instructions: https://github.com/skyverge/wc-plugins/wiki/Facebook-for-WooCommerce#s2s-pixel-tracking

1. Visit the shop page
    - [x] No events are fired
1. Visit a product category archive page
    - [x] The JS event is logged correctly
    - [x] The server-side event is logged with the same content parameters