### PR TITLE
Store and display the ad account on connection

### DIFF
--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -49,6 +49,19 @@ class Response extends API\Response  {
 
 
 	/**
+	 * Gets the ad account ID.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_ad_account_id() {
+
+		return ! empty( $this->get_data()->ad_account_id ) ? $this->get_data()->ad_account_id : '';
+	}
+
+
+	/**
 	 * Gets the catalog ID.
 	 *
 	 * @since 2.0.0-dev.1

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -139,6 +139,10 @@ class Connection extends Admin\Abstract_Settings_Screen {
 				'label' => __( 'Business Manager account', 'facebook-for-woocommerce' ),
 				'value' => facebook_for_woocommerce()->get_connection_handler()->get_business_manager_id(),
 			],
+			'ad-account' => [
+				'label' => __( 'Ad Manager account', 'facebook-for-woocommerce' ),
+				'value' => facebook_for_woocommerce()->get_connection_handler()->get_ad_account_id(),
+			],
 		];
 
 		// if the catalog ID is set, try and get its name for display

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -262,6 +262,7 @@ class Connection {
 		$this->update_merchant_access_token( '' );
 		$this->update_system_user_id( '' );
 		$this->update_business_manager_id( '' );
+		$this->update_ad_account_id( '' );
 
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -83,8 +83,10 @@ class Connection {
 	 * Refreshes the connected installation data.
 	 *
 	 * @since 2.0.0-dev.1
+	 *
+	 * @param bool $force whether to force the refresh
 	 */
-	public function refresh_installation_data() {
+	public function refresh_installation_data( $force = false ) {
 
 		// bail if not connected
 		if ( ! $this->is_connected() ) {
@@ -92,7 +94,7 @@ class Connection {
 		}
 
 		// only refresh once a day
-		if ( get_transient( 'wc_facebook_connection_refresh' ) ) {
+		if ( ! $force && get_transient( 'wc_facebook_connection_refresh' ) ) {
 			return;
 		}
 
@@ -175,25 +177,7 @@ class Connection {
 			$this->update_merchant_access_token( $merchant_access_token );
 			$this->update_system_user_id( $system_user_id );
 
-			$api = new \WC_Facebookcommerce_Graph_API( $system_user_access_token );
-
-			$asset_ids = $api->get_asset_ids( $this->get_external_business_id() );
-
-			if ( ! empty( $asset_ids['page_id'] ) ) {
-				update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $asset_ids['page_id'] ) );
-			}
-
-			if ( ! empty( $asset_ids['pixel_id'] ) ) {
-				update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, sanitize_text_field( $asset_ids['pixel_id'] ) );
-			}
-
-			if ( ! empty( $asset_ids['catalog_id'] ) ) {
-				update_option( \WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, sanitize_text_field( $asset_ids['catalog_id'] ) );
-			}
-
-			if ( ! empty( $asset_ids['business_manager_id'] ) ) {
-				$this->update_business_manager_id( sanitize_text_field( $asset_ids['business_manager_id'] ) );
-			}
+			$this->refresh_installation_data( true );
 
 			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -118,6 +118,10 @@ class Connection {
 				$this->update_business_manager_id( sanitize_text_field( $response->get_business_manager_id() ) );
 			}
 
+			if ( $response->get_ad_account_id() ) {
+				$this->update_ad_account_id( sanitize_text_field( $response->get_ad_account_id() ) );
+			}
+
 		} catch ( SV_WC_API_Exception $exception ) {
 
 			if ( $integration->is_debug_mode_enabled() ) {

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -43,6 +43,9 @@ class Connection {
 	/** @var string the business manager ID option name */
 	const OPTION_BUSINESS_MANAGER_ID = 'wc_facebook_business_manager_id';
 
+	/** @var string the ad account ID option name */
+	const OPTION_AD_ACCOUNT_ID = 'wc_facebook_ad_account_id';
+
 	/** @var string the system user ID option name */
 	const OPTION_SYSTEM_USER_ID = 'wc_facebook_system_user_id';
 
@@ -454,6 +457,19 @@ class Connection {
 
 
 	/**
+	 * Gets the ad account ID value.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_ad_account_id() {
+
+		return get_option( self::OPTION_AD_ACCOUNT_ID, '' );
+	}
+
+
+	/**
 	 * Gets the System User ID value.
 	 *
 	 * @since 2.0.0-dev.1
@@ -596,6 +612,19 @@ class Connection {
 	public function update_business_manager_id( $value ) {
 
 		update_option( self::OPTION_BUSINESS_MANAGER_ID, $value );
+	}
+
+
+	/**
+	 * Stores the given ID value.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param string $value the ad account ID
+	 */
+	public function update_ad_account_id( $value ) {
+
+		update_option( self::OPTION_AD_ACCOUNT_ID, $value );
 	}
 
 

--- a/tests/integration/API/FBE/Installation/Read/ResponseTest.php
+++ b/tests/integration/API/FBE/Installation/Read/ResponseTest.php
@@ -13,7 +13,7 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 	/** @var \IntegrationTester */
 	protected $tester;
 
-	protected $data = '{"data":[{"business_manager_id":"1234","pixel_id":"5678","profiles":["123"],"catalog_id":"456","pages":["123"]}]}';
+	protected $data = '{"data":[{"business_manager_id":"1234","ad_account_id":"ad-account","pixel_id":"5678","profiles":["123"],"catalog_id":"456","pages":["123"]}]}';
 
 
 	public function _before() {
@@ -48,6 +48,15 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 		$response = new Response( $this->data );
 
 		$this->assertEquals( '1234', $response->get_business_manager_id() );
+	}
+
+
+	/** @see Response::get_ad_account_id() */
+	public function test_get_ad_account_id() {
+
+		$response = new Response( $this->data );
+
+		$this->assertEquals( 'ad-account', $response->get_ad_account_id() );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -37,15 +37,6 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Connection::create_system_user_token() */
-	public function test_create_system_user_token() {
-
-		$user_token = 'user token';
-
-		$this->assertEquals( $user_token, $this->get_connection()->create_system_user_token( $user_token ) );
-	}
-
-
 	/** @see Connection::get_access_token() */
 	public function test_get_access_token() {
 
@@ -229,6 +220,17 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_ad_account_id() */
+	public function test_get_ad_account_id() {
+
+		$ad_account_id = 'ad account id';
+
+		$this->get_connection()->update_ad_account_id( $ad_account_id );
+
+		$this->assertSame( $ad_account_id, $this->get_connection()->get_ad_account_id() );
+	}
+
+
 	/** @see Connection::get_system_user_id() */
 	public function test_get_system_user_id() {
 
@@ -368,6 +370,17 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 		$this->get_connection()->update_business_manager_id( $business_manager_id );
 
 		$this->assertSame( $business_manager_id, $this->get_connection()->get_business_manager_id() );
+	}
+
+
+	/** @see Connection::update_ad_account_id() */
+	public function test_update_ad_account_id() {
+
+		$ad_account_id = 'ad account id';
+
+		$this->get_connection()->update_ad_account_id( $ad_account_id );
+
+		$this->assertSame( $ad_account_id, $this->get_connection()->get_ad_account_id() );
 	}
 
 


### PR DESCRIPTION
# Summary

Stores the ad account after connection and displays it on the frontend, like the other asset IDs.

### Story: [CH 1234](story-url)
### Release: #1412 

## Details

We cannot query the API for the ad account's name or URL, so the raw ID will be displayed.

## UI Changes

- New **Ad Manager account** row: https://cloud.skyver.ge/d5uWPn9m

## QA

1. Connect the plugin using your local proxy app as detailed in https://github.com/skyverge/woocommerce-connect/pull/4
    - [x] The Ad Manager account ID is displayed on the settings page

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version