### PR TITLE
Include partner_agent field in S2S pixel event requests

### DIFF
--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -82,13 +82,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Pixel' ) ) :
 		 */
 		private function get_pixel_init_code() {
 
-			$version_info = self::get_version_info();
-			$agent_string = sprintf(
-				'%s-%s-%s',
-				$version_info['source'],
-				$version_info['version'],
-				$version_info['pluginVersion']
-			);
+			$agent_string = Event::get_platform_identifier();
 
 			/**
 			 * Filters Facebook Pixel init code.

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -8,6 +8,8 @@
  * @package FacebookCommerce
  */
 
+use SkyVerge\WooCommerce\Facebook\Events\Event;
+
 if ( ! class_exists( 'WC_Facebookcommerce_Pixel' ) ) :
 
 
@@ -459,7 +461,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Pixel' ) ) :
 		 */
 		private static function build_params( $params = [], $event = '' ) {
 
-			$params = array_replace( self::get_version_info(), $params );
+			$params = array_replace( Event::get_version_info(), $params );
 
 			/**
 			 * Filters the parameters for the pixel code.

--- a/includes/API/Pixel/Events/Request.php
+++ b/includes/API/Pixel/Events/Request.php
@@ -51,7 +51,8 @@ class Request extends API\Request {
 	public function get_data() {
 
 		$data = [
-			'data' => [],
+			'data'          => [],
+			'partner_agent' => Event::get_platform_identifier(),
 		];
 
 		foreach ( $this->events as $event ) {

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -29,6 +29,25 @@ class Event {
 
 
 	/**
+	 * Gets version information for pixel events.
+	 *
+	 * @return array {
+	 *     @type string source 'woocommerce'
+	 *     @type string version WooCommerce's version
+	 *     @type string pluginVersion Facebook for WooCommerce's version
+	 * }
+	 */
+	public static function get_version_info() {
+
+		return [
+			'source'        => 'woocommerce',
+			'version'       => WC()->version,
+			'pluginVersion' => facebook_for_woocommerce()->get_version(),
+		];
+	}
+
+
+	/**
 	 * Constructor.
 	 *
 	 * @see https://developers.facebook.com/docs/marketing-api/server-side-api/parameters

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -48,6 +48,19 @@ class Event {
 
 
 	/**
+	 * Gets the agent string for pixel events.
+	 *
+	 * @return string
+	 */
+	public static function get_platform_identifier() {
+
+		$info = self::get_version_info();
+
+		return "{$info['source']}-{$info['version']}-{$info['pluginVersion']}";
+	}
+
+
+	/**
 	 * Constructor.
 	 *
 	 * @see https://developers.facebook.com/docs/marketing-api/server-side-api/parameters

--- a/tests/integration/API/Pixel/Events/RequestTest.php
+++ b/tests/integration/API/Pixel/Events/RequestTest.php
@@ -19,17 +19,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		if ( ! class_exists( Event::class ) ) {
-			require_once 'includes/Events/Event.php';
-		}
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
 
-		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\API\Request::class ) ) {
-			require_once 'includes/API/Request.php';
-		}
-
-		if ( ! class_exists( Request::class ) ) {
-			require_once 'includes/API/Pixel/Events/Request.php';
-		}
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
 	}
 
 
@@ -64,6 +58,9 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertIsArray( $data['data'] );
 		$this->assertNotEmpty( $data['data'] );
 		$this->assertArrayHasKey( 'event_name', $data['data'][0] );
+
+		$this->assertArrayHasKey( 'partner_agent', $data );
+		$this->assertEquals( Event::get_platform_identifier(), $data['partner_agent'] );
 	}
 
 

--- a/tests/integration/Events/EventTest.php
+++ b/tests/integration/Events/EventTest.php
@@ -39,6 +39,19 @@ class EventTest extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
+	/** @see Event::get_version_info() */
+	public function test_get_version_info() {
+
+		$version_info = [
+			'source'        => 'woocommerce',
+			'version'       => WC()->version,
+			'pluginVersion' => facebook_for_woocommerce()->get_version(),
+		];
+
+		$this->assertEquals( $version_info, Event::get_version_info() );
+	}
+
+
 	/** @see Event::__construct() */
 	public function test_constructor() {
 

--- a/tests/integration/Events/EventTest.php
+++ b/tests/integration/Events/EventTest.php
@@ -52,6 +52,16 @@ class EventTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Event::get_platform_identifier() */
+	public function get_platform_identifier() {
+
+		$wc_version     = WC()->version;
+		$plugin_version = facebook_for_woocommerce()->get_version();
+
+		$this->assertEquals( "woocommerce-{$wc_version}-{$plugin_version}", Event::get_platform_identifier() );
+	}
+
+
 	/** @see Event::__construct() */
 	public function test_constructor() {
 


### PR DESCRIPTION
# Summary

This PR adds the `partner_agent` field to the S2S pixel event request payload.

### Story: [CH 57626](https://app.clubhouse.io/skyverge/story/57626)
### Release: #1277 

## Details

We should include that parameter to attribute S2S events to the Facebook for WooComemrce plugin.

## QA

### Setup

1. Install the plugin and connect your store to Facebook

Use the folowing snippet to connect through hosted proxy app:

```php
add_filter( 'wc_facebook_connection_proxy_url', function() {

    return 'https://wc-connect-test.skyverge.com/auth/facebook/';
} );
```

### Steps

1. Enable debug log
1. Add a product to the cart
    - [x] The log includes "partner_agent":"woocommerce-4.2.2-2.0.0-dev.1" in the payload ([see example payload](https://developers.facebook.com/docs/marketing-api/server-side-api/set-up-server-side-as-a-platform#attribute-events-to-your-platform-using-partner-agent))
    - [x] The response for that request is similar to `{"events_received":1,"messages":[],"fbtrace_id":"******"}`

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
