### PR TITLE
Messenger: add messenger upgrade notice

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -227,7 +227,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				if (
 					   $this->get_integration()->get_external_merchant_settings_id()
 					&& $this->get_integration()->is_messenger_enabled()
-					&& ( '#0084ff' !== $this->get_integration()->get_messenger_color_hex() || 'Hi! How can we help you?' !== $this->get_integration()->get_messenger_greeting() )
+					&& ( '#0084ff' !== $this->get_integration()->get_messenger_color_hex() || ! in_array( $this->get_integration()->get_messenger_greeting(), [ 'Hi! How can we help you?', "Hi! We're here to answer any questions you may have.", '' ], true ) )
 				) {
 
 					$message = sprintf(

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -232,7 +232,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 					$message = sprintf(
 					/* translators: Placeholders: %1$s - <strong> tag, %2$s - </strong> tag, %3$s - <a> tag, %4$s - </a> tag */
-						__( '%1$sHeads up!%2$s If you’ve customized your Facebook Messenger color or greeting settings, please update those settings again from the %3$sManage Connection%4$s area.', 'facebook-for-woocommerce' ),
+						__( '%1$sHeads up!%2$s If you\'ve customized your Facebook Messenger color or greeting settings, please update those settings again from the %3$sManage Connection%4$s area.', 'facebook-for-woocommerce' ),
 						'<strong>', '</strong>',
 						'<a href="' . esc_url( $this->get_connection_handler()->get_manage_url() ) . '" target="_blank">', '</a>'
 					);

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -219,6 +219,29 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 						'notice_class' => 'notice-info',
 					] );
 				}
+
+			// notices for those connected to FBE 2
+			} else {
+
+				// if upgraders had messenger enabled and one of the removed settings was customized, alert them to reconfigure
+				if (
+					   $this->get_integration()->get_external_merchant_settings_id()
+					&& $this->get_integration()->is_messenger_enabled()
+					&& ( '#0084ff' !== $this->get_integration()->get_messenger_color_hex() || 'Hi! How can we help you?' !== $this->get_integration()->get_messenger_greeting() )
+				) {
+
+					$message = sprintf(
+					/* translators: Placeholders: %1$s - <strong> tag, %2$s - </strong> tag, %3$s - <a> tag, %4$s - </a> tag */
+						__( '%1$sHeads up!%2$s If you’ve customized your Facebook Messenger color or greeting settings, please update those settings again from the %3$sManage Connection%4$s area.', 'facebook-for-woocommerce' ),
+						'<strong>', '</strong>',
+						'<a href="' . esc_url( $this->get_connection_handler()->get_manage_url() ) . '" target="_blank">', '</a>'
+					);
+
+					$this->get_admin_notice_handler()->add_admin_notice( $message, 'update_messenger', [
+						'always_show_on_settings' => false,
+						'notice_class'            => 'notice-info',
+					] );
+				}
 			}
 
 			// if the connection is otherwise invalid, but there is an access token

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -582,6 +582,15 @@ class Connection {
 			$parameters['setup']['merchant_settings_id'] = $external_merchant_settings_id;
 		}
 
+		// if messenger was previously enabled
+		if ( facebook_for_woocommerce()->get_integration()->is_messenger_enabled() ) {
+
+			$parameters['business_config']['messenger_chat'] = [
+				'enabled' => true,
+				'domains' => home_url( '/' ),
+			];
+		}
+
 		return $parameters;
 	}
 

--- a/tests/acceptance/Admin/NoticesCest.php
+++ b/tests/acceptance/Admin/NoticesCest.php
@@ -16,6 +16,7 @@ class NoticesCest {
 
 		// prevent API calls
 		$I->haveTransientInDatabase( 'wc_facebook_connection_refresh', time() );
+		$I->haveTransientInDatabase( 'wc_facebook_business_configuration_refresh', time() );
 
 		$I->loginAsAdmin();
 	}
@@ -63,6 +64,80 @@ class NoticesCest {
 		$I->amOnPluginsPage();
 
 		$I->dontSee( 'Your connection to Facebook is no longer valid', '.notice' );
+	}
+
+
+	/**
+	 * @see \WC_Facebookcommerce::add_admin_notices()
+	 */
+	public function try_messenger_prompt_new_install( AcceptanceTester $I ) {
+
+		$I->haveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_ACCESS_TOKEN, '12345' );
+
+		$I->amOnPluginsPage();
+
+		$I->dontSee( 'Heads up! If you\'ve customized your Facebook Messenger color or greeting settings, please update those settings again', '.notice' );
+	}
+
+
+	/**
+	 * @see \WC_Facebookcommerce::add_admin_notices()
+	 */
+	public function try_messenger_prompt_upgrade_messenger_disabled( AcceptanceTester $I ) {
+
+		$I->haveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_ACCESS_TOKEN, '12345' );
+		$I->haveOptionInDatabase( \WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '12345' );
+
+		$I->amOnPluginsPage();
+
+		$I->dontSee( 'Heads up! If you\'ve customized your Facebook Messenger color or greeting settings, please update those settings again', '.notice' );
+	}
+
+
+	/**
+	 * @see \WC_Facebookcommerce::add_admin_notices()
+	 */
+	public function try_messenger_prompt_upgrade_messenger_enabled_default( AcceptanceTester $I ) {
+
+		$I->haveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_ACCESS_TOKEN, '12345' );
+		$I->haveOptionInDatabase( \WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '12345' );
+		$I->haveOptionInDatabase( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, 'yes' );
+
+		$I->amOnPluginsPage();
+
+		$I->dontSee( 'Heads up! If you\'ve customized your Facebook Messenger color or greeting settings, please update those settings again', '.notice' );
+	}
+
+
+	/**
+	 * @see \WC_Facebookcommerce::add_admin_notices()
+	 */
+	public function try_messenger_prompt_upgrade_messenger_enabled_customized_color( AcceptanceTester $I ) {
+
+		$I->haveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_ACCESS_TOKEN, '12345' );
+		$I->haveOptionInDatabase( \WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '12345' );
+		$I->haveOptionInDatabase( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, 'yes' );
+		$I->haveOptionInDatabase( \WC_Facebookcommerce_Integration::SETTING_MESSENGER_COLOR_HEX, 'custom' );
+
+		$I->amOnPluginsPage();
+
+		$I->see( 'Heads up! If you\'ve customized your Facebook Messenger color or greeting settings, please update those settings again', '.notice' );
+	}
+
+
+	/**
+	 * @see \WC_Facebookcommerce::add_admin_notices()
+	 */
+	public function try_messenger_prompt_upgrade_messenger_enabled_customized_greeting( AcceptanceTester $I ) {
+
+		$I->haveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_ACCESS_TOKEN, '12345' );
+		$I->haveOptionInDatabase( \WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '12345' );
+		$I->haveOptionInDatabase( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, 'yes' );
+		$I->haveOptionInDatabase( \WC_Facebookcommerce_Integration::SETTING_MESSENGER_GREETING, 'custom' );
+
+		$I->amOnPluginsPage();
+
+		$I->see( 'Heads up! If you\'ve customized your Facebook Messenger color or greeting settings, please update those settings again', '.notice' );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -320,6 +320,9 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayHasKey( 'business', $extras['business_config'] );
 
 		$this->assertEquals( $connection->get_business_name(), $extras['business_config']['business']['name'] );
+
+		// messenger shouldn't be enabled by default
+		$this->assertArrayNotHasKey( 'messenger_chat', $extras['business_config'] );
 	}
 
 
@@ -328,6 +331,8 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 
 		facebook_for_woocommerce()->get_integration()->update_external_merchant_settings_id( '1234' );
 
+		update_option( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, 'yes' );
+
 		$connection = $this->get_connection();
 
 		$method = IntegrationTester::getMethod( Connection::class, 'get_connect_parameters_extras' );
@@ -335,6 +340,10 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayHasKey( 'merchant_settings_id', $extras['setup'] );
 		$this->assertSame( '1234', $extras['setup']['merchant_settings_id'] );
+
+		$this->assertArrayHasKey( 'messenger_chat', $extras['business_config'] );
+		$this->assertTrue( $extras['business_config']['messenger_chat']['enabled'] );
+		$this->assertSame( home_url( '/' ), $extras['business_config']['messenger_chat']['domains'] );
 	}
 
 


### PR DESCRIPTION
# Summary

Adds a notice for folks upgrading from v1.x to prompt them to reconfigure messenger.

### Story: [CH 57143](https://app.clubhouse.io/skyverge/story/57143)
### Release: #1277 

## UI Changes

- New notice: https://cloud.skyver.ge/NQug1A8w

## QA

### Common steps

1. Uninstall from the Connection tab
1. Checkout the tagged version `1.11.4`
1. Clear all facebook DB options
1. Connect the plugin

### Cases

#### Messenger enabled and customized

1. Follow the above common steps
1. From the FBE popup, enable messenger and customize it
1. Save your settings
    - [x] The messenger is loaded as expected on the frontend
1. Check out this branch & visit the Plugins page (to trigger routines)
1. Visit the frontend
    - [x] The messenger is loaded as expected
1. Visit any admin page
    - [x] The new notice is _not_ displayed
1. Follow the reconnect flow and migrate to FBE 2
    - [x] The new notice is displayed
1. Visit the frontend
    - [x] The messenger is loaded as expected, except for the greeting & color

#### Messenger enabled, defaults

1. Follow the above common steps
1. From the FBE popup, enable messenger but leave the defaults
1. Save your settings
    - [x] The messenger is loaded as expected on the frontend
1. Check out this branch & visit the Plugins page (to trigger routines)
1. Follow the reconnect flow and migrate to FBE 2
    - [x] The new notice is _not_ displayed

#### Messenger disabled

1. Follow the above common steps
1. Do not enable messenger
1. Check out this branch & visit the Plugins page (to trigger routines)
1. Follow the reconnect flow and migrate to FBE 2
    - [x] The new notice is _not_ displayed
1. Visit the frontend
    - [x] Messenger does not load

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version