### PR TITLE
Use the site URL as business name fallback if blog name is empty

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -482,18 +482,25 @@ class Connection {
 	 */
 	public function get_business_name() {
 
-		$business_name = html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES, 'UTF-8' );
+		$business_name = trim( html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES, 'UTF-8' ) );
 
 		/**
 		 * Filters the shop's business name.
 		 *
-		 * This is passed to Facebook when connecting. Defaults to the site name.
+		 * This is passed to Facebook when connecting.
+		 * Defaults to the site name. Should be non-empty, otherwise the site URL will be used as fallback.
 		 *
 		 * @since 2.0.0
 		 *
 		 * @param string $business_name the shop's business name
 		 */
-		return apply_filters( 'wc_facebook_connection_business_name', $business_name );
+		$business_name = trim( (string) apply_filters( 'wc_facebook_connection_business_name', $business_name ) );
+
+		if ( empty( $business_name ) ) {
+			$business_name = trim( html_entity_decode( get_bloginfo( 'url' ), ENT_QUOTES, 'UTF-8' ) );
+		}
+
+		return $business_name;
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -482,7 +482,7 @@ class Connection {
 	 */
 	public function get_business_name() {
 
-		$business_name = trim( html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES, 'UTF-8' ) );
+		$business_name = get_bloginfo( 'name' );
 
 		/**
 		 * Filters the shop's business name.
@@ -494,13 +494,13 @@ class Connection {
 		 *
 		 * @param string $business_name the shop's business name
 		 */
-		$business_name = trim( (string) apply_filters( 'wc_facebook_connection_business_name', $business_name ) );
+		$business_name = trim( (string) apply_filters( 'wc_facebook_connection_business_name', is_string( $business_name ) ? $business_name : '' ) );
 
 		if ( empty( $business_name ) ) {
-			$business_name = trim( html_entity_decode( get_bloginfo( 'url' ), ENT_QUOTES, 'UTF-8' ) );
+			$business_name = get_bloginfo( 'url' );
 		}
 
-		return $business_name;
+		return html_entity_decode( $business_name, ENT_QUOTES, 'UTF-8' );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -453,7 +453,7 @@ class Connection {
 
 			if ( ! is_string( $value ) ) {
 
-				$value = sanitize_title( get_bloginfo( 'name' ) ) . '-' . uniqid();
+				$value = uniqid( sanitize_title( $this->get_business_name() ) . '-', false );
 
 				update_option( self::OPTION_EXTERNAL_BUSINESS_ID, $value );
 			}

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -210,6 +210,23 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_business_name() */
+	public function test_get_business_name_empty() {
+
+		update_option( 'blogname', '' );
+
+		$this->assertSame( get_bloginfo( 'url' ), $this->get_connection()->get_business_name() );
+
+		update_option( 'blogname', 'Test Store' );
+
+		add_filter( 'wc_facebook_connection_business_name', function() {
+			return '';
+		} );
+
+		$this->assertSame( get_bloginfo( 'url' ), $this->get_connection()->get_business_name() );
+	}
+
+
 	/** @see Connection::get_business_manager_id() */
 	public function test_get_business_manager_id() {
 


### PR DESCRIPTION
# Summary

Ensures that the business name is never empty string.

### Story: [CH 60521](https://app.clubhouse.io/skyverge/story/60521/get-business-name-may-return-empty-string-27)
### Release: #1438 

## QA

### Steps

- [ ] Code review
- [ ] Integration tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version