### PR TITLE
Fix compatibility conflict with YITH Bookings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
  * Tweak - Allow to bulk enable sync for virtual products, but automatically set them to Sync and hide
  * Fix - Use the plugin version instead of a timestamp as the version number for enqueued scripts and stylesheets
  * Fix - Use the short description of the parent product for product variations that don't have a description or Facebook description
+ * Fix - Prevent an error when YITH Booking and Appointment for WooCommerce plugin is active
 
 2020.06.04 - version 1.11.4
  * Fix - Do not sync variations for draft variable products created by duplicating products

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -172,7 +172,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 		 *
 		 * TODO: add an integration that filters the Facebook price instead {WV 2020-07-22}
 		 *
-		 * @since 1.11.5-dev.1
+		 * @since 2.0.0-dev.3
 		 *
 		 * @return bool
 		 */

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -153,10 +153,10 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$regular_price = floatval( $this->get_regular_price() );
 
 			// If it's a bookable product, the normal price is null/0.
-			if ( ! $regular_price && class_exists( 'WC_Product_Booking' ) && is_wc_booking_product( $this ) ) {
+			if ( ! $regular_price && $this->is_bookable_product() ) {
 
 				$product       = new WC_Product_Booking( $this->woo_product );
-				$regular_price = $product->get_display_cost();
+				$regular_price = is_callable( [ $product, 'get_display_cost' ] ) ? $product->get_display_cost() : 0;
 			}
 
 			// Get regular price plus tax, if it's set to display and taxable
@@ -164,6 +164,21 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$price          = $this->get_price_plus_tax( $regular_price );
 			$this->fb_price = intval( round( $price * 100 ) );
 			return $this->fb_price;
+		}
+
+
+		/**
+		 * Determines whether the current product is a WooCommerce Bookings product.
+		 *
+		 * TODO: add an integration that filters the Facebook price instead {WV 2020-07-22}
+		 *
+		 * @since 1.11.5-dev.1
+		 *
+		 * @return bool
+		 */
+		private function is_bookable_product() {
+
+			return facebook_for_woocommerce()->is_plugin_active( 'woocommerce-bookings.php') && class_exists( 'WC_Product_Booking' ) && is_callable( 'is_wc_booking_product' ) && is_wc_booking_product( $this );
 		}
 
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -153,9 +153,8 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$regular_price = floatval( $this->get_regular_price() );
 
 			// If it's a bookable product, the normal price is null/0.
-			if ( ! $regular_price &&
-			  class_exists( 'WC_Product_Booking' ) &&
-			  is_wc_booking_product( $this ) ) {
+			if ( ! $regular_price && class_exists( 'WC_Product_Booking' ) && is_wc_booking_product( $this ) ) {
+
 				$product       = new WC_Product_Booking( $this->woo_product );
 				$regular_price = $product->get_display_cost();
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,7 @@ When opening a bug on GitHub, please give us as many details as possible.
  * Tweak - Allow to bulk enable sync for virtual products, but automatically set them to Sync and hide
  * Fix - Use the plugin version instead of a timestamp as the version number for enqueued scripts and stylesheets
  * Fix - Use the short description of the parent product for product variations that don't have a description or Facebook description
+ * Fix - Prevent an error when YITH Booking and Appointment for WooCommerce plugin is active
 
 = 2020.06.04 - version 1.11.4 =
  * Fix - Do not sync variations for draft variable products created by duplicating products


### PR DESCRIPTION
# Summary

This PR fixes a conflict with YITH Booking and Appointment for WooCommerce plugin that triggers a Fatal error when the feed is being generated.

### Story: [CH 59528](https://app.clubhouse.io/skyverge/story/59528/compatibility-conflict-with-yith-bookings-6)
### Release: #1438 
## QA
### Setup

1. Install YITH Bookings
1. Create a Booking product (define at least the name and the base cost, and remove the virtual check from the product)

### Steps

Checkout tag `1.11.4`

1. Try and generate a feed file
    - Go to WooCommerce > Settings > Integration > Facebook for WooCommerce
    - Open the browser's console and type `copy(facebookAdsToolboxConfig.feedPrepared.feedUrl)`
    - Paste the feed URL from the clipboard and append `&regenerate=true` to the URL
    - Access the resulting URL
    - [x] `call to undefined function is_wc_booking_product()`

Checkout this branch

1. Try and generate a feed file
    - [x] The feed file is generated correctly
    - [x] There are not Fatal errors or PHP warnings

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version