### PR TITLE
Facebook sync column collapse in some cases

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -34,3 +34,8 @@
 .notice .button.js-wc-plugin-framework-notice-dismiss {
 	margin-left: 10px;
 }
+
+/* adjusts widths of the products table, same as WooCommerce categories and tags */
+.column-facebook_sync {
+	width: 11% !important;
+}


### PR DESCRIPTION
# Summary

This PRs adds a width to the Facebook sync column (same solution used in https://github.com/skyverge/fb-for-woocommerce/pull/98).

### Story: [CH 55665](https://app.clubhouse.io/skyverge/story/55665/admin-columns-collapse-in-some-cases)
### Release: #1277 

## QA

1. Navigate to the Products page in a small screen (I can see it on my MacBook Pro)
    - [x] The column in displayed correct