### PR TITLE
Ensure excluded products are marked as Do not sync

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2310,7 +2310,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @internal
 	 *
 	 * @since 1.10.0
-	 * @deprecate 2.0.0-dev.1
+	 * @deprecated 2.0.0-dev.1
 	 */
 	public function process_admin_options() {
 


### PR DESCRIPTION
# Summary

This PR marks products as **Do not sync** after they are excluded via term from the Product Sync settings.

### Story: [CH 55678](https://app.clubhouse.io/skyverge/story/55678)
### Release: #1277 

## Details

Previously, clicking the Exclude button in the dialog that shows up when a term with synced products is added to the list of excluded terms was not disabling sync for matching products.

This PR restores some of the modifications from [CH 31781](https://app.clubhouse.io/skyverge/story/31781).

## QA

## Steps

### Simple product

1. Mark a simple product as synced
1. Add a category to it
1. From the sync settings, exclude that category and click Exclude in the modal
1. Edit the product
    - [ ] Facebook sync is set to `Do not sync`

### Variable product

1. Mark a variable product as synced
1. Add a tag to it
1. From the sync settings, exclude that tag and click Exclude in the modal
1. Edit the product
    - [ ] Facebook sync is set to `Do not sync` for each variation