### PR TITLE
Mark connection as failed when installation IDs cannot be retrieved

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -191,6 +191,39 @@ class Connection {
 
 
 	/**
+	 * Retrieves and stores the connected installation data.
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @throws SV_WC_API_Exception
+	 */
+	private function update_installation_data() {
+
+		$response = $this->get_plugin()->get_api()->get_installation_ids( $this->get_external_business_id() );
+
+		if ( $response->get_page_id() ) {
+			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $response->get_page_id() ) );
+		}
+
+		if ( $response->get_pixel_id() ) {
+			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, sanitize_text_field( $response->get_pixel_id() ) );
+		}
+
+		if ( $response->get_catalog_id() ) {
+			update_option( \WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, sanitize_text_field( $response->get_catalog_id() ) );
+		}
+
+		if ( $response->get_business_manager_id() ) {
+			$this->update_business_manager_id( sanitize_text_field( $response->get_business_manager_id() ) );
+		}
+
+		if ( $response->get_ad_account_id() ) {
+			$this->update_ad_account_id( sanitize_text_field( $response->get_ad_account_id() ) );
+		}
+	}
+
+
+	/**
 	 * Processes the returned connection.
 	 *
 	 * @internal

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -151,15 +151,13 @@ class Connection {
 			return;
 		}
 
-		$integration = $this->get_plugin()->get_integration();
-
 		try {
 
 			$this->update_installation_data();
 
 		} catch ( SV_WC_API_Exception $exception ) {
 
-			if ( $integration->is_debug_mode_enabled() ) {
+			if ( $this->get_plugin()->get_integration()->is_debug_mode_enabled() ) {
 				$this->get_plugin()->log( 'Could not refresh installation data. ' . $exception->getMessage() );
 			}
 		}

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -138,10 +138,8 @@ class Connection {
 	 * Refreshes the connected installation data.
 	 *
 	 * @since 2.0.0-dev.1
-	 *
-	 * @param bool $force whether to force the refresh
 	 */
-	public function refresh_installation_data( $force = false ) {
+	public function refresh_installation_data() {
 
 		// bail if not connected
 		if ( ! $this->is_connected() ) {
@@ -149,7 +147,7 @@ class Connection {
 		}
 
 		// only refresh once a day
-		if ( ! $force && get_transient( 'wc_facebook_connection_refresh' ) ) {
+		if ( get_transient( 'wc_facebook_connection_refresh' ) ) {
 			return;
 		}
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -157,27 +157,7 @@ class Connection {
 
 		try {
 
-			$response = $this->get_plugin()->get_api()->get_installation_ids( $this->get_external_business_id() );
-
-			if ( $response->get_page_id() ) {
-				update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $response->get_page_id() ) );
-			}
-
-			if ( $response->get_pixel_id() ) {
-				update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, sanitize_text_field( $response->get_pixel_id() ) );
-			}
-
-			if ( $response->get_catalog_id() ) {
-				update_option( \WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, sanitize_text_field( $response->get_catalog_id() ) );
-			}
-
-			if ( $response->get_business_manager_id() ) {
-				$this->update_business_manager_id( sanitize_text_field( $response->get_business_manager_id() ) );
-			}
-
-			if ( $response->get_ad_account_id() ) {
-				$this->update_ad_account_id( sanitize_text_field( $response->get_ad_account_id() ) );
-			}
+			$this->update_installation_data();
 
 		} catch ( SV_WC_API_Exception $exception ) {
 
@@ -264,8 +244,7 @@ class Connection {
 			$this->update_access_token( $system_user_access_token );
 			$this->update_merchant_access_token( $merchant_access_token );
 			$this->update_system_user_id( $system_user_id );
-
-			$this->refresh_installation_data( true );
+			$this->update_installation_data();
 
 			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
 


### PR DESCRIPTION
# Summary

This PR updates the Connection Handler to flag the connection as failed when the request to the `/fbe_business/fbe_installs` endpoint returns an error.

### Story: [CH 58485](https://app.clubhouse.io/skyverge/story/58485)
### Release: #1277

## Details

The exception that the API throws is currently being caught in `Connection::refresh_installation_data()`, which prevents `Connection::handle_connection()` from knowing that something went wrong.

## UI Changes

- A notice is shown when the request to get the installation IDs fails during the connection setup: https://cloud.skyver.ge/2Nu599dB

## QA

### Setup

1. Install Facebook for WooCommerce
1. If the website is currently connected, use the Uninstall link to remove the connection
1. Add the following snippet to connect through the hosted connect app:

    ```php
    add_filter( 'wc_facebook_connection_proxy_url', function() {
        return 'https://wc-connect-test.skyverge.com/auth/facebook/';
    } );
    ```

1. Add the following snippet to mock a failed request to the `fbe_business/fbe_installs` endpoint:

    ```php
    add_filter( 'pre_http_request', static function( $response, $args, $url ) {

        if ( false !== strpos( $url, '/fbe_business/fbe_installs' ) ) {

            $response = [
                'headers'       => [],
                'body'          => '{"error":{"message":"(#33) An FBE installation does not exist for the business with ID arcade-5efc14e936c7d or you do not have permission to see it","type":"OAuthException","code":33,"fbtrace_id":"AQo7RBwkA25rjGhFUtCYr4g"}}',
                'response'      => [
                    'code'    => 400,
                    'message' => 'Bad Request',
                ],
                'cookies'       => [],
                'http_response' => null,
            ];
        }

        return $response;
    }, 10, 3 );
    ```

### Steps 

1. Attempt to connect your store to Facebook
1. Once you are redirected back to the store from the connect app:
    - [x] The `Heads up! It looks like there was a problem with reconnecting your site to Facebook` notices shows up
1. Remove the snippet to mock the failed request and try to connect the store again
    - [x] The connection is successful
    - [x] The Page ID is shown
    - [x] The Pixel ID is shown
    - [x] The Catalog link opens the catalog manager for the configured catalog in a new tab
    - [x] The Business Manager link opens the business manager settings in a new tab
    - [x] The Ad Manager account ID is shown