### PR TITLE
Update on_variable_product_publish() to verify individual variations should be synced

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1127,9 +1127,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// scheduled update for each variation that should be synced
 		foreach ( $woo_product->get_children() as $variation_id ) {
 
-			if ( ! $variation = wc_get_product( $variation_id ) ) {
-				continue;
-			}
+			$variation = wc_get_product( $variation_id )
 
 			if ( $variation instanceof \WC_Product && $this->product_should_be_synced( $variation ) && ! $this->delete_on_out_of_stock( $variation_id, $variation ) ) {
 				$variation_ids[] = $variation_id;

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1122,12 +1122,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$this->create_product_group( $woo_product, $retailer_id, true );
 		}
 
-		$child_products = $woo_product->get_children();
-
 		$variation_ids = [];
 
 		// scheduled update for each variation that should be synced
-		foreach ( $child_products as $variation_id ) {
+		foreach ( $woo_product->get_children() as $variation_id ) {
 
 			if ( ! $variation = wc_get_product( $variation_id ) ) {
 				continue;

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1124,11 +1124,21 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		$child_products = $woo_product->get_children();
 
-		// scheduled update for each variation
-		foreach ( $child_products as $item_id ) {
+		$variation_ids = [];
 
-			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( [ $item_id ] );
+		// scheduled update for each variation that should be synced
+		foreach ( $child_products as $variation_id ) {
+
+			if ( ! $variation = wc_get_product( $variation_id ) ) {
+				continue;
+			}
+
+			if ( $variation instanceof \WC_Product && $this->product_should_be_synced( $variation ) && ! $this->delete_on_out_of_stock( $variation_id, $variation ) ) {
+				$variation_ids[] = $variation_id;
+			}
 		}
+
+		facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( $variation_ids );
 	}
 
 

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -1084,6 +1084,34 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	}
 
 
+	/** @see \WC_Facebookcommerce_Integration::on_variable_product_publish() */
+	public function test_on_variable_product_publish_with_out_of_stock_product_variations() {
+
+		$product = $this->tester->get_variable_product( [
+			'children'     => 3,
+			'status'       => 'publish',
+		] );
+
+		$excluded_variation_ids = array_slice( $product->get_children(), -2 );
+
+		foreach ( $excluded_variation_ids as $variation_id ) {
+
+			$variation = wc_get_product( $variation_id );
+
+			$variation->set_stock_status( 'outofstock' );
+			$variation->save();
+		}
+
+		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
+
+		$this->check_on_variable_product_publish_does_not_sync_product_variations(
+			$product->get_id(),
+			$product,
+			$excluded_variation_ids
+		);
+	}
+
+
 	/** @see \WC_Facebookcommerce_Integration::on_simple_product_publish() */
 	public function test_on_simple_product_publish() {
 

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -1112,6 +1112,26 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	}
 
 
+	/** @see \WC_Facebookcommerce_Integration::on_variable_product_publish() */
+	public function test_on_variable_product_publish_with_do_not_sync_product_variations() {
+
+		$product = $this->tester->get_variable_product( [
+			'children'     => 3,
+			'status'       => 'publish',
+		] );
+
+		$excluded_variation_ids = array_slice( $product->get_children(), -2 );
+
+		Products::disable_sync_for_products( array_map( 'wc_get_product', $excluded_variation_ids ) );
+
+		$this->check_on_variable_product_publish_does_not_sync_product_variations(
+			$product->get_id(),
+			$product,
+			$excluded_variation_ids
+		);
+	}
+
+
 	/** @see \WC_Facebookcommerce_Integration::on_simple_product_publish() */
 	public function test_on_simple_product_publish() {
 


### PR DESCRIPTION
# Summary

This PR updates `WC_Facebookcommerce_Integration::on_variable_product_publish()` to also check whether each variation should be synced or not.

### Story: [CH 56109](https://app.clubhouse.io/skyverge/story/56109)
### Release: #1277

## Details

The current implementation accidentally allows variations excluded from Facebook sync or that should be deleted given their stock status to be synced.

The story also mentions that `update_fb_visibility()` doesn't perform any verifications for variations, but I realized we are only calling that method from places where those verifications are being made ([here](https://github.com/facebookincubator/facebook-for-woocommerce/blob/f686e897198ab51df5cafe8cf19923a0a291e361/facebook-commerce.php#L1038) and [here](https://github.com/facebookincubator/facebook-for-woocommerce/blob/f686e897198ab51df5cafe8cf19923a0a291e361/facebook-commerce.php#L3355)), so I no longer believe we need to make changes there.

## QA

### Setup

- Check Out of stock visibility in WooCommerce > Settings > Products > Inventory to hide out of stock items from the catalog

### Steps

1. Add a variable product
1. Add a variation with price, in stock, and configured to Sync and show
1. Add a variation with price and out of stock
1. Add a variation with price and configured to Do not sync
    - [x] The variation with price, in stock, and configured to Sync and show is synced to Facebook
    - [x] No other variations are synced

#### Tests

- [x] `codecept run integration` pass
