### PR TITLE
Include Sync and hide products in all products sync

### DIFF
--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -108,10 +108,6 @@ class Sync {
 
 			$woo_product = new \WC_Facebook_Product( $product_id );
 
-			if ( $woo_product->is_hidden() ) {
-				continue;
-			}
-
 			// skip if we don't have a valid product object
 			if ( ! $woo_product->woo_product instanceof \WC_Product ) {
 				continue;

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -566,10 +566,6 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 
 					$woo_product = new WC_Facebook_Product( $wp_id );
 
-					if ( $woo_product->is_hidden() ) {
-						continue;
-					}
-
 					// skip if we don't have a valid product object
 					if ( ! $woo_product->woo_product instanceof \WC_Product ) {
 						continue;

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use SkyVerge\WooCommerce\Facebook\Products;
 use SkyVerge\WooCommerce\Facebook\Products\Sync;
 
 /**
@@ -104,6 +105,25 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 
 			$this->assertArrayNotHasKey( $index, $requests );
 		}
+	}
+
+
+	/** @see Sync::create_or_update_all_products() */
+	public function test_create_or_update_all_products_with_hidden_product() {
+
+		$product = $this->tester->get_variable_product( [ 'children' => 1 ] );
+
+		$variation = wc_get_product( current( $product->get_children() ) );
+		$variation->set_regular_price( 4.99 );
+		$variation->save();
+
+		Products::enable_sync_for_products( [ $variation ] );
+		Products::set_product_visibility( $variation, false );
+
+		// add all eligible products to the sync queue
+		$requests = $this->create_or_update_all_products();
+
+		$this->tester->assertProductsAreScheduledForSync( [ $variation->get_id() ], $requests );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR updates the `Sync::create_or_update_all_products()` to include Sync and hide products and products variations in the list of products to sync.

### Story: [CH 57662](https://app.clubhouse.io/skyverge/story/57662)
### Release: #1277

## QA

### Steps

1. Enable debug log
1. Add a product configured to Sync and hide
1. Sync products from WooCommerce > Facebook > Product sync
1. Wait for the batch requests to occur
    - [ ] The requests include data for the Sync and hide products (look for wc_post_id_{id})

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
