### PR TITLE
Make sure timezone identifiers don't have escaped slashes in requests

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -606,7 +606,7 @@ class Connection {
 			'display'       => 'page',
 			'response_type' => 'code',
 			'scope'         => implode( ',', $this->get_scopes() ),
-			'extras'        => json_encode( $this->get_connect_parameters_extras(), JSON_UNESCAPED_SLASHES ),
+			'extras'        => json_encode( $this->get_connect_parameters_extras(), JSON_UNESCAPED_SLASHES ), // this is mainly to avoid escaping timezone identifiers improperly
 		] );
 	}
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -606,7 +606,7 @@ class Connection {
 			'display'       => 'page',
 			'response_type' => 'code',
 			'scope'         => implode( ',', $this->get_scopes() ),
-			'extras'        => json_encode( $this->get_connect_parameters_extras() ),
+			'extras'        => json_encode( $this->get_connect_parameters_extras(), JSON_UNESCAPED_SLASHES ),
 		] );
 	}
 


### PR DESCRIPTION
# Summary

Ensures that timezone identifiers don't have slashes escaped.

### Story: [CH 59528](https://app.clubhouse.io/skyverge/story/60517/json-encode-may-add-backslashes-to-the-timezone-identifier-27)
### Release: #1438 

## QA

### Steps

- [x] Code review
- [x] Integration tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version