### PR TITLE
Fire server-side Search event when results include a single product 

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -277,64 +277,17 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 
 		/**
-		 * Triggers Search for result pages
+		 * Injects a Search event on result pages.
 		 */
 		public function actually_inject_search_event() {
-			global $wp_query;
 
-			if ( ! self::$isEnabled || empty( $_GET['post_type'] ) || 'product' !== $_GET['post_type'] ) {
-				return;
-			}
+			$event = $this->get_search_event();
 
-			// if any product is a variant, fire the pixel with
-			// content_type: product_group
-			$content_type = 'product';
-			$product_ids  = [];
-			$contents     = [];
-			$total_value  = 0.00;
-
-			foreach ( $wp_query->posts as $post ) {
-
-				$product = wc_get_product( $post );
-
-				if ( ! $product instanceof \WC_Product ) {
-					continue;
-				}
-
-				$product_ids = array_merge( $product_ids, WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) );
-
-				$contents[] = [
-					'id'       => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
-					'quantity' => 1, // consider the search results a quantity of 1
-				];
-
-				$total_value += (float) $product->get_price();
-
-				if ( WC_Facebookcommerce_Utils::is_variable_type( $product->get_type() ) ) {
-					$content_type = 'product_group';
-				}
-			}
-
-			$event_name = 'Search';
-			$event_data = [
-				'event_name'  => $event_name,
-				'custom_data' => [
-					'content_type'  => $content_type,
-					'content_ids'   => json_encode( array_slice( $product_ids, 0, 10 ) ),
-					'contents'      => $contents,
-					'search_string' => get_search_query(),
-					'value'         => \SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper::number_format( $total_value ),
-					'currency'      => get_woocommerce_currency(),
-				],
-			];
-
-			$event = new Event( $event_data );
-
-			$this->send_api_event( $event );
-
-			$event_data['event_id'] = $event->get_id();
-
-			$this->pixel->inject_event( $event_name, $event_data );
+			$this->pixel->inject_event( $event->get_name(), [
+				'event_id'    => $event->get_id(),
+				'event_name'  => $event->get_name(),
+				'custom_data' => $event->get_custom_data(),
+			] );
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -182,6 +182,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 		/**
 		 * Triggers Search for result pages (deduped)
+		 *
+		 * @internal
 		 */
 		public function inject_search_event() {
 
@@ -278,6 +280,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 		/**
 		 * Injects a Search event on result pages.
+		 *
+		 * @internal
 		 */
 		public function actually_inject_search_event() {
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -9,6 +9,7 @@
  */
 
 use SkyVerge\WooCommerce\Facebook\Events\Event;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
@@ -266,7 +267,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 						'content_ids'   => json_encode( array_slice( $product_ids, 0, 10 ) ),
 						'contents'      => $contents,
 						'search_string' => get_search_query(),
-						'value'         => \SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper::number_format( $total_value ),
+						'value'         => Framework\SV_WC_Helper::number_format( $total_value ),
 						'currency'      => get_woocommerce_currency(),
 					],
 				];
@@ -837,7 +838,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 				$success = true;
 
-			} catch ( \SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Exception $exception ) {
+			} catch ( Framework\SV_WC_API_Exception $exception ) {
 
 				$success = false;
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -191,7 +191,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			if ( ! is_admin() && is_search() && get_search_query() !== '' && 'product' === get_query_var( 'post_type' ) ) {
+			if ( ! is_admin() && is_search() && '' !== get_search_query() && 'product' === get_query_var( 'post_type' ) ) {
 
 				if ( $this->pixel->is_last_event( 'Search' ) ) {
 					return;

--- a/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
+++ b/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
@@ -39,6 +39,20 @@ class WC_Facebookcommerce_EventsTracker_Test extends \Codeception\TestCase\WPTes
 	}
 
 
+	/** @see WC_Facebookcommerce_EventsTracker::get_search_event() */
+	public function test_get_search_event_returns_same_instance() {
+		global $wp_query;
+
+		$wp_query->posts = [];
+
+		$tracker = $this->get_events_tracker();
+		$method  = $this->tester->getMethod( $tracker, 'get_search_event' );
+		$event   = $method->invoke( $tracker );
+
+		$this->assertSame( $event, $method->invoke( $tracker ) );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
+++ b/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
@@ -1,0 +1,51 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Events\Event;
+
+/**
+ * Tests the WC_Facebookcommerce_EventsTracker class.
+ */
+class WC_Facebookcommerce_EventsTracker_Test extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see WC_Facebookcommerce_EventsTracker::get_search_event() */
+	public function test_get_search_event() {
+		global $wp_query;
+
+		$product = $this->tester->get_product();
+
+		$wp_query->query_vars = [
+			's' => 'term',
+		];
+
+		$wp_query->posts = [
+			(object) [ 'ID' => $product->get_id() ],
+		];
+
+		$tracker = $this->get_events_tracker();
+		$event   = $this->tester->getMethod( $tracker, 'get_search_event' )->invoke( $tracker );
+
+		$this->assertInstanceOf( Event::class, $event );
+		$this->assertEquals( 'Search', $event->get_name() );
+		$this->assertEquals( 'term', $event->get_custom_data()['search_string'] );
+		$this->assertStringContainsString( $product->get_id(), $event->get_custom_data()['content_ids'] );
+	}
+
+
+	/** Helper methods ************************************************************************************************/
+
+
+	private function get_events_tracker( array $user_info = [] ) {
+
+		return new WC_Facebookcommerce_EventsTracker( $user_info );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR updates the event tracker to send server-side Search event on `template_redirect` before WooCommerce gets a chance to redirect users to a product page.

### Story: [CH 59890](https://app.clubhouse.io/skyverge/story/59890)
### Release: #1277 

## Details

If the search results include a single product, WooCommerce automatically [redirects users](https://github.com/woocommerce/woocommerce/blob/4b1a8cd96c0db479d7a227bed75e52e433ec4cae/includes/wc-template-functions.php#L57-L65) to that product's page. As a result the search page results are never rendered and the plugin is unable to inject a snippet to trigger a browser event.

We were previously injecting the browser event and sending the server-side event at the same time, but we don't need to wait until the shop loop starts to send a server-side event.

## UI Changes

N/A

## QA


### Setup


- Install and configure Facebook for WooCommere
- Enable debug log
- Install the [Facebook Pixel Helper](https://chrome.google.com/webstore/detail/facebook-pixel-helper/fdgfkebogiimcoedlicjlajpkdmockpc?hl=en) extension

### Steps

1. Search for a product using a search term that returns two or more results
    - [x] The pixel helper registers a Search event for the products in the results
    - [x] A server-side Search event is successfully sent (check the logs)
1. Search for a product using a search term that returns a single result
    - [x] You're redirected to the product page
    - [x] A server-side Search event is successfully sent (check the logs)

### Tests

- [ ] `codecept run integration` pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version