### PR TITLE
Fix uncaught error when saving tag-less products

### DIFF
--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -132,6 +132,9 @@ class AJAX {
 						// try with categories first, since we have already IDs
 						$has_excluded_terms = ! empty( $product_cats ) && array_intersect( $product_cats, $integration->get_excluded_product_category_ids() );
 
+						// the form post can send an array with empty items, so filter them out
+						$product_tags = array_filter( $product_tags );
+
 						// try next with tags, but WordPress only gives us tag names
 						if ( ! $has_excluded_terms && ! empty( $product_tags ) ) {
 
@@ -139,13 +142,19 @@ class AJAX {
 
 							foreach ( $product_tags as $product_tag_name_or_id ) {
 
-								if ( $term = get_term_by( 'name', $product_tag_name_or_id, 'product_tag' ) ) {
+								$term = get_term_by( 'name', $product_tag_name_or_id, 'product_tag' );
+
+								if ( $term instanceof \WP_Term ) {
 
 									$product_tag_ids[] = $term->term_id;
 
-								} elseif ( $term = get_term( (int) $product_tag_name_or_id, 'product_tag' ) ) {
+								} else {
 
-									$product_tag_ids[] = $term->term_id;
+									$term = get_term( (int) $product_tag_name_or_id, 'product_tag' );
+
+									if ( $term instanceof \WP_Term ) {
+										$product_tag_ids[] = $term->term_id;
+									}
 								}
 							}
 


### PR DESCRIPTION
# Summary

Prevents an uncaught error when saving a product with no tags selected.

### Story: [CH 54846](https://app.clubhouse.io/skyverge/story/54846)
### Release: #1277 

## QA

- Set a few tags as excluded from sync

1. Edit a product
1. Remove any tags
1. Enable for sync
1. Save
    - [x] No notice is logged

- [x] `integration AJAX_Test` tests pass
- [x] `acceptance Admin/ProductSyncSettingCest` tests pass