### PR TITLE
Draft variations should not be synced

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Facebook for WooCommerce Changelog ***
 
+2020.nn.nn - version 1.11.4-dev.1
+ * Fix - Do not sync variations for draft variable products created by duplicating products
+
 2020.05.20 - version 1.11.3
  * Tweak - Write product feed to a temporary file and rename it when done, to prevent Facebook from downloading an incomplete feed file
  * Tweak - Hide Facebook options for virtual products and virtual variations

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 
 		/** @var string the plugin version */
-		const VERSION = '1.11.3';
+		const VERSION = '1.11.4-dev.1';
 
 		/** @var string for backwards compatibility TODO: remove this in v2.0.0 {CW 2020-02-06} */
 		const PLUGIN_VERSION = self::VERSION;

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 1.11.3
+ * Version: 1.11.4-dev.1
  * Text Domain: facebook-for-woocommerce
  * WC requires at least: 3.5.0
  * WC tested up to: 4.1.1

--- a/i18n/languages/facebook-for-woocommerce.pot
+++ b/i18n/languages/facebook-for-woocommerce.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Facebook for WooCommerce package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Facebook for WooCommerce 1.11.3\n"
+"Project-Id-Version: Facebook for WooCommerce 1.11.4-dev.1\n"
 "Report-Msgid-Bugs-To: "
 "https://woocommerce.com/my-account/marketplace-ticket-form/\n"
-"POT-Creation-Date: 2020-05-21 03:03:55+00:00\n"
+"POT-Creation-Date: 2020-06-04 00:01:39+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -650,19 +650,19 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: includes/fbproductfeed.php:474
+#: includes/fbproductfeed.php:483
 msgid "Could not create product catalog feed directory"
 msgstr ""
 
-#: includes/fbproductfeed.php:540
+#: includes/fbproductfeed.php:549
 msgid "Could not open the product catalog temporary feed file for writing"
 msgstr ""
 
-#: includes/fbproductfeed.php:547
+#: includes/fbproductfeed.php:556
 msgid "Could not open the product catalog feed file for writing"
 msgstr ""
 
-#: includes/fbproductfeed.php:594
+#: includes/fbproductfeed.php:603
 msgid "Could not rename the product catalog feed file"
 msgstr ""
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -446,7 +446,16 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 		 */
 		private function get_product_ids() {
 
-			$post_ids           = $this->get_product_wpid();
+			$post_ids = $this->get_product_wpid();
+
+			// remove variations with unpublished parents
+			$post_ids = array_filter( $post_ids,
+				function ( $post_id ) {
+					return ( 'product_variation' !== get_post_type( $post_id )
+					         || 'publish' === get_post( wp_get_post_parent_id( $post_id ) )->post_status );
+				}
+			);
+
 			$all_parent_product = array_map(
 				function( $post_id ) {
 					if ( 'product_variation' === get_post_type( $post_id ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 5.3.2
-Stable tag: 1.11.3
+Stable tag: 1.11.4-dev.1
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -38,6 +38,9 @@ When opening a bug on GitHub, please give us as many details as possible.
 * Current version of Facebook-for-WooCommerce, WooCommerce, Wordpress, PHP
 
 == Changelog ==
+
+= 2020.nn.nn - version 1.11.4-dev.1 =
+ * Fix - Do not sync variations for draft variable products created by duplicating products
 
 = 2020.05.20 - version 1.11.3 =
  * Tweak - Write product feed to a temporary file and rename it when done, to prevent Facebook from downloading an incomplete feed file


### PR DESCRIPTION
# Summary

This PR fixes an issue that is causing variations of draft products to be synced and visible.

### Story: [CH 55753](https://app.clubhouse.io/skyverge/story/55753/draft-variations-should-not-be-synced)

## Details

When a variable product is duplicated, the variation posts are created with "publish" status. So when checking the status to get the products, we need to check the parent status as well, for variations.

A pre-release was sent to the customer.

## UI Changes

N/A.

## QA

### Setup

- The plugin is connected and product sync is enabled

### Steps

1. Create a variable product with variations with prices
1. Duplicate this product and save the new one as a draft (do not publish it)
1. Sync all your products/regenerate your feed
    - [ ] The new draft product is not synced (not included in the feed)
1. Publish the product
1. Sync all your products/regenerate your feed
    - [ ] The product is synced (included in the feed)

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version