### PR TITLE
Include Sync and hide products in all products sync

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -381,11 +381,8 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				'product_visibility',
 				$wpid
 			);
-			// fb_visibility === '': after initial sync by feed
-			// fb_visibility === false: set hidden on FB metadata
-			// Explicitly check whether flip 'hide' before.
-			return ( $hidden_from_catalog && $hidden_from_search ) ||
-			$this->fb_visibility === false || ! $this->get_fb_price();
+
+			return ( $hidden_from_catalog && $hidden_from_search ) || ! $this->get_fb_price();
 		}
 
 		public function get_price_plus_tax( $price ) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -366,6 +366,16 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			return $product_data;
 		}
 
+
+		/**
+		 * Determines whether a product should be excluded from all-products sync or the feed file.
+		 *
+		 * The plugin also avoids trying to get the Facebook ID of products where is_hidden() returns true.
+		 *
+		 * @see SkyVerge\WooCommerce\Facebook\Products\Sync::create_or_update_all_products()
+		 * @see WC_Facebook_Product_Feed::write_product_feed_file()
+		 * @see WC_Facebookcommerce_Integration::get_product_fbid()
+		 */
 		public function is_hidden() {
 			$wpid = $this->id;
 			if ( WC_Facebookcommerce_Utils::is_variation_type( $this->get_type() ) ) {
@@ -384,6 +394,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 
 			return ( $hidden_from_catalog && $hidden_from_search ) || ! $this->get_fb_price();
 		}
+
 
 		public function get_price_plus_tax( $price ) {
 			$woo_product = $this->woo_product;

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use SkyVerge\WooCommerce\Facebook\Products;
 use SkyVerge\WooCommerce\Facebook\Products\Sync;
 
 /**
@@ -105,6 +106,25 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 
 			$this->assertArrayNotHasKey( $index, $requests );
 		}
+	}
+
+
+	/** @see Sync::create_or_update_all_products() */
+	public function test_create_or_update_all_products_with_hidden_product() {
+
+		$product = $this->tester->get_variable_product( [ 'children' => 1 ] );
+
+		$variation = wc_get_product( current( $product->get_children() ) );
+		$variation->set_regular_price( 4.99 );
+		$variation->save();
+
+		Products::enable_sync_for_products( [ $variation ] );
+		Products::set_product_visibility( $variation, false );
+
+		// add all eligible products to the sync queue
+		$requests = $this->create_or_update_all_products();
+
+		$this->tester->assertProductsAreScheduledForSync( [ $variation->get_id() ], $requests );
 	}
 
 


### PR DESCRIPTION
# Summary

**This is an alternative version to https://github.com/facebookincubator/facebook-for-woocommerce/pull/1425 that doesn't require the refactor from #1424.**

This PR updates the `Sync::create_or_update_all_products()` to include Sync and hide products and products variations in the list of products to sync.

### Story: [CH 57662](https://app.clubhouse.io/skyverge/story/57662)
### Release: #1277

## QA

### Steps

1. Enable debug log
1. Add a product configured to Sync and hide
1. Sync products from WooCommerce > Facebook > Product sync
1. Wait for the batch requests to occur
    - [x] The requests include data for the Sync and hide products (look for wc_post_id_{id})

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
