### PR TITLE
Tweak tooltip positioning for product data textarea

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -957,6 +957,7 @@ class Admin {
 					'description' => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
 					'cols'        => 40,
 					'rows'        => 20,
+					'style'       => 'width: 80%;',
 					'value'       => $description,
 					'class'       => 'enable-if-sync-enabled',
 				] );
@@ -1067,6 +1068,7 @@ class Admin {
 			'rows'          => 5,
 			'value'         => $description,
 			'class'         => 'enable-if-sync-enabled',
+			'style'         => 'max-width: 80%;',
 			'wrapper_class' => 'form-row form-row-full hide_if_variation_virtual',
 		] );
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1068,7 +1068,6 @@ class Admin {
 			'rows'          => 5,
 			'value'         => $description,
 			'class'         => 'enable-if-sync-enabled',
-			'style'         => 'max-width: 80%;',
 			'wrapper_class' => 'form-row form-row-full hide_if_variation_virtual',
 		] );
 


### PR DESCRIPTION
# Summary

Slightly adjusts the CSS of textareas in the product data to make sure the tooltip doesn't break alignment on smaller screens.

### Story: [CH 54088](https://app.clubhouse.io/skyverge/story/55676/tweak-tooltip-positioning-on-the-product-edit-panel)
### Release: #1277 

## UI

The textarea width is slightly reduced to 80% - you can notice the issue only when using a smaller screen (tried iPad size in chrome tools); with the PR's tweak the issue no longer shows.

![image](https://user-images.githubusercontent.com/1227930/83386885-5c231a80-a41e-11ea-877e-d89d64f897ff.png)


## QA

1. [ ] Check the FB tab in a simple product and try to resize your screen - the tooltip schould be correctly aligned to the right of the description textarea
1. [ ] The change is not needed for variable products, as the HTML output is comparable to those of other inputs