### PR TITLE
Fix sync for variation's descriptions in Short Description mode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 2020.nn.nn - version 2.0.0-dev.1
  * Tweak - When using checkboxes for tags, make sure the modal is displayed when trying to enable sync for a product with an excluded tag
  * Fix - Use the plugin version instead of a timestamp as the version number for enqueued scripts and stylesheets
+ * Fix - Use the short description of the parent product for product variations that don't have a description or Facebook description
 
 2020.05.20 - version 1.11.3
  * Tweak - Write product feed to a temporary file and rename it when done, to prevent Facebook from downloading an incomplete feed file

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -248,7 +248,7 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 			throw new Framework\SV_WC_Plugin_Exception( "No parent product found with ID equal to {$product->get_parent_id()}." );
 		}
 
-		$fb_parent_product = new \WC_Facebook_Product( $parent_product );
+		$fb_parent_product = new \WC_Facebook_Product( $parent_product->get_id() );
 		$fb_product        = new \WC_Facebook_Product( $product->get_id(), $fb_parent_product );
 
 		$data = $fb_product->prepare_product();

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 = 2020.nn.nn - version 2.0.0-dev.1 =
  * Tweak - When using checkboxes for tags, make sure the modal is displayed when trying to enable sync for a product with an excluded tag
  * Fix - Use the plugin version instead of a timestamp as the version number for enqueued scripts and stylesheets
+ * Fix - Use the short description of the parent product for product variations that don't have a description or Facebook description
 
 = 2020.05.20 - version 1.11.3 =
  * Tweak - Write product feed to a temporary file and rename it when done, to prevent Facebook from downloading an incomplete feed file

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -253,6 +253,42 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Background::process_item() */
+	public function test_process_item_update_request_with_product_variation_and_short_descriptions() {
+
+		$short_description = 'parent short description';
+
+		// force the plugin to use short descriptions
+		add_filter( 'wc_facebook_product_description_mode', static function() use ( $short_description ) {
+
+			return $short_description;
+		} );
+
+		$parent_product = new \WC_Product_Variable();
+		$parent_product->set_short_description( 'parent short description' );
+		$parent_product->save();
+
+		$product_variation = new \WC_Product_Variation();
+		$product_variation->save();
+
+		$product_variation->set_parent_id( $parent_product->get_id() );
+		$product_variation->save();
+
+		$parent_product->set_children( [ $product_variation->get_id() ] );
+		$parent_product->save();
+
+		$request = [
+			'retailer_id' => "wc_post_id_{$product_variation->get_id()}",
+			'data'        => [
+				'retailer_product_group_id' => "wc_post_id_{$parent_product->get_id()}",
+				'description'               => $short_description,
+			],
+		];
+
+		$this->check_process_item_update_request( $product_variation, $request );
+	}
+
+
 	/**
 	 * Tests that the retailer ID field uses the product SKU if avaiable.
 	 *

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -290,12 +290,12 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
-	 * Tests that the retailer ID field uses the product SKU if avaiable.
+	 * Tests that the retailer ID field uses the product SKU if available.
 	 *
 	 * @see Background::process_item()
 	 *
 	 * @param string $sku product SKU
-	 * @param string $reatiler_id expected retailer ID
+	 * @param string $retailer_id expected retailer ID
 	 *
 	 * @dataProvider provider_process_item_update_request_retailer_id_generation
 	 */


### PR DESCRIPTION
# Summary

This PR fixes a bug in the sync background job handler that prevent the plugin from using the parent product's description as the description of variations that had no individual description or Facebook description override configured.

### Story: [CH 55919](https://app.clubhouse.io/skyverge/story/55919)
### Release: #1277

## QA

- [ ] `codecept run integration` pass