### PR TITLE
Add upgrade routine

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -176,22 +176,51 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 			parent::add_admin_notices();
 
-			// inform users that they need to connect to FBE 2.0 if they've upgraded from FBE 1.x
-			if ( 'no' === get_option( 'wc_facebook_has_connected_fbe_2' ) && ! $this->get_connection_handler()->is_connected() && $this->get_integration()->get_external_merchant_settings_id() ) {
+			// inform users that they need to connect
+			if ( ! $this->get_connection_handler()->is_connected() ) {
 
-				$docs_url = 'https://docs.woocommerce.com/document/facebook-for-woocommerce/';
+				$message    = '';
+				$message_id = '';
 
-				$message = sprintf(
-					__( '%1$sHeads up!%2$s Facebook for WooCommerce is migrating to a more secure connection experience. Please %3$sclick here%4$s to securely reconnect your account. %5$sLearn more%6$s.', 'facebook-for-woocommerce' ),
-					'<strong>', '</strong>',
-					'<a href="' . esc_url( $this->get_connection_handler()->get_connect_url() ) . '">', '</a>',
-					'<a href="' . esc_url( $docs_url ) . '" target="_blank">', '</a>'
-				);
+				//  to FBE 2.0 if they've upgraded from FBE 1.x
+				if ( 'no' === get_option( 'wc_facebook_has_connected_fbe_2' ) && $this->get_integration()->get_external_merchant_settings_id() ) {
 
-				$this->get_admin_notice_handler()->add_admin_notice( $message, self::PLUGIN_ID . '_migrate_to_v2_0', [
-					'dismissible'  => false,
-					'notice_class' => 'notice-info wc-facebook-migrate-notice',
-				] );
+					$docs_url = 'https://docs.woocommerce.com/document/facebook-for-woocommerce/';
+
+					$message = sprintf(
+						__( '%1$sHeads up!%2$s Facebook for WooCommerce is migrating to a more secure connection experience. Please %3$sclick here%4$s to securely reconnect your account. %5$sLearn more%6$s.', 'facebook-for-woocommerce' ),
+						'<strong>', '</strong>',
+						'<a href="' . esc_url( $this->get_connection_handler()->get_connect_url() ) . '">', '</a>',
+						'<a href="' . esc_url( $docs_url ) . '" target="_blank">', '</a>'
+					);
+
+					$message_id = 'migrate_to_v2_0';
+
+				// otherwise, a general getting started message
+				} elseif ( ! $this->is_plugin_settings() ) {
+
+					$message = sprintf(
+					/* translators: Placeholders %1$s - opening strong HTML tag, %2$s - closing strong HTML tag, %3$s - opening link HTML tag, %4$s - closing link HTML tag */
+						esc_html__(
+							'%1$sFacebook for WooCommerce is almost ready.%2$s To complete your configuration, %3$scomplete the setup steps%4$s.',
+							'facebook-for-woocommerce'
+						),
+						'<strong>',
+						'</strong>',
+						'<a href="' . esc_url( facebook_for_woocommerce()->get_settings_url() ) . '">',
+						'</a>'
+					);
+
+					$message_id = 'get_started';
+				}
+
+				if ( $message ) {
+
+					$this->get_admin_notice_handler()->add_admin_notice( $message, self::PLUGIN_ID . '_' . $message_id, [
+						'dismissible'  => false,
+						'notice_class' => 'notice-info',
+					] );
+				}
 			}
 
 			// if the connection is otherwise invalid, but there is an access token
@@ -207,6 +236,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				$this->get_admin_notice_handler()->add_admin_notice( $message, 'connection_invalid', [
 					'notice_class' => 'notice-error',
 				] );
+			}
+
+			if ( ! $this->get_connection_handler()->is_connected() ) {
+
 			}
 		}
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -188,6 +188,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					$docs_url = 'https://docs.woocommerce.com/document/facebook-for-woocommerce/';
 
 					$message = sprintf(
+						/* translators: Placeholders %1$s - opening strong HTML tag, %2$s - closing strong HTML tag, %3$s - opening link HTML tag, %4$s - closing link HTML tag, %5$s - opening link HTML tag, %6$s - closing link HTML tag */
 						__( '%1$sHeads up!%2$s Facebook for WooCommerce is migrating to a more secure connection experience. Please %3$sclick here%4$s to securely reconnect your account. %5$sLearn more%6$s.', 'facebook-for-woocommerce' ),
 						'<strong>', '</strong>',
 						'<a href="' . esc_url( $this->get_connection_handler()->get_connect_url() ) . '">', '</a>',
@@ -200,7 +201,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				} elseif ( ! $this->is_plugin_settings() ) {
 
 					$message = sprintf(
-					/* translators: Placeholders %1$s - opening strong HTML tag, %2$s - closing strong HTML tag, %3$s - opening link HTML tag, %4$s - closing link HTML tag */
+						/* translators: Placeholders %1$s - opening strong HTML tag, %2$s - closing strong HTML tag, %3$s - opening link HTML tag, %4$s - closing link HTML tag */
 						esc_html__(
 							'%1$sFacebook for WooCommerce is almost ready.%2$s To complete your configuration, %3$scomplete the setup steps%4$s.',
 							'facebook-for-woocommerce'
@@ -236,10 +237,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				$this->get_admin_notice_handler()->add_admin_notice( $message, 'connection_invalid', [
 					'notice_class' => 'notice-error',
 				] );
-			}
-
-			if ( ! $this->get_connection_handler()->is_connected() ) {
-
 			}
 		}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2969,7 +2969,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @param bool $is_enabled whether the Facebook messenger is enabled
 		 * @param \WC_Facebookcommerce_Integration $integration the integration instance
 		 */
-		return (bool) apply_filters( 'wc_facebook_is_messenger_enabled', 'yes' === get_option( self::SETTING_ENABLE_MESSENGER, 'yes' ), $this );
+		return (bool) apply_filters( 'wc_facebook_is_messenger_enabled', 'yes' === get_option( self::SETTING_ENABLE_MESSENGER ), $this );
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -45,10 +45,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	const OPTION_PIXEL_INSTALL_TIME = 'wc_facebook_pixel_install_time';
 
 	/** @var string the facebook page ID setting ID */
-	const SETTING_FACEBOOK_PAGE_ID = 'facebook_page_id';
+	const SETTING_FACEBOOK_PAGE_ID = 'wc_facebook_page_id';
 
 	/** @var string the facebook pixel ID setting ID */
-	const SETTING_FACEBOOK_PIXEL_ID = 'facebook_pixel_id';
+	const SETTING_FACEBOOK_PIXEL_ID = 'wc_facebook_pixel_id';
 
 	/** @var string the "enable advanced matching" setting ID */
 	const SETTING_ENABLE_ADVANCED_MATCHING = 'enable_advanced_matching';
@@ -330,12 +330,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			add_action(
 				'wp_ajax_ajax_schedule_force_resync',
 				array( $this, 'ajax_schedule_force_resync' ),
-				self::FB_PRIORITY_MID
-			);
-
-			add_action(
-				'wp_ajax_ajax_update_fb_option',
-				array( $this, 'ajax_update_fb_option' ),
 				self::FB_PRIORITY_MID
 			);
 
@@ -1771,25 +1765,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$this->display_errors();
 		}
 
-		// check required fields
-		if ( ! $this->is_configured() ) {
-
-			$message = sprintf(
-				/* translators: Placeholders %1$s - opening strong HTML tag, %2$s - closing strong HTML tag, %3$s - opening link HTML tag, %4$s - closing link HTML tag */
-				esc_html__(
-					'%1$sFacebook for WooCommerce is almost ready.%2$s To complete your configuration, %3$scomplete the setup steps%4$s.',
-					'facebook-for-woocommerce'
-				),
-				'<strong>',
-				'</strong>',
-				'<a href="' . esc_url( facebook_for_woocommerce()->get_settings_url() ) . '">',
-				'</a>'
-			);
-
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo $this->get_message_html( $message, 'info' );
-		}
-
 		$this->maybe_display_facebook_api_messages();
 	}
 
@@ -2554,7 +2529,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @param string $page_id the configured Facebook page ID
 		 * @param \WC_Facebookcommerce_Integration $integration the integration instance
 		 */
-		return (string) apply_filters( 'wc_facebook_page_id', $this->get_option( self::SETTING_FACEBOOK_PAGE_ID, '' ), $this );
+		return (string) apply_filters( 'wc_facebook_page_id', get_option( self::SETTING_FACEBOOK_PAGE_ID, '' ), $this );
 	}
 
 
@@ -2575,7 +2550,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @param string $pixel_id the configured Facebook pixel ID
 		 * @param \WC_Facebookcommerce_Integration $integration the integration instance
 		 */
-		return (string) apply_filters( 'wc_facebook_pixel_id', $this->get_option( self::SETTING_FACEBOOK_PIXEL_ID, '' ), $this );
+		return (string) apply_filters( 'wc_facebook_pixel_id', get_option( self::SETTING_FACEBOOK_PIXEL_ID, '' ), $this );
 	}
 
 	/**
@@ -2957,7 +2932,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @param bool $is_enabled whether product sync is enabled
 		 * @param \WC_Facebookcommerce_Integration $integration the integration instance
 		 */
-		return (bool) apply_filters( 'wc_facebook_is_product_sync_enabled', 'yes' === get_option( self::SETTING_ENABLE_PRODUCT_SYNC ), $this );
+		return (bool) apply_filters( 'wc_facebook_is_product_sync_enabled', 'yes' === get_option( self::SETTING_ENABLE_PRODUCT_SYNC, 'yes' ), $this );
 	}
 
 
@@ -2994,7 +2969,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @param bool $is_enabled whether the Facebook messenger is enabled
 		 * @param \WC_Facebookcommerce_Integration $integration the integration instance
 		 */
-		return (bool) apply_filters( 'wc_facebook_is_messenger_enabled', 'yes' === get_option( self::SETTING_ENABLE_MESSENGER ), $this );
+		return (bool) apply_filters( 'wc_facebook_is_messenger_enabled', 'yes' === get_option( self::SETTING_ENABLE_MESSENGER, 'yes' ), $this );
 	}
 
 
@@ -3539,25 +3514,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		wc_deprecated_function( __METHOD__, '1.10.0' );
 		die;
-	}
-
-
-	function ajax_update_fb_option() {
-
-		check_ajax_referer( 'wc_facebook_settings_jsx' );
-		WC_Facebookcommerce_Utils::check_woo_ajax_permissions( 'update fb options', true );
-
-		if ( isset( $_POST ) && ! empty( $_POST['option'] ) && isset( $_POST['option_value'] ) ) {
-
-			$option_name  = sanitize_text_field( wp_unslash( $_POST['option'] ) );
-			$option_value = sanitize_text_field( wp_unslash( $_POST['option_value'] ) );
-
-			if ( stripos( $option_name, 'fb_' ) === 0  ) {
-				update_option( $option_name, $option_value );
-			}
-		}
-
-		wp_die();
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -95,15 +95,15 @@ class Connection {
 			$response = $this->get_plugin()->get_api()->get_installation_ids( $this->get_external_business_id() );
 
 			if ( $response->get_page_id() ) {
-				$integration->update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $response->get_page_id() ) );
+				update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $response->get_page_id() ) );
 			}
 
 			if ( $response->get_pixel_id() ) {
-				$integration->update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, sanitize_text_field( $response->get_pixel_id() ) );
+				update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, sanitize_text_field( $response->get_pixel_id() ) );
 			}
 
 			if ( $response->get_catalog_id() ) {
-				$integration->update_product_catalog_id( sanitize_text_field( $response->get_catalog_id() ) );
+				update_option( \WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, sanitize_text_field( $response->get_catalog_id() ) );
 			}
 
 			if ( $response->get_business_manager_id() ) {
@@ -151,21 +151,20 @@ class Connection {
 
 			$this->update_access_token( $access_token );
 
-			$integration = facebook_for_woocommerce()->get_integration();
-			$api         = new \WC_Facebookcommerce_Graph_API( $access_token );
+			$api = new \WC_Facebookcommerce_Graph_API( $access_token );
 
 			$asset_ids = $api->get_asset_ids( $this->get_external_business_id() );
 
 			if ( ! empty( $asset_ids['page_id'] ) ) {
-				$integration->update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $asset_ids['page_id'] ) );
+				update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $asset_ids['page_id'] ) );
 			}
 
 			if ( ! empty( $asset_ids['pixel_id'] ) ) {
-				$integration->update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, sanitize_text_field( $asset_ids['pixel_id'] ) );
+				update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, sanitize_text_field( $asset_ids['pixel_id'] ) );
 			}
 
 			if ( ! empty( $asset_ids['catalog_id'] ) ) {
-				$integration->update_product_catalog_id( sanitize_text_field( $asset_ids['catalog_id'] ) );
+				update_option( \WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, sanitize_text_field( $asset_ids['catalog_id'] ) );
 			}
 
 			if ( ! empty( $asset_ids['business_manager_id'] ) ) {

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -243,6 +243,32 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 	protected function upgrade_to_2_0_0() {
 
 		update_option( 'wc_facebook_has_connected_fbe_2', 'no' );
+
+		$settings = get_option( 'woocommerce_facebookcommerce_settings' );
+
+		if ( is_array( $settings ) ) {
+
+			$settings_map = [
+				'facebook_pixel_id'             => \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID,
+				'facebook_page_id'              => \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID,
+				'enable_product_sync'           => \WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC,
+				'excluded_product_category_ids' => \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS,
+				'excluded_product_tag_ids'      => \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_TAG_IDS,
+				'product_description_mode'      => \WC_Facebookcommerce_Integration::SETTING_PRODUCT_DESCRIPTION_MODE,
+				'enable_messenger'              => \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER,
+				'messenger_locale'              => \WC_Facebookcommerce_Integration::SETTING_MESSENGER_LOCALE,
+				'messenger_greeting'            => \WC_Facebookcommerce_Integration::SETTING_MESSENGER_GREETING,
+				'messenger_color_hex'           => \WC_Facebookcommerce_Integration::SETTING_MESSENGER_COLOR_HEX,
+				'enable_debug_mode'             => \WC_Facebookcommerce_Integration::SETTING_ENABLE_DEBUG_MODE,
+			];
+
+			foreach ( $settings_map as $old_name => $new_name ) {
+
+				if ( ! empty( $settings[ $old_name ] ) ) {
+					update_option( $new_name, $settings[ $old_name ] );
+				}
+			}
+		}
 	}
 
 


### PR DESCRIPTION
# Summary

Adds a simple upgrade routine for the product sync and messenger settings.

### Story: [CH 55372](https://app.clubhouse.io/skyverge/story/55372)
### Release: #1277 

## UI Changes

N/A

## QA

1. Install v1.11.x of the plugin
1. Connect as usual
1. Enable messenger & product sync, and fill in some settings
1. Switch to this branch & load an admin page
1. Visit the frontend
    - [x] Messenger is enabled
1. Visit the plugin settings tabs
    - [x] Your configured settings are filled in

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version