### PR TITLE
S2S: Handle the InitiateCheckout event

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -545,13 +545,25 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			$this->pixel->inject_event( 'InitiateCheckout', [
-				'num_items'    => $this->get_cart_num_items(),
-				'content_ids'  => $this->get_cart_content_ids(),
-				'content_type' => 'product',
-				'value'        => $this->get_cart_total(),
-				'currency'     => get_woocommerce_currency(),
-			] );
+			$event_name = 'InitiateCheckout';
+			$event_data = [
+				'event_name'  => $event_name,
+				'custom_data' => [
+					'num_items'    => $this->get_cart_num_items(),
+					'content_ids'  => $this->get_cart_content_ids(),
+					'content_type' => 'product',
+					'value'        => $this->get_cart_total(),
+					'currency'     => get_woocommerce_currency(),
+				],
+			];
+
+			$event = new Event( $event_data );
+
+			$this->send_api_event( $event );
+
+			$event_data['event_id'] = $event->get_id();
+
+			$this->pixel->inject_event( $event_name, $event_data );
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -551,7 +551,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'custom_data' => [
 					'num_items'    => $this->get_cart_num_items(),
 					'content_ids'  => $this->get_cart_content_ids(),
+					'content_name' => $this->get_cart_content_names(),
 					'content_type' => 'product',
+					'contents'     => $this->get_cart_contents(),
 					'value'        => $this->get_cart_total(),
 					'currency'     => get_woocommerce_currency(),
 				],


### PR DESCRIPTION
# Summary

This PRs updates the `WC_Facebookcommerce_EventsTracker::inject_initiate_checkout_event()` method to send the event server-side and add the event ID to the JS script.

### Story: [CH 55489](https://app.clubhouse.io/skyverge/story/55489/handle-the-initiatecheckout-event)
### Release: #1369

## QA

### Setup

- Enable the Facebook Pixel Helper extension
- Click Troubleshoot Pixel and start listening to Pixel events
- Enable logging for the plugin

### Steps

1. Add some products to the cart
1. Proceed to Checkout
    - [ ] An API call is made to create an `InitiateCheckout` event, with an event ID
    - [ ] The corresponding JS event is triggered with the same event ID (check in the Events Manager or Pixel Helper)