### PR TITLE
S2S: Handle the search event

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -172,7 +172,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				}
 
 				if ( WC_Facebookcommerce_Utils::isWoocommerceIntegration() ) {
-					$this->actually_inject_search_event();
+					add_action( 'woocommerce_before_shop_loop', array( $this, 'actually_inject_search_event' ) );
 				} else {
 					add_action( 'wp_head', array( $this, 'actually_inject_search_event' ), 11 );
 				}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -183,7 +183,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * Triggers Search for result pages
 		 */
 		public function actually_inject_search_event() {
-			if ( ! self::$isEnabled ) {
+			global $wp_query;
+
+			if ( ! self::$isEnabled || empty( $_GET['post_type'] ) || 'product' !== $_GET['post_type'] ) {
 				return;
 			}
 


### PR DESCRIPTION
# Summary

Updates `::actually_inject_search_event()` to call the S2S API for the event.

### Story: [CH 55505](https://app.clubhouse.io/skyverge/story/55505)
### Release: #1375 

## QA

### Setup

- Get set up using the current instructions: https://github.com/skyverge/wc-plugins/wiki/Facebook-for-WooCommerce#s2s-pixel-tracking

1. Use frontend search with a keyword that will return a subset of products
    - [x] The JS event is logged correctly
    - [x] The server-side event is logged with the same content parameters
    - [x] Both events contain the correct `value` amount for all of the products total