### PR TITLE
Allow to explicitly delete products with sync disabled

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -971,7 +971,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * bail if not enabled for sync, except if explicitly deleting from the metabox
 		 * @see ajax_delete_fb_product()
 		 */
-		if ( ! isset( $_POST['wp_id'] ) && ! Products::product_should_be_synced( $product ) ) {
+		if ( ( ! is_ajax() || ! isset( $_POST['action'] ) || 'ajax_delete_fb_product' !== $_POST['action'] )
+		     && ! Products::product_should_be_synced( $product ) ) {
+
 			return;
 		}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -967,8 +967,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			return;
 		}
 
-		// bail if not enabled for sync
-		if ( ! Products::product_should_be_synced( $product ) ) {
+		/**
+		 * bail if not enabled for sync, except if explicitly deleting from the metabox
+		 * @see ajax_delete_fb_product()
+		 */
+		if ( ! isset( $_POST['wp_id'] ) && ! Products::product_should_be_synced( $product ) ) {
 			return;
 		}
 


### PR DESCRIPTION
# Summary

This PR updates `on_product_delete()` to allow sync-disabled/virtual products to be deleted from the metabox link.

### Story: [CH 55667](https://app.clubhouse.io/skyverge/story/55667/allow-to-explicitly-delete-products-with-sync-disabled)
### Release: #1277 

## QA

### Delete from the metabox

1. Create a non-virtual product with a price
1. Wait for it to be synchronized to Facebook
1. Edit the product, making it virtual
1. Wait for the page to reload
    - [x] The Facebook metabox displays the Facebook ID
1. Click the Delete link in the Facebook metabox
    - [x] The product is deleted from the catalog

### Delete on Product delete with sync enabled

1. Create a non-virtual product with a price
1. Wait for it to be synchronized to Facebook
1. Permanently delete the product
    - [x] The product is deleted from the catalog

### Delete on Product delete with sync disabled

1. Create a non-virtual product with a price
1. Wait for it to be synchronized to Facebook
1. Permanently delete the product
    - [x] The product is **not** deleted from the catalog