### PR TITLE
Prevent Find requests for virtual products

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -3405,6 +3405,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			return null;
 		}
 
+		// do not make find requests for virtual products
+		if ( $woo_product->woo_product->is_virtual() ) {
+			return null;
+		}
+
 		$fb_retailer_id = WC_Facebookcommerce_Utils::get_fb_retailer_id( $woo_product );
 
 		$product_fbid_result = $this->fbgraph->get_facebook_id(

--- a/includes/API.php
+++ b/includes/API.php
@@ -137,7 +137,7 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param $page_id page ID
+	 * @param string $page_id page ID
 	 * @return API\Pages\Read\Response
 	 * @throws Framework\SV_WC_API_Exception
 	 */

--- a/includes/test/facebook-integration-test.php
+++ b/includes/test/facebook-integration-test.php
@@ -40,6 +40,7 @@ if ( ! class_exists( 'WC_Facebook_Integration_Test' ) ) :
 
 		/** @var WC_Facebookcommerce_Integration full integration object */
 		public static $commerce  = null;
+		/** @var WC_Facebookcommerce_Graph_API */
 		public static $fbgraph   = null;
 		public static $test_mode = false;
 

--- a/tests/acceptance/Admin/Settings/ConnectionSettingsCest.php
+++ b/tests/acceptance/Admin/Settings/ConnectionSettingsCest.php
@@ -2,7 +2,7 @@
 
 use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
 
-class ConnectionCest {
+class ConnectionSettingsCest {
 
 
 	public function _before( AcceptanceTester $I ) {

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -28,6 +28,12 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 		$this->add_settings();
 
 		$this->integration->init_settings();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
 	}
 
 
@@ -552,19 +558,9 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 
 
 	/** @see \WC_Facebookcommerce_Integration::get_page() */
-	public function test_get_page() {
+	public function test_get_page_method() {
 
-		if ( ! class_exists( API\Response::class ) ) {
-			require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/API/Response.php';
-		}
-
-		if ( ! class_exists( API\Pages\Read\Response::class ) ) {
-			require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/API/Pages/Read/Response.php';
-		}
-
-		if ( ! class_exists( API::class ) ) {
-			require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/API.php';
-		}
+		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '1234' );
 
 		$response_data = [ 'name' => 'Test Page', 'link' => 'https://example.org' ];
 		$response      = new API\Pages\Read\Response( json_encode( $response_data ) );
@@ -582,10 +578,9 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	 * @param API $api API stub
 	 * @param string $access_token configured access token
 	 * @param array $expected_result expected return value
+	 * @throws ReflectionException
 	 */
 	private function check_get_page( $api, $access_token, $expected_result ) {
-
-		facebook_for_woocommerce()->get_connection_handler()->update_access_token( $access_token );
 
 		// replace the API instance with our stub
 		$property = new ReflectionProperty( \WC_Facebookcommerce::class, 'api' );


### PR DESCRIPTION
# Summary

This PRs updates the `WC_Facebookcommerce_Integration:: get_product_fbid()` method not to send API requests to retrieve the ID of virtual products.

### Story: [CH 55644](https://app.clubhouse.io/skyverge/story/55644/prevent-find-requests-for-virtual-products)
### Release: #1277 

## Details

If the product was ever non-virtual and synced, the metadata should be set. 

## QA

### Setup

- The plugin is enabled and connected
- Logging in enabled

### Create a virtual product

1. Create a new virtual product with a price
    - [x] No API call is made

### Edit a virtual product

1. Create a virtual product with a price
1. Edit a virtual product
    - [x] No API call is made

### Make a synchronized product virtual

1. Create a non-virtual product with a price
1. Wait for it to be synchronized to Facebook
1. Edit the product, making it virtual
    - [x] No API call is made

### Delete a synchronized virtual product

1. Create a non-virtual product with a price
1. Wait for it to be synchronized to Facebook
1. Edit the product, making it virtual
    - [x] No API call is made
1. Wait for the page to reload
    - [x] The Facebook metabox displays the Facebook ID (allowing the merchant to delete it from Facebook)