### PR TITLE
Clean up integration tab and related code

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -32,9 +32,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var string the integration ID */
 		const INTEGRATION_ID = 'facebookcommerce';
 
-		/** @var string the integration class name (including namespaces) */
-		const INTEGRATION_CLASS = '\\WC_Facebookcommerce_Integration';
-
 
 		/** @var \WC_Facebookcommerce singleton instance */
 		protected static $instance;
@@ -68,6 +65,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 		/** @var \SkyVerge\WooCommerce\Facebook\Handlers\Connection connection handler */
 		private $connection_handler;
+
+		/** @var \SkyVerge\WooCommerce\Facebook\Integrations\Integrations integrations handler */
+		private $integrations;
 
 
 		/**
@@ -123,9 +123,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 					$this->ajax = new \SkyVerge\WooCommerce\Facebook\AJAX();
 				}
-
-				// register the WooCommerce integration
-				add_filter( 'woocommerce_integrations', [ $this, 'add_woocommerce_integration' ] );
 
 				$this->integrations = new \SkyVerge\WooCommerce\Facebook\Integrations\Integrations( $this );
 
@@ -236,28 +233,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					'notice_class' => 'notice-error',
 				] );
 			}
-		}
-
-
-		/**
-		 * Adds a Facebook integration to WooCommerce.
-		 *
-		 * @internal
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string[] $integrations class names
-		 * @return string[]
-		 */
-		public function add_woocommerce_integration( $integrations = [] ) {
-
-			if ( ! class_exists( self::INTEGRATION_CLASS ) ) {
-				include_once __DIR__ . '/facebook-commerce.php';
-			}
-
-			$integrations[ self::INTEGRATION_ID ] = self::INTEGRATION_CLASS;
-
-			return $integrations;
 		}
 
 
@@ -521,20 +496,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		public function get_integration() {
 
 			if ( null === $this->integration ) {
-
-				$integrations = null === WC()->integrations ? [] : WC()->integrations->get_integrations();
-				$integration  = self::INTEGRATION_CLASS;
-
-				if ( isset( $integrations[ self::INTEGRATION_ID ] ) && $integrations[ self::INTEGRATION_ID ] instanceof $integration ) {
-
-					$this->integration = $integrations[ self::INTEGRATION_ID ];
-
-				} else {
-
-					$this->add_woocommerce_integration();
-
-					$this->integration = new $integration();
-				}
+				$this->integration = new WC_Facebookcommerce_Integration();
 			}
 
 			return $this->integration;

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -96,6 +96,8 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		 */
 		public function init() {
 
+			add_action( 'init', [ $this, 'get_integration' ] );
+
 			if ( \WC_Facebookcommerce_Utils::isWoocommerceIntegration() ) {
 
 				include_once 'facebook-commerce.php';

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1761,7 +1761,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	public function checks() {
 
 		// TODO improve this by checking the settings page with Framework method and ensure error notices are displayed under the Integration sections {FN 2020-01-30}
-		if ( isset( $_GET['page'], $_GET['section'] ) && 'wc-settings' === $_GET['page'] && \WC_Facebookcommerce::INTEGRATION_ID === $_GET['section'] ) {
+		if ( isset( $_GET['page'] ) && 'wc-facebook' === $_GET['page'] ) {
 			$this->display_errors();
 		}
 

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -73,7 +73,7 @@ class AJAX {
 		check_admin_referer( Product_Sync::ACTION_GET_SYNC_STATUS, 'nonce' );
 
 		$remaining_products = 0;
-		
+
 		$jobs = facebook_for_woocommerce()->get_products_sync_background_handler()->get_jobs( [
 			'status' => 'processing',
 		] );
@@ -170,7 +170,7 @@ class AJAX {
 						<a
 							id="facebook-for-woocommerce-go-to-settings"
 							class="button button-large"
-							href="<?php echo esc_url( add_query_arg( 'section', \WC_Facebookcommerce::INTEGRATION_ID, admin_url( 'admin.php?page=wc-settings&tab=integration' ) ) ); ?>"
+							href="<?php echo esc_url( add_query_arg( 'tab', Product_Sync::ID, facebook_for_woocommerce()->get_settings_url() ) ); ?>"
 						><?php esc_html_e( 'Go to Settings', 'facebook-for-woocommerce' ); ?></a>
 						<button
 							id="facebook-for-woocommerce-cancel-sync"
@@ -239,7 +239,7 @@ class AJAX {
 				<a
 					id="facebook-for-woocommerce-go-to-settings"
 					class="button button-large"
-					href="<?php echo esc_url( add_query_arg( 'section', \WC_Facebookcommerce::INTEGRATION_ID, admin_url( 'admin.php?page=wc-settings&tab=integration' ) ) ); ?>"
+					href="<?php echo esc_url( add_query_arg( 'tab', Product_Sync::ID, facebook_for_woocommerce()->get_settings_url() ) ); ?>"
 				><?php esc_html_e( 'Go to Settings', 'facebook-for-woocommerce' ); ?></a>
 				<button
 					id="facebook-for-woocommerce-cancel-sync"


### PR DESCRIPTION
# Summary

This PRs removes the Facebook tab from WC Settings > Integration and related code.

### Story: [CH 55666](https://app.clubhouse.io/skyverge/story/55666/clean-up-integration-tab-and-related-code)
### Release: #1277 

## QA

1. Navigate to the WC Settings > Integration
    - [x] There is no Facebook section