### PR TITLE
Exclude variations with unpublished parents from sync

### DIFF
--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -82,12 +82,21 @@ class Sync {
 			'posts_per_page' => -1,
 		];
 
-		foreach ( get_posts( $args ) as $post_id => $post_parent ) {
-
-			$product_ids[] = $post_id;
+		foreach ( get_posts( $args ) as $post_id => $parent_id ) {
 
 			if ( 'product_variation' === get_post_type( $post_id ) ) {
-				$parent_product_ids[] = $post_parent;
+
+				// keep track of all parents to remove them from the list of products to sync
+				$parent_product_ids[] = $parent_id;
+
+				// include variations with published parents only
+				if ( 'publish' === get_post_status( $parent_id ) ) {
+					$product_ids[] = $post_id;
+				}
+
+			} else {
+
+				$product_ids[] = $post_id;
 			}
 		}
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -37,14 +37,7 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 		$simple_product->save();
 
 		// add all eligible products to the sync queue
-		$sync = $this->get_sync();
-
-		$sync->create_or_update_all_products();
-
-		$requests_property = new \ReflectionProperty( Sync::class, 'requests' );
-		$requests_property->setAccessible( true );
-
-		$requests = $requests_property->getValue( $sync );
+		$requests = $this->create_or_update_all_products();
 
 		// test that create_or_update_all_products() added the three variations with price to the sync queue
 		foreach ( $variable_product->get_children() as $variation_id ) {
@@ -61,6 +54,26 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 
 		// test no other products or variations were added
 		$this->assertEquals( count( $variable_product->get_children() ) + 1, count( $requests ) );
+	}
+
+
+	/**
+	 * Uses the Sync handler to add all eligible product IDs to the requests array to be created or updated.
+	 *
+	 * Returns an array of UPDATE requests.
+	 *
+	 * @return array
+	 */
+	private function create_or_update_all_products() {
+
+		$sync = $this->get_sync();
+
+		$sync->create_or_update_all_products();
+
+		$requests_property = new \ReflectionProperty( Sync::class, 'requests' );
+		$requests_property->setAccessible( true );
+
+		return $requests_property->getValue( $sync );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR adds the changes from https://github.com/facebookincubator/facebook-for-woocommerce/pull/1402 to the `Sync::create_or_update_all_products()`.

### Story: [CH 56055](https://app.clubhouse.io/skyverge/story/56055)

## Details

When a variable product is duplicated, the variation posts are created with "publish" status. So when checking the status to get the products, we need to check the parent status as well, for variations.

## QA

### Setup

- Version 2.0.0 of the plugin is connected and product sync is enabled

### Steps

1. Create a variable product with variations with prices
1. Duplicate this product and save the new one as a draft (do not publish it)
1. Sync all your products/regenerate your feed
    - [ ] The new draft product is not synced (not included in the feed)
1. Publish the product
1. Sync all your products/regenerate your feed
    - [ ] The product is synced (included in the feed)

### Tests

- [ ] `codecept run integration` pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version