### PR TITLE
Add new settings location notice

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -176,14 +176,11 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 			parent::add_admin_notices();
 
-			// inform users that they need to connect
+			// inform users who are not connected to Facebook
 			if ( ! $this->get_connection_handler()->is_connected() ) {
 
-				$message    = '';
-				$message_id = '';
-
-				//  to FBE 2.0 if they've upgraded from FBE 1.x
-				if ( 'no' === get_option( 'wc_facebook_has_connected_fbe_2' ) && $this->get_integration()->get_external_merchant_settings_id() ) {
+				// users who've never connected to FBE 2 but have previously connected to FBE 1
+				if ( ! $this->get_connection_handler()->has_previously_connected_fbe_2() && $this->get_connection_handler()->has_previously_connected_fbe_1() ) {
 
 					$message = sprintf(
 						/* translators: Placeholders %1$s - opening strong HTML tag, %2$s - closing strong HTML tag, %3$s - opening link HTML tag, %4$s - closing link HTML tag */

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -189,7 +189,25 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 						'<a href="' . esc_url( $this->get_connection_handler()->get_connect_url() ) . '">', '</a>'
 					);
 
-					$message_id = 'migrate_to_v2_0';
+					$this->get_admin_notice_handler()->add_admin_notice( $message, self::PLUGIN_ID . '_migrate_to_v2_0', [
+						'dismissible'  => false,
+						'notice_class' => 'notice-info',
+					] );
+
+					// direct these users to the new plugin settings page
+					if ( ! $this->is_plugin_settings() ) {
+
+						$message = sprintf(
+							/* translators: Placeholders %1$s - opening link HTML tag, %2$s - closing link HTML tag */
+							__( 'For your convenience, the Facebook for WooCommerce settings are now located under %1$sWooCommerce > Facebook%2$s.', 'facebook-for-woocommerce' ),
+							'<a href="' . esc_url( facebook_for_woocommerce()->get_settings_url() ) . '">', '</a>'
+						);
+
+						$this->get_admin_notice_handler()->add_admin_notice( $message, self::PLUGIN_ID . '_relocated_settings', [
+							'dismissible'  => true,
+							'notice_class' => 'notice-info',
+						] );
+					}
 
 				// otherwise, a general getting started message
 				} elseif ( ! $this->is_plugin_settings() ) {
@@ -206,13 +224,8 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 						'</a>'
 					);
 
-					$message_id = 'get_started';
-				}
-
-				if ( $message ) {
-
-					$this->get_admin_notice_handler()->add_admin_notice( $message, self::PLUGIN_ID . '_' . $message_id, [
-						'dismissible'  => false,
+					$this->get_admin_notice_handler()->add_admin_notice( $message, self::PLUGIN_ID . '_get_started', [
+						'dismissible'  => true,
 						'notice_class' => 'notice-info',
 					] );
 				}

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -51,11 +51,12 @@ abstract class Abstract_Settings_Screen {
 			return;
 		}
 
-		$is_connected = facebook_for_woocommerce()->get_connection_handler()->is_connected();
+		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
+		$is_connected       = $connection_handler->is_connected();
 
 		?>
 
-		<?php if ( ! $is_connected && $this->get_disconnected_message() ) : ?>
+		<?php if ( ! $is_connected && ! $connection_handler->has_previously_connected_fbe_1() && $this->get_disconnected_message() ) : ?>
 			<div class="notice notice-info"><p><?php echo wp_kses_post( $this->get_disconnected_message() ); ?></p></div>
 		<?php endif; ?>
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -582,6 +582,34 @@ class Connection {
 
 
 	/**
+	 * Determines whether the site has previously connected to FBE 2.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function has_previously_connected_fbe_2() {
+
+		return 'yes' === get_option( 'wc_facebook_has_connected_fbe_2' );
+	}
+
+
+	/**
+	 * Determines whether the site has previously connected to FBE 1.x.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function has_previously_connected_fbe_1() {
+
+		$integration = $this->get_plugin()->get_integration();
+
+		return $integration && $integration->get_external_merchant_settings_id();
+	}
+
+
+	/**
 	 * Gets the client ID for connection.
 	 *
 	 * @since 2.0.0-dev.1

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -396,6 +396,7 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see test_has_previously_connected_fbe_2 */
 	public function provider_has_previously_connected_fbe_2() {
 
 		return [
@@ -422,6 +423,7 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see test_has_previously_connected_fbe_1 */
 	public function provider_has_previously_connected_fbe_1() {
 
 		return [

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -378,6 +378,59 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * @see Connection::has_previously_connected_fbe_2()
+	 *
+	 * @dataProvider provider_has_previously_connected_fbe_2
+	 *
+	 * @param string|null $option_value option value to set, or null to not set one
+	 * @param bool $expected_value expected result
+	 */
+	public function test_has_previously_connected_fbe_2( $option_value, $expected_value ) {
+
+		if ( $option_value ) {
+			update_option( 'wc_facebook_has_connected_fbe_2', $option_value );
+		}
+
+		$this->assertSame( $expected_value, $this->get_connection()->has_previously_connected_fbe_2() );
+	}
+
+
+	public function provider_has_previously_connected_fbe_2() {
+
+		return [
+			'not set'                  => [ null, false ],
+			'not previously connected' => [ 'no', false ],
+			'previously connected'     => [ 'yes', true ],
+		];
+	}
+
+
+	/**
+	 * @see Connection::has_previously_connected_fbe_1()
+	 *
+	 * @dataProvider provider_has_previously_connected_fbe_1
+	 *
+	 * @param string|null $option_value option value to set, or null to not set one
+	 * @param bool $expected_value expected result
+	 */
+	public function test_has_previously_connected_fbe_1( $option_value, $expected_value ) {
+
+		facebook_for_woocommerce()->get_integration()->update_external_merchant_settings_id( $option_value );
+
+		$this->assertSame( $expected_value, $this->get_connection()->has_previously_connected_fbe_1() );
+	}
+
+
+	public function provider_has_previously_connected_fbe_1() {
+
+		return [
+			'not previously connected' => [ '', false ],
+			'previously connected'     => [ '1234', true ],
+		];
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 


### PR DESCRIPTION
# Summary

Adds a notice for upgraders to inform them of the new settings location.

### Story: [CH 57142](https://app.clubhouse.io/skyverge/story/57142)
### Release: #1277 

## Details

Adds some helper methods to determine when sites have previously connected to either FBE 1 or 2.

## UI Changes

- New notice: https://cloud.skyver.ge/rRul01Dz

## QA

1. Disconnect the plugin
1. Remove all facebook DB options
1. Refresh any non-settings admin page
    - [x] The `Facebook for WooCommerce is almost ready` notice is displayed and dismissible
1. Manually add the `wc_facebook_external_merchant_settings_id` option with any value
1. Refresh any admin page
    - [x] The "reconnect" notice is displayed
    - [x] The new notice is displayed and dismissible
1. Manually add the `wc_facebook_has_connected_fbe_2` option with `yes` as the value
    - [ ] The "reconnect" notice is displayed
    - [x] The new notice is _not_ displayed
1. Connect the plugin
    - [x] No notices are displayed
## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version