### PR TITLE
Release v2.0.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2020.nn.nn - version 2.0.1-dev.1
+2020.08.17 - version 2.0.1
  * Fix - Ensure the configured business name is never empty when connecting to Facebook
 
 2020.07.30 - version 2.0.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Facebook for WooCommerce Changelog ***
 
+2020.nn.nn - version 2.0.1-dev.1
+ * Fix - Ensure the configured business name is never empty when connecting to Facebook
+
 2020.07.30 - version 2.0.0
  * Tweak - Show Facebook options for virtual products and variations
  * Tweak - Hide "Sync and show" option for virtual products and variations

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 
 		/** @var string the plugin version */
-		const VERSION = '2.0.1-dev.1';
+		const VERSION = '2.0.1';
 
 		/** @var string for backwards compatibility TODO: remove this in v2.0.0 {CW 2020-02-06} */
 		const PLUGIN_VERSION = self::VERSION;

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 
 		/** @var string the plugin version */
-		const VERSION = '2.0.0';
+		const VERSION = '2.0.1-dev.1';
 
 		/** @var string for backwards compatibility TODO: remove this in v2.0.0 {CW 2020-02-06} */
 		const PLUGIN_VERSION = self::VERSION;

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,10 +10,10 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.0.1-dev.1
+ * Version: 2.0.1
  * Text Domain: facebook-for-woocommerce
  * WC requires at least: 3.5.0
- * WC tested up to: 4.3.1
+ * WC tested up to: 4.3.3
  *
  * @package FacebookCommerce
  */

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.0.0
+ * Version: 2.0.1-dev.1
  * Text Domain: facebook-for-woocommerce
  * WC requires at least: 3.5.0
  * WC tested up to: 4.3.1

--- a/i18n/languages/facebook-for-woocommerce.pot
+++ b/i18n/languages/facebook-for-woocommerce.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Facebook for WooCommerce package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Facebook for WooCommerce 2.0.0\n"
+"Project-Id-Version: Facebook for WooCommerce 2.0.1\n"
 "Report-Msgid-Bugs-To: "
 "https://woocommerce.com/my-account/marketplace-ticket-form/\n"
-"POT-Creation-Date: 2020-07-30 19:04:18+00:00\n"
+"POT-Creation-Date: 2020-08-17 20:20:42+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 5.3.2
-Stable tag: 1.11.4
+Stable tag: 2.0.1-dev.1
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -38,6 +38,9 @@ When opening a bug on GitHub, please give us as many details as possible.
 * Current version of Facebook-for-WooCommerce, WooCommerce, Wordpress, PHP
 
 == Changelog ==
+
+= 2020.nn.nn - version 2.0.1-dev.1 =
+ * Fix - Ensure the configured business name is never empty when connecting to Facebook
 
 = 2020.07.30 - version 2.0.0 =
  * Tweak - Show Facebook options for virtual products and variations

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 5.3.2
-Stable tag: 2.0.1-dev.1
+Stable tag: 2.0.1
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 2020.nn.nn - version 2.0.1-dev.1 =
+= 2020.08.17 - version 2.0.1 =
  * Fix - Ensure the configured business name is never empty when connecting to Facebook
 
 = 2020.07.30 - version 2.0.0 =


### PR DESCRIPTION
# Summary

Bumps the stable tag back to v2.0.x

### Stories

- [CH 60521](https://app.clubhouse.io/skyverge/story/60521/get-business-name-may-return-empty-string-27)

### Final story

[CH 60521](https://app.clubhouse.io/skyverge/story/60521/get-business-name-may-return-empty-string-27)

## Details

Also includes [this PR](https://github.com/facebookincubator/facebook-for-woocommerce/pull/1447) which was merged into master but not officially released, making the new version number 2.0.1

## Before merge

- [x] I have confirmed the final story is merged