### PR TITLE
Modifications necessary to create a System User

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -797,10 +797,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			try {
 
-				// TODO: remove before releasing 2.0.0-dev.1
-				if ( apply_filters( 'wc_facebook_enable_s2s', false ) ) {
-					facebook_for_woocommerce()->get_api()->send_pixel_events( facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id(), [ $event ] );
-				}
+				facebook_for_woocommerce()->get_api()->send_pixel_events( facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id(), [ $event ] );
 
 				$success = true;
 

--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -49,6 +49,19 @@ class Response extends API\Response  {
 
 
 	/**
+	 * Gets the ad account ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_ad_account_id() {
+
+		return ! empty( $this->get_data()->ad_account_id ) ? $this->get_data()->ad_account_id : '';
+	}
+
+
+	/**
 	 * Gets the catalog ID.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -139,6 +139,10 @@ class Connection extends Admin\Abstract_Settings_Screen {
 				'label' => __( 'Business Manager account', 'facebook-for-woocommerce' ),
 				'value' => facebook_for_woocommerce()->get_connection_handler()->get_business_manager_id(),
 			],
+			'ad-account' => [
+				'label' => __( 'Ad Manager account', 'facebook-for-woocommerce' ),
+				'value' => facebook_for_woocommerce()->get_connection_handler()->get_ad_account_id(),
+			],
 		];
 
 		// if the catalog ID is set, try and get its name for display

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -165,6 +165,7 @@ class Connection {
 			}
 
 			$this->update_access_token( $system_user_access_token );
+			$this->update_merchant_access_token( $merchant_access_token );
 			$this->update_system_user_id( $system_user_id );
 
 			$api = new \WC_Facebookcommerce_Graph_API( $merchant_access_token );

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -43,10 +43,10 @@ class Connection {
 	/** @var string the business manager ID option name */
 	const OPTION_BUSINESS_MANAGER_ID = 'wc_facebook_business_manager_id';
 
-	/** @var string the system user access token option name */
+	/** @var string the system user ID option name */
 	const OPTION_SYSTEM_USER_ID = 'wc_facebook_system_user_id';
 
-	/** @var string the access token option name */
+	/** @var string the system user access token option name */
 	const OPTION_ACCESS_TOKEN = 'wc_facebook_access_token';
 
 	/** @var string the merchant access token option name */

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -168,6 +168,7 @@ class Connection {
 			$this->update_merchant_access_token( $merchant_access_token );
 			$this->update_system_user_id( $system_user_id );
 
+			// TODO: use the system user access token once the fix for the fbe_installs endpoint is approved and deployed {WV 2020-06-17}
 			$api = new \WC_Facebookcommerce_Graph_API( $merchant_access_token );
 
 			$asset_ids = $api->get_asset_ids( $this->get_external_business_id() );

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -158,9 +158,14 @@ class Connection {
 				throw new SV_WC_API_Exception( 'System User access token is missing' );
 			}
 
-			$access_token = $this->create_system_user_token( $access_token );
+			$system_user_id = ! empty( $_GET['system_user_id'] ) ? sanitize_text_field( $_GET['system_user_id'] ) : '';
+
+			if ( ! $system_user_id ) {
+				throw new SV_WC_API_Exception( 'System User ID is missing' );
+			}
 
 			$this->update_access_token( $system_user_access_token );
+			$this->update_system_user_id( $system_user_id );
 
 			$api = new \WC_Facebookcommerce_Graph_API( $merchant_access_token );
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -460,6 +460,19 @@ class Connection {
 
 
 	/**
+	 * Gets the System User ID value.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_system_user_id() {
+
+		return get_option( self::OPTION_SYSTEM_USER_ID, '' );
+	}
+
+
+	/**
 	 * Gets the proxy URL.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -327,6 +327,8 @@ class Connection {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
+	 * @link https://developers.facebook.com/docs/marketing-api/access/#access_token
+	 *
 	 * @return string[]
 	 */
 	public function get_scopes() {
@@ -335,6 +337,8 @@ class Connection {
 			'manage_business_extension',
 			'catalog_management',
 			'business_management',
+			'ads_management',
+			'ads_read',
 		];
 
 		/**

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -451,8 +451,9 @@ class Connection {
 	public function get_redirect_url() {
 
 		$redirect_url = add_query_arg( [
-			'wc-api' => self::ACTION_CONNECT,
-			'nonce'  => wp_create_nonce( self::ACTION_CONNECT ),
+			'wc-api'               => self::ACTION_CONNECT,
+			'external_business_id' => $this->get_external_business_id(),
+			'nonce'                => wp_create_nonce( self::ACTION_CONNECT ),
 		], home_url( '/' ) );
 
 		/**

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -147,9 +147,15 @@ class Connection {
 				throw new SV_WC_API_Exception( 'Access token is missing' );
 			}
 
+			$system_user_access_token = ! empty( $_GET['system_user_access_token'] ) ? sanitize_text_field( $_GET['system_user_access_token'] ) : '';
+
+			if ( ! $system_user_access_token ) {
+				throw new SV_WC_API_Exception( 'System User access token is missing' );
+			}
+
 			$access_token = $this->create_system_user_token( $access_token );
 
-			$this->update_access_token( $access_token );
+			$this->update_access_token( $system_user_access_token );
 
 			$api = new \WC_Facebookcommerce_Graph_API( $access_token );
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -252,6 +252,8 @@ class Connection {
 	private function disconnect() {
 
 		$this->update_access_token( '' );
+		$this->update_merchant_access_token( '' );
+		$this->update_system_user_id( '' );
 		$this->update_business_manager_id( '' );
 
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '' );

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -43,6 +43,9 @@ class Connection {
 	/** @var string the business manager ID option name */
 	const OPTION_BUSINESS_MANAGER_ID = 'wc_facebook_business_manager_id';
 
+	/** @var string the system user access token option name */
+	const OPTION_SYSTEM_USER_ID = 'wc_facebook_system_user_id';
+
 	/** @var string the access token option name */
 	const OPTION_ACCESS_TOKEN = 'wc_facebook_access_token';
 
@@ -586,6 +589,19 @@ class Connection {
 	public function update_business_manager_id( $value ) {
 
 		update_option( self::OPTION_BUSINESS_MANAGER_ID, $value );
+	}
+
+
+	/**
+	 * Stores the given system user ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $value the ID
+	 */
+	public function update_system_user_id( $value ) {
+
+		update_option( self::OPTION_SYSTEM_USER_ID, $value );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -168,8 +168,7 @@ class Connection {
 			$this->update_merchant_access_token( $merchant_access_token );
 			$this->update_system_user_id( $system_user_id );
 
-			// TODO: use the system user access token once the fix for the fbe_installs endpoint is approved and deployed {WV 2020-06-17}
-			$api = new \WC_Facebookcommerce_Graph_API( $merchant_access_token );
+			$api = new \WC_Facebookcommerce_Graph_API( $system_user_access_token );
 
 			$asset_ids = $api->get_asset_ids( $this->get_external_business_id() );
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -46,6 +46,8 @@ class Connection {
 	/** @var string the access token option name */
 	const OPTION_ACCESS_TOKEN = 'wc_facebook_access_token';
 
+	/** @var string the merchant access token option name */
+	const OPTION_MERCHANT_ACCESS_TOKEN = 'wc_facebook_merchant_access_token';
 
 	/** @var string|null the generated external merchant settings ID */
 	private $external_business_id;
@@ -574,6 +576,19 @@ class Connection {
 	public function update_access_token( $value ) {
 
 		update_option( self::OPTION_ACCESS_TOKEN, $value );
+	}
+
+
+	/**
+	 * Stores the given merchant access token.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $value the access token
+	 */
+	public function update_merchant_access_token( $value ) {
+
+		update_option( self::OPTION_MERCHANT_ACCESS_TOKEN, $value );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -141,9 +141,9 @@ class Connection {
 				throw new SV_WC_API_Exception( 'Invalid nonce' );
 			}
 
-			$access_token = ! empty( $_GET['access_token'] ) ? sanitize_text_field( $_GET['access_token'] ) : '';
+			$merchant_access_token = ! empty( $_GET['merchant_access_token'] ) ? sanitize_text_field( $_GET['merchant_access_token'] ) : '';
 
-			if ( ! $access_token ) {
+			if ( ! $merchant_access_token ) {
 				throw new SV_WC_API_Exception( 'Access token is missing' );
 			}
 
@@ -157,7 +157,7 @@ class Connection {
 
 			$this->update_access_token( $system_user_access_token );
 
-			$api = new \WC_Facebookcommerce_Graph_API( $access_token );
+			$api = new \WC_Facebookcommerce_Graph_API( $merchant_access_token );
 
 			$asset_ids = $api->get_asset_ids( $this->get_external_business_id() );
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -289,6 +289,29 @@ class Connection {
 
 
 	/**
+	 * Gets the merchant access token.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_merchant_access_token() {
+
+		$access_token = get_option( self::OPTION_MERCHANT_ACCESS_TOKEN, '' );
+
+		/**
+		 * Filters the merchant access token.
+		 *
+		 * @since 2.0.0-dev.1
+		 *
+		 * @param string $access_token access token
+		 * @param Connection $connection connection handler instance
+		 */
+		return apply_filters( 'wc_facebook_connection_merchant_access_token', $access_token, $this );
+	}
+
+
+	/**
 	 * Gets the URL to start the connection flow.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -263,20 +263,6 @@ class Connection {
 
 
 	/**
-	 * Converts a temporary user token to a system user token via the Graph API.
-	 *
-	 * @since 2.0.0-dev.1
-	 *
-	 * @param string $user_token
-	 * @return string
-	 */
-	public function create_system_user_token( $user_token ) {
-
-		return $user_token;
-	}
-
-
-	/**
 	 * Gets the API access token.
 	 *
 	 * @since 2.0.0-dev.1

--- a/tests/integration/API/FBE/Installation/Read/ResponseTest.php
+++ b/tests/integration/API/FBE/Installation/Read/ResponseTest.php
@@ -13,7 +13,7 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 	/** @var \IntegrationTester */
 	protected $tester;
 
-	protected $data = '{"data":[{"business_manager_id":"1234","pixel_id":"5678","profiles":["123"],"catalog_id":"456","pages":["123"]}]}';
+	protected $data = '{"data":[{"business_manager_id":"1234","ad_account_id":"ad-account","pixel_id":"5678","profiles":["123"],"catalog_id":"456","pages":["123"]}]}';
 
 
 	public function _before() {
@@ -48,6 +48,15 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 		$response = new Response( $this->data );
 
 		$this->assertEquals( '1234', $response->get_business_manager_id() );
+	}
+
+
+	/** @see Response::get_ad_account_id() */
+	public function test_get_ad_account_id() {
+
+		$response = new Response( $this->data );
+
+		$this->assertEquals( 'ad-account', $response->get_ad_account_id() );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -220,6 +220,17 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_ad_account_id() */
+	public function test_get_ad_account_id() {
+
+		$ad_account_id = 'ad account id';
+
+		$this->get_connection()->update_ad_account_id( $ad_account_id );
+
+		$this->assertSame( $ad_account_id, $this->get_connection()->get_ad_account_id() );
+	}
+
+
 	/** @see Connection::get_system_user_id() */
 	public function test_get_system_user_id() {
 
@@ -359,6 +370,17 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 		$this->get_connection()->update_business_manager_id( $business_manager_id );
 
 		$this->assertSame( $business_manager_id, $this->get_connection()->get_business_manager_id() );
+	}
+
+
+	/** @see Connection::update_ad_account_id() */
+	public function test_update_ad_account_id() {
+
+		$ad_account_id = 'ad account id';
+
+		$this->get_connection()->update_ad_account_id( $ad_account_id );
+
+		$this->assertSame( $ad_account_id, $this->get_connection()->get_ad_account_id() );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -229,6 +229,17 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_system_user_id() */
+	public function test_get_system_user_id() {
+
+		$system_user_id = 'system user id';
+
+		$this->get_connection()->update_system_user_id( $system_user_id );
+
+		$this->assertSame( $system_user_id, $this->get_connection()->get_system_user_id() );
+	}
+
+
 	/** @see Connection::get_proxy_url() */
 	public function test_get_proxy_url() {
 
@@ -357,6 +368,17 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 		$this->get_connection()->update_business_manager_id( $business_manager_id );
 
 		$this->assertSame( $business_manager_id, $this->get_connection()->get_business_manager_id() );
+	}
+
+
+	/** @see Connection::update_system_user_id() */
+	public function test_update_system_user_id() {
+
+		$system_user_id = 'system user id';
+
+		$this->get_connection()->update_system_user_id( $system_user_id );
+
+		$this->assertSame( $system_user_id, $this->get_connection()->get_system_user_id() );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -57,6 +57,17 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_merchant_access_token() */
+	public function test_get_merchant_access_token() {
+
+		$access_token = 'access token';
+
+		$this->get_connection()->update_merchant_access_token( $access_token );
+
+		$this->assertSame( $access_token, $this->get_connection()->get_merchant_access_token() );
+	}
+
+
 	/** @see Connection::get_access_token() */
 	public function test_get_access_token_filter() {
 
@@ -357,6 +368,17 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 		$this->get_connection()->update_access_token( $access_token );
 
 		$this->assertSame( $access_token, $this->get_connection()->get_access_token() );
+	}
+
+
+	/** @see Connection::update_merchant_access_token() */
+	public function test_update_merchant_access_token() {
+
+		$access_token = 'access token';
+
+		$this->get_connection()->update_merchant_access_token( $access_token );
+
+		$this->assertSame( $access_token, $this->get_connection()->get_merchant_access_token() );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -37,15 +37,6 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Connection::create_system_user_token() */
-	public function test_create_system_user_token() {
-
-		$user_token = 'user token';
-
-		$this->assertEquals( $user_token, $this->get_connection()->create_system_user_token( $user_token ) );
-	}
-
-
 	/** @see Connection::get_access_token() */
 	public function test_get_access_token() {
 


### PR DESCRIPTION
# Summary

This PR adds the necessary modifications to get a system user access token from the connect app and use that new token for API requests.

### Story: [CH 55664](https://app.clubhouse.io/skyverge/story/55664)
### Release: #1277 

## Details

1. We now include in the external business ID in the redirect URL sent as the `state` parameter.
    
    We need to update the proxy app to create a System User before the user is redirected back to the website. The external business ID is used to retrieve the Business Manager ID connected to the FB Extension, which is a required parameter for the API requests that create the System User. It's also used to retrieve the IDs of the assets associated with the current installation.
2. The connect app now sends back the System User ID, the System User access token, and the merchant access token. This PR includes modifications to store the new values.
3. The System User access token is stored in the OPTION_ACCESS_TOKEN option and is used for most API requests.
4. The merchant access token is currently required to retrieve the IDs of the assets associated with the current installation.

## Open Questions

**Do we really need the merchant access token to retrieve the installation assets IDs?**

I [asked Connor](https://a8c.slack.com/archives/C010ND8MRPU/p1592418973316500?thread_ts=1591237950.248100&cid=C010ND8MRPU) whether is possible to use the System User access token to retrieve the installation assets IDs. If we can't, we would need to update `Connect::refresh_installation_data()` to use a different access token.

## QA

### Setup

1. Make sure the plugin is configured via snippets to connect through a local proxy running the changes from https://github.com/skyverge/woocommerce-connect/pull/4

### Steps

#### Connection

1. Connect your store
    - [x] The connection flow completes successfully

#### Products sync

1. Edit a product that has Facebook sync enabled
    - [x] The product is successfully updated in the Catalog
1. Edit a variable product that has Facebook sync enabled
    - [x] The product variations are updated using the Catalog Batch API
    - [x] The product variations are successfully updated in the Catalog

#### S2S

1. Add a product to cart
    - [x] The logs include a successful S2S API request for the AddToCart event
1. Go to Checkout
    - [x] The logs include a successful S2S API request for the InitiateCheckout event
1. Place the order
    - [x] The logs include a successful S2S API request for the Purchase event

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version