### PR TITLE
Remove FB_CART_URL notice

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -141,6 +141,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string the API flag to set a product as not visible in the Facebook shop */
 	const FB_SHOP_PRODUCT_HIDDEN = 'staging';
 
+	/** @var string @deprecated  */
 	const FB_CART_URL = 'fb_cart_url';
 
 	const FB_MESSAGE_DISPLAY_TIME = 180;
@@ -2053,12 +2054,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			throw new Framework\SV_WC_Plugin_Exception( __( "We've detected that your Facebook Product Catalog is no longer valid. This may happen if it was deleted, but could also be a temporary error. If the error persists, please click Manage connection > Advanced Options > Remove and setup the plugin again.", 'facebook-for-woocommerce' ) );
 		}
 
-		// Cache the cart URL to display a warning in case it changes later
-		$cart_url = get_option( self::FB_CART_URL );
-		if ( $cart_url != wc_get_cart_url() ) {
-			update_option( self::FB_CART_URL, wc_get_cart_url() );
-		}
-
 		// Get all published posts. First unsynced then already-synced.
 		$post_ids_new = WC_Facebookcommerce_Utils::get_wp_posts(
 			self::FB_PRODUCT_GROUP_ID,
@@ -2209,12 +2204,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			);
 
 			throw new Framework\SV_WC_Plugin_Exception( __( "We've detected that your Facebook Product Catalog is no longer valid. This may happen if it was deleted, but could also be a temporary error. If the error persists, please click Manage connection > Advanced Options > Remove and setup the plugin again.", 'facebook-for-woocommerce' ) );
-		}
-
-		// Cache the cart URL to display a warning in case it changes later
-		$cart_url = get_option( self::FB_CART_URL );
-		if ( $cart_url != wc_get_cart_url() ) {
-			update_option( self::FB_CART_URL, wc_get_cart_url() );
 		}
 
 		if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -741,12 +741,12 @@ class Admin {
 	/**
 	 * Prints a notice on products page in case the current cart URL is not the original sync URL.
 	 *
-     * TODO remove this deprecated method by version 3.0.0 or by June 2021 {FN 2020-06-09}
-     *
+	 * TODO remove this deprecated method by version 3.0.0 or by June 2021 {FN 2020-06-09}
+	 *
 	 * @internal
 	 *
 	 * @since 1.10.0
-     * @deprecated 2.0.0-dev.1
+	 * @deprecated 2.0.0-dev.1
 	 */
 	public function validate_cart_url() {
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -54,9 +54,6 @@ class Admin {
 		// may trigger the modal to open to warn the merchant about a conflict with the current product terms
 		add_action( 'admin_footer', [ $this, 'validate_product_excluded_terms' ] );
 
-		// add admin notification in case of site URL change
-		add_action( 'admin_notices', [ $this, 'validate_cart_url' ] );
-
 		// add admin notice to inform that disabled products may need to be deleted manually
 		add_action( 'admin_notices', [ $this, 'maybe_show_product_disabled_sync_notice' ] );
 
@@ -744,36 +741,16 @@ class Admin {
 	/**
 	 * Prints a notice on products page in case the current cart URL is not the original sync URL.
 	 *
+     * TODO remove this deprecated method by version 3.0.0 or by June 2021 {FN 2020-06-09}
+     *
 	 * @internal
 	 *
-	 * TODO: update this method to use the notice handler once we framework the plugin {CW 2020-01-09}
-	 *
 	 * @since 1.10.0
+     * @deprecated 2.0.0-dev.1
 	 */
 	public function validate_cart_url() {
-		global $current_screen;
 
-		if ( isset( $current_screen->id ) && in_array( $current_screen->id, [ 'edit-product', 'product' ], true ) ) :
-
-			$cart_url = get_option( \WC_Facebookcommerce_Integration::FB_CART_URL, '' );
-
-			if ( ! empty( $cart_url ) && $cart_url !== wc_get_cart_url() ) :
-
-				?>
-				<div class="notice notice-warning">
-					<?php printf(
-						/* translators: Placeholders: %1$s - Facebook for Woocommerce, %2$s - opening HTML <a> link tag, %3$s - closing HTML </a> link tag */
-						'<p>' . esc_html__( '%1$s: One or more of your products is using a checkout URL that may be different than your shop checkout URL. %2$sRe-sync your products to update checkout URLs on Facebook%3$s.', 'facebook-for-woocommerce' ) . '</p>',
-						'<strong>' . esc_html__( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ) . '</strong>',
-						'<a href="' . esc_url( facebook_for_woocommerce()->get_settings_url() ) . '">',
-						'</a>'
-					); ?>
-				</div>
-				<?php
-
-			endif;
-
-		endif;
+		wc_deprecated_function( __METHOD__, '2.0.0' );
 	}
 
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -269,6 +269,9 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 				}
 			}
 		}
+
+		// deletes an option that is not longer used to generate an admin notice
+		delete_option( 'fb_cart_url' );
 	}
 
 

--- a/tests/integration/Admin_Test.php
+++ b/tests/integration/Admin_Test.php
@@ -49,13 +49,6 @@ class Admin_Test extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
-	/** @see Facebook\Admin::validate_cart_url() */
-	public function test_validate_cart_url() {
-
-		$this->assertTrue( (bool) has_action( 'admin_notices', [ $this->admin, 'validate_cart_url' ] ) );
-	}
-
-
 	/** @see Facebook\Admin::add_product_list_table_column() */
 	public function test_add_product_list_table_columns() {
 


### PR DESCRIPTION
# Summary

Removes the triggering of an admin notice based on the value of an option that saves the cart URL. 

### Story: [CH 55764](https://app.clubhouse.io/skyverge/story/55764/remove-notice-about-fb-cart-url)

## Details

We no longer need this notice. The constant is kept for backwards compatibility. A public method has been deprecated. An upgrade routine has been added to delete the db option that is no longer used, if this was generated in a past release.

## QA

### Setup

- Start off with an older version of the plugin in the 1.11.x branch.

### Steps

- [x] The `fb_cart_url` option should be visible in database
- [x] Update to this version: the option is no longer visible

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version