### PR TITLE
S2S: Handle the Purchase event

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -585,7 +585,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_purchase_event( $order_id ) {
 
-			if ( ! self::$isEnabled || $this->pixel->is_last_event( 'Purchase' ) ) {
+			$event_name = 'Purchase';
+
+			if ( ! self::$isEnabled || $this->pixel->is_last_event( $event_name ) ) {
 				return;
 			}
 
@@ -639,7 +641,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				}
 			}
 
-			$this->pixel->inject_event( 'Purchase', [
+			$this->pixel->inject_event( $event_name, [
 				'num_items'    => $num_items,
 				'content_ids'  => wp_json_encode( array_merge( ... $product_ids ) ),
 				'contents'     => wp_json_encode( $contents ),

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -616,7 +616,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			}
 
 			$content_type  = 'product';
-			$num_items     = 0;
 			$contents      = [];
 			$product_ids   = [ [] ];
 			$product_names = [ [] ];
@@ -639,14 +638,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					$content->quantity = $quantity;
 
 					$contents[] = $content;
-					$num_items += $quantity;
 				}
 			}
 
 			$event_data = [
 				'event_name'  => $event_name,
 				'custom_data' => [
-					'num_items'    => $num_items,
 					'content_ids'  => wp_json_encode( array_merge( ... $product_ids ) ),
 					'content_name' => wp_json_encode( array_merge( ... $product_names ) ),
 					'contents'     => wp_json_encode( $contents ),

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -653,6 +653,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				],
 			];
 
+			$event = new Event( $event_data );
+
+			$this->send_api_event( $event );
+
+			$event_data['event_id'] = $event->get_id();
+
 			$this->pixel->inject_event( $event_name, $event_data );
 
 			$this->inject_subscribe_event( $order_id );

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -615,16 +615,18 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			$content_type = 'product';
-			$num_items    = 0;
-			$contents     = [];
-			$product_ids  = [ [] ];
+			$content_type  = 'product';
+			$num_items     = 0;
+			$contents      = [];
+			$product_ids   = [ [] ];
+			$product_names = [ [] ];
 
 			foreach ( $order->get_items() as $item ) {
 
 				if ( $product = isset( $item['product_id'] ) ? wc_get_product( $item['product_id'] ) : null ) {
 
-					$product_ids[] = \WC_Facebookcommerce_Utils::get_fb_content_ids( $product );
+					$product_ids[]   = \WC_Facebookcommerce_Utils::get_fb_content_ids( $product );
+					$product_names[] = $product->get_name();
 
 					if ( 'product_group' !== $content_type && $product->is_type( 'variable' ) ) {
 						$content_type = 'product_group';
@@ -646,6 +648,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'custom_data' => [
 					'num_items'    => $num_items,
 					'content_ids'  => wp_json_encode( array_merge( ... $product_ids ) ),
+					'content_name' => wp_json_encode( array_merge( ... $product_names ) ),
 					'contents'     => wp_json_encode( $contents ),
 					'content_type' => $content_type,
 					'value'        => $order->get_total(),

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -618,7 +618,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$content_type  = 'product';
 			$contents      = [];
 			$product_ids   = [ [] ];
-			$product_names = [ [] ];
+			$product_names = [];
 
 			foreach ( $order->get_items() as $item ) {
 
@@ -645,7 +645,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'event_name'  => $event_name,
 				'custom_data' => [
 					'content_ids'  => wp_json_encode( array_merge( ... $product_ids ) ),
-					'content_name' => wp_json_encode( array_merge( ... $product_names ) ),
+					'content_name' => wp_json_encode( $product_names ),
 					'contents'     => wp_json_encode( $contents ),
 					'content_type' => $content_type,
 					'value'        => $order->get_total(),

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -641,14 +641,19 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				}
 			}
 
-			$this->pixel->inject_event( $event_name, [
-				'num_items'    => $num_items,
-				'content_ids'  => wp_json_encode( array_merge( ... $product_ids ) ),
-				'contents'     => wp_json_encode( $contents ),
-				'content_type' => $content_type,
-				'value'        => $order->get_total(),
-				'currency'     => get_woocommerce_currency(),
-			] );
+			$event_data = [
+				'event_name'  => $event_name,
+				'custom_data' => [
+					'num_items'    => $num_items,
+					'content_ids'  => wp_json_encode( array_merge( ... $product_ids ) ),
+					'contents'     => wp_json_encode( $contents ),
+					'content_type' => $content_type,
+					'value'        => $order->get_total(),
+					'currency'     => get_woocommerce_currency(),
+				],
+			];
+
+			$this->pixel->inject_event( $event_name, $event_data );
 
 			$this->inject_subscribe_event( $order_id );
 


### PR DESCRIPTION
# Summary

This PRs updates the `WC_Facebookcommerce_EventsTracker::inject_purchase_event()` method to send the event server-side and add the event ID to the JS script.

### Story: [CH 55618](https://app.clubhouse.io/skyverge/story/55618/handle-the-purchase-event)
### Release: #1369

## QA

### Setup

- Enable the Facebook Pixel Helper extension
- Click Troubleshoot Pixel and start listening to Pixel events
- Enable logging for the plugin

### Steps

1. Add the subscription product to the cart
1. Proceed to Checkout
1. Place the order
    - [x] An API call is made to create a `Purchase` event, with an event ID
    - [x] The corresponding JS event is triggered with the same event ID (check in the Events Manager or Pixel Helper)
1. Refresh the Thank You page
    - [x] No API call is made
    - [x] The corresponding JS event is not triggered