### PR TITLE
Truncate product brand values to 100 characters

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -10,6 +10,7 @@
 
 use SkyVerge\WooCommerce\Facebook\Admin;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper;
 use SkyVerge\WooCommerce\Facebook\Products;
 use SkyVerge\WooCommerce\Facebook\Products\Feed;
 
@@ -1791,7 +1792,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				'description'  => strip_tags( $product_data['description'] ),
 				'id'           => $product_data['retailer_id'],
 				'image_link'   => $product_data['image_url'],
-				'brand'        => strip_tags( WC_Facebookcommerce_Utils::get_store_name() ),
+				'brand'        => SV_WC_Helper::str_truncate( strip_tags( WC_Facebookcommerce_Utils::get_store_name() ), 100 ),
 				'link'         => $product_data['url'],
 				'price'        => $product_data['price'] . ' ' . get_woocommerce_currency(),
 			];

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -10,7 +10,6 @@
 
 use SkyVerge\WooCommerce\Facebook\Admin;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
-use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper;
 use SkyVerge\WooCommerce\Facebook\Products;
 use SkyVerge\WooCommerce\Facebook\Products\Feed;
 
@@ -1792,7 +1791,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				'description'  => strip_tags( $product_data['description'] ),
 				'id'           => $product_data['retailer_id'],
 				'image_link'   => $product_data['image_url'],
-				'brand'        => SV_WC_Helper::str_truncate( strip_tags( WC_Facebookcommerce_Utils::get_store_name() ), 100 ),
+				'brand'        => Framework\SV_WC_Helper::str_truncate( strip_tags( WC_Facebookcommerce_Utils::get_store_name() ), 100 ),
 				'link'         => $product_data['url'],
 				'price'        => $product_data['price'] . ' ' . get_woocommerce_currency(),
 			];

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1791,7 +1791,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				'description'  => strip_tags( $product_data['description'] ),
 				'id'           => $product_data['retailer_id'],
 				'image_link'   => $product_data['image_url'],
-				'brand'        => Framework\SV_WC_Helper::str_truncate( strip_tags( WC_Facebookcommerce_Utils::get_store_name() ), 100 ),
+				'brand'        => Framework\SV_WC_Helper::str_truncate( wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() ), 100 ),
 				'link'         => $product_data['url'],
 				'price'        => $product_data['price'] . ' ' . get_woocommerce_currency(),
 			];

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -542,10 +542,9 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			}
 			$categories =
 			WC_Facebookcommerce_Utils::get_product_categories( $id );
-			$brand      = get_the_term_list( $id, 'product_brand', '', ', ' );
-			$brand      = is_wp_error( $brand ) || ! $brand
-			? WC_Facebookcommerce_Utils::get_store_name()
-			: WC_Facebookcommerce_Utils::clean_string( $brand );
+
+			$brand = get_the_term_list( $id, 'product_brand', '', ', ' );
+			$brand = is_wp_error( $brand ) || ! $brand ? wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() ) : WC_Facebookcommerce_Utils::clean_string( $brand );
 
 			$product_data = array(
 				'name'                  => WC_Facebookcommerce_Utils::clean_string(

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -9,7 +9,7 @@
  */
 
 use SkyVerge\WooCommerce\Facebook\Products;
-use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -556,7 +556,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				'additional_image_urls' => array_slice( $image_urls, 1 ),
 				'url'                   => $product_url,
 				'category'              => $categories['categories'],
-				'brand'                 => SV_WC_Helper::str_truncate( $brand, 100 ),
+				'brand'                 => Framework\SV_WC_Helper::str_truncate( $brand, 100 ),
 				'retailer_id'           => $retailer_id,
 				'price'                 => $this->get_fb_price(),
 				'currency'              => get_woocommerce_currency(),

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -9,6 +9,7 @@
  */
 
 use SkyVerge\WooCommerce\Facebook\Products;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -555,7 +556,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				'additional_image_urls' => array_slice( $image_urls, 1 ),
 				'url'                   => $product_url,
 				'category'              => $categories['categories'],
-				'brand'                 => $brand,
+				'brand'                 => SV_WC_Helper::str_truncate( $brand, 100 ),
 				'retailer_id'           => $retailer_id,
 				'price'                 => $this->get_fb_price(),
 				'currency'              => get_woocommerce_currency(),


### PR DESCRIPTION
# Summary

This PR truncates the brand property included in product data to be 100 characters or less.

### Story: [CH 56869](https://app.clubhouse.io/skyverge/story/56869)
### Release: #1277 

## Details

If the brand name is more than 100 characters long, the API fails with an error like the one below:

```
{"error":{"message":"Invalid parameter","type":"OAuthException","code":100,"error_subcode":1803059,"is_transient":false,"error_user_title":"El campo es demasiado largo","error_user_msg":"El valor de brand supera los 100 caracteres.","fbtrace_id":"A-j56AbnqBPho8EqrNeitBC"}}
```

## QA

### Setup

- Set the site title to something > 100 characters, like `Supposedly there are over one million words in the English Language - We trimmed some fat to take away really odd words and determiners`
- Enable debug log for Facebook for WooCommerce

### Sync products

1. Update a simple product with sync enabled
	- [x] The product is synced successfully
	- [x] No error notices are shown
	- [x] There are no errors in the response logs

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
