### PR TITLE
Display message in metabox for virtual products

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -632,6 +632,15 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 			<?php
 
+		} elseif ( $woo_product->woo_product->is_virtual() ) {
+
+			printf(
+				/* translators: Placeholders: %1$s - opening HTML <a> tag, %2$s - closing HTML </a> tag */
+				esc_html__( 'Facebook does not support selling virtual products, so we can\'t include virtual products in your catalog sync. %1$sClick here to read more about Facebook\'s policy%2$s.', 'facebook-for-woocommerce' ),
+				'<a href="https://www.facebook.com/help/130910837313345" target="_blank">',
+				'</a>'
+			);
+
 		} else {
 
 			?>


### PR DESCRIPTION
# Summary

This PR updates the metabox content for virtual products.

### Story: [CH 55574](https://app.clubhouse.io/skyverge/story/55574/display-message-in-metabox-for-virtual-products)
### Release: #1277

## UI changes

- The product metabox display a message informing that virtual products are not synced: https://cloud.skyver.ge/2NuXG97P