### PR TITLE
Change "domains" chat connection param  to array

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -653,7 +653,9 @@ class Connection {
 
 			$parameters['business_config']['messenger_chat'] = [
 				'enabled' => true,
-				'domains' => home_url( '/' ),
+				'domains' => [
+					home_url( '/' ),
+				],
 			];
 		}
 


### PR DESCRIPTION
## Summary

Converts the `domains` chat connection param from string to  array.

### Story [CH 60805](https://app.clubhouse.io/skyverge/story/60805/update-connect-parameters-extra-to-use-an-array-to-pass-the-messenger-chat-domain-6)

## Additional details

I could connect and reconnect safely to Facebook after this change, and Messenger continued working. I've read through the concerns described in CH story, but couldn't replicate that occurrence.

## QA

### Scenario 1: Update from 1.x

- [x] Activate v1.11.4 and connect to FB
- [x] Switch to this branch: ensure that Messenger still works

### Scenario 2: Update from 2.0.1

- [x] Activate v2.0.1 and connect to FB
- [x] Switch to this branch: ensure that Messenger still works

### Scenario 3: Connect from this branch

- [x] Activate from this branch and connect to FB
- [x] Ensure that Messenger is working
- [ ] Disable messenger, and re-enable, check that it still works


## Before merge

- [x] Update the base branch accordingly
- [ ] Update changelog
- [x] I have confirmed these changes in each supported minor WooCommerce version
