### PR TITLE
S2S: Handle the Subscribe event

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -674,13 +674,25 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			foreach ( wcs_get_subscriptions_for_order( $order_id ) as $subscription ) {
 
 				// TODO consider 'StartTrial' event for free trial Subscriptions, which is the same as here (minus sign_up_fee) and tracks "when a person starts a free trial of a product or service" {FN 2020-03-20}
+				$event_name = 'Subscribe';
 
 				// TODO consider including (int|float) 'predicted_ltv': "Predicted lifetime value of a subscriber as defined by the advertiser and expressed as an exact value." {FN 2020-03-20}
-				$this->pixel->inject_event( 'Subscribe', [
-					'sign_up_fee' => $subscription->get_sign_up_fee(),
-					'value'       => $subscription->get_total(),
-					'currency'    => get_woocommerce_currency(),
-				] );
+				$event_data = [
+					'event_name'  => $event_name,
+					'custom_data' => [
+						'sign_up_fee' => $subscription->get_sign_up_fee(),
+						'value'       => $subscription->get_total(),
+						'currency'    => get_woocommerce_currency(),
+					],
+				];
+
+				$event = new Event( $event_data );
+
+				$this->send_api_event( $event );
+
+				$event_data['event_id'] = $event->get_id();
+
+				$this->pixel->inject_event( $event_name, $event_data );
 			}
 		}
 


### PR DESCRIPTION
# Summary

This PRs updates the `WC_Facebookcommerce_EventsTracker::inject_subscribe_event()` method to send the event server-side and add the event ID to the JS script.

### Story: [CH 55625](https://app.clubhouse.io/skyverge/story/55625/handle-the-subscribe-event)
### Release: #1369

## QA

### Setup

- Enable the Facebook Pixel Helper extension
- Click Troubleshoot Pixel and start listening to Pixel events
- Enable logging for the plugin
- Enable Subscriptions and create a subscription product

### Steps

1. Add the subscription product to the cart
1. Proceed to Checkout
1. Place the order
    - [x] An API call is made to create a `Subscribe` event, with an event ID
    - [x] The corresponding JS event is triggered with the same event ID (check in the Events Manager or Pixel Helper)