### PR TITLE
S2S: Adjust the contents params for multi product events

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -591,7 +591,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 					$categories = \WC_Facebookcommerce_Utils::get_product_categories( $item['data']->get_id() );
 
-					$event_data['custom_data']['content_category'] = $categories['name'];
+					if ( ! empty( $categories['name'] ) ) {
+						$event_data['custom_data']['content_category'] = $categories['name'];
+					}
 				}
 			}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -130,11 +130,20 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			// if any product is a variant, fire the pixel with
 			// content_type: product_group
 			$content_type = 'product';
-			$product_ids  = array();
+			$product_ids  = [];
+			$contents     = [];
+
 			foreach ( $products as $product ) {
+
 				if ( ! $product ) {
 					continue;
 				}
+
+				$contents[] = [
+					'id'       => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
+					'quantity' => 1, // consider category results a quantity of 1
+				];
+
 				$product_ids = array_merge(
 					$product_ids,
 					WC_Facebookcommerce_Utils::get_fb_content_ids( $product )
@@ -154,6 +163,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					'content_category' => $categories['categories'],
 					'content_ids'      => json_encode( array_slice( $product_ids, 0, 10 ) ),
 					'content_type'     => $content_type,
+					'contents'         => $contents,
 				],
 			];
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -559,6 +559,19 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				],
 			];
 
+			// if there is only one item in the cart, send its first category
+			if ( ( $cart = WC()->cart ) && count( $cart->get_cart() ) === 1 ) {
+
+				$item = current( $cart->get_cart() );
+
+				if ( isset( $item['data'] ) && $item['data'] instanceof \WC_Product ) {
+
+					$categories = \WC_Facebookcommerce_Utils::get_product_categories( $item['data']->get_id() );
+
+					$event_data['custom_data']['content_category'] = $categories['name'];
+				}
+			}
+
 			$event = new Event( $event_data );
 
 			$this->send_api_event( $event );

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -275,6 +275,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					'content_name'     => $product->get_title(),
 					'content_ids'      => wp_json_encode( \WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) ),
 					'content_type'     => $content_type,
+					'contents'         => [
+						[
+							'id'       => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
+							'quantity' => 1,
+						]
+					],
 					'content_category' => $categories['name'],
 					'value'            => $product->get_price(),
 					'currency'         => get_woocommerce_currency(),

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -201,6 +201,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			// content_type: product_group
 			$content_type = 'product';
 			$product_ids  = [];
+			$contents     = [];
 			$total_value  = 0.00;
 
 			foreach ( $wp_query->posts as $post ) {
@@ -212,6 +213,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				}
 
 				$product_ids = array_merge( $product_ids, WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) );
+
+				$contents[] = [
+					'id'       => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
+					'quantity' => 1, // consider the search results a quantity of 1
+				];
 
 				$total_value += (float) $product->get_price();
 
@@ -226,6 +232,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'custom_data' => [
 					'content_type'  => $content_type,
 					'content_ids'   => json_encode( array_slice( $product_ids, 0, 10 ) ),
+					'contents'      => $contents,
 					'search_string' => get_search_query(),
 					'value'         => \SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper::number_format( $total_value ),
 					'currency'      => get_woocommerce_currency(),


### PR DESCRIPTION
# Summary

Adds the `contents` param to `Search`, `ViewContent`, and `ViewCategory`.

Adds the `content_category` param to `InitiateCheckout` when there is only one item in the cart.

### Story: [CH 55638](https://app.clubhouse.io/skyverge/story/55638)
### Release: #1369

## Details

See [this discussion](https://skyverge.slack.com/archives/CR8VDB4G7/p1590772355255300) for details on approach.

## QA

### Setup

- Enable the Facebook Pixel Helper extension
- Click Troubleshoot Pixel and start listening to Pixel events
- Enable logging for the plugin

### Steps

1. Search for a term that will return products
    - [ ] The `Search` event contains the `contents` param with the product results
1. Click on one of the products
    - [ ] The `ViewContent` event contains the `contents` param
1. Add the product to cart
1. Visit checkout
    - [ ] The `InitiateCheckout` event contains `content_category` with the product's first category name
1. Add a different product to cart & visit checkout
    - [ ] The `InitiateCheckout` event does not contain the `content_category` event
