### PR TITLE
Add better connection failure notice

### DIFF
--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -36,6 +36,37 @@ class Connection extends Admin\Abstract_Settings_Screen {
 		$this->title = __( 'Connection', 'facebook-for-woocommerce' );
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+
+		add_action( 'admin_notices', [ $this, 'add_notices' ] );
+	}
+
+
+	/**
+	 * Adds admin notices.
+	 *
+	 * @internal
+	 *
+	 * @since 2.0.0-dev.1
+	 */
+	public function add_notices() {
+
+		// display a notice if the connection has previously failed
+		if ( get_transient( 'wc_facebook_connection_failed' ) ) {
+
+			$message = sprintf(
+				/* translators: Placeholders: %1$s - <strong> tag, %2$s - </strong> tag, %3$s - <a> tag, %4$s - </a> tag, %5$s - <a> tag, %6$s - </a> tag */
+				__( '%1$sHeads up!%2$s It looks like there was a problem with reconnecting your site to Facebook. Please %3$sclick here%4$s to try again, or %5$sget in touch with our support team%6$s for assistance.', 'facebook-for-woocommerce' ),
+				'<strong>', '</strong>',
+				'<a href="' . esc_url( facebook_for_woocommerce()->get_connection_handler()->get_connect_url() ) . '">', '</a>',
+				'<a href="' . esc_url( facebook_for_woocommerce()->get_support_url() ) . '" target="_blank">', '</a>'
+			);
+
+			facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice( $message, 'wc_facebook_connection_failed', [
+				'notice_class' => 'error',
+			] );
+
+			delete_transient( 'wc_facebook_connection_failed' );
+		}
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -181,7 +181,7 @@ class Connection {
 
 			facebook_for_woocommerce()->log( sprintf( 'Connection failed: %s', $exception->getMessage() ) );
 
-			facebook_for_woocommerce()->get_message_handler()->add_error( __( 'Connection unsuccessful. Please try again.', 'facebook-for-woocommerce' ) );
+			set_transient( 'wc_facebook_connection_failed', time(), 30 );
 		}
 
 		wp_safe_redirect( facebook_for_woocommerce()->get_settings_url() );

--- a/tests/acceptance/Admin/Settings/ConnectionSettingsCest.php
+++ b/tests/acceptance/Admin/Settings/ConnectionSettingsCest.php
@@ -96,4 +96,26 @@ class ConnectionSettingsCest {
 	}
 
 
+	/**
+	 * Test that the connection failure message displays correctly.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 * @throws Exception
+	 */
+	public function try_connection_failure_notice( AcceptanceTester $I ) {
+
+		$I->haveTransientInDatabase( 'wc_facebook_connection_failed', time() );
+
+		$I->amOnAdminPage('admin.php?page=wc-facebook' );
+
+		$I->waitForText( 'It looks like there was a problem with reconnecting your site to Facebook' );
+
+		$I->dontHaveTransientInDatabase( 'wc_facebook_connection_failed' );
+
+		$I->amOnAdminPage('admin.php?page=wc-facebook' );
+
+		$I->dontSee( 'It looks like there was a problem with reconnecting your site to Facebook' );
+	}
+
+
 }


### PR DESCRIPTION
# Summary

Updates the connection failure notice with some better messaging.

### Story: [CH 54088](https://app.clubhouse.io/skyverge/story/54088)
### Release: #1277 

## UI

- New notice: https://cloud.skyver.ge/8LujR1xD

## QA

1. Visit the redirect URL without any necessary data, e.g. `?wc-api=wc_facebook_connect
    - [x] When back at the settings screen, the notice is displayed
1. Refresh the page
    - [x] The notice is gone