### PR TITLE
Update product catalog link

### DIFF
--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -114,7 +114,7 @@ class Connection extends Admin\Abstract_Settings_Screen {
 		 *
 		 * + Page: just the ID
 		 * + Pixel: just the ID
-		 * + Catalog: name, general link to the user's catalog manager (we can't link to a specific catalog)
+		 * + Catalog: name, full URL
 		 * + Business manager: name, full URL
 		 * + Ad account: not currently available
 		 *
@@ -145,12 +145,14 @@ class Connection extends Admin\Abstract_Settings_Screen {
 			],
 		];
 
-		// if the catalog ID is set, try and get its name for display
-		if ( $static_items['catalog']['value'] ) {
+		// if the catalog ID is set, update the URL and try to get its name for display
+		if ( $catalog_id = $static_items['catalog']['value'] ) {
+
+			$static_items['catalog']['url'] = "https://facebook.com/products/catalogs/{$catalog_id}";
 
 			try {
 
-				$response = facebook_for_woocommerce()->get_api()->get_catalog( $static_items['catalog']['value'] );
+				$response = facebook_for_woocommerce()->get_api()->get_catalog( $catalog_id );
 
 				if ( $name = $response->get_name() ) {
 					$static_items['catalog']['value'] = $name;


### PR DESCRIPTION
# Summary

This PRs updates the Connection screen to link to a specific catalog. We were previously linking to the Catalogs Manager

### Story: [CH 58471](https://app.clubhouse.io/skyverge/story/58471)
### Release: #1277

## UI Changes

- Clicking the Catalog link in the Connection settings screen takes you to the configured catalog

## QA

### Setup

- Install Facebook for WooCommerce and connect the store using the hosted connect app

```php
add_filter( 'wc_facebook_connection_proxy_url', function() {
    return 'https://wc-connect-test.skyverge.com/auth/facebook/';
} );
```

### Steps

1. Go to WooCommerce > Facebook > settings
    - [x] The Catalog link points to `https://facebook.com/products/catalogs/{catalog_id}`
1. Click the Catalog link
    - [x] A new tab opens up with the Catalog Manager for that specific catalog (https://cloud.skyver.ge/7Kumn6vg)

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version