### PR TITLE
Allow simple and variable products with zero/empty price to sync

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1299,10 +1299,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 	function create_product_item( $woo_product, $retailer_id, $product_group_id ) {
 
-		$product_data               = $woo_product->prepare_product( $retailer_id );
-		if ( ! $product_data['price'] ) {
-			return 0;
-		}
+		$product_data = $woo_product->prepare_product( $retailer_id );
 
 		$product_result = $this->check_api_result(
 			$this->fbgraph->create_product_item(

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -896,6 +896,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				case 'simple':
 				case 'booking':
 				case 'external':
+				case 'composite':
 					$this->on_simple_product_publish( $wp_id );
 				break;
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -572,11 +572,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		global $post;
 
 		$woo_product         = new WC_Facebook_Product( $post->ID );
-		$fb_product_group_id = $this->get_product_fbid(
-			self::FB_PRODUCT_GROUP_ID,
-			$post->ID,
-			$woo_product
-		);
+		$fb_product_group_id = null;
+
+		if ( $woo_product->woo_product instanceof \WC_Product && Products::product_should_be_synced( $woo_product->woo_product ) ) {
+			$fb_product_group_id = $this->get_product_fbid( self::FB_PRODUCT_GROUP_ID, $post->ID, $woo_product );
+		}
 
 		?>
 			<span id="fb_metadata">
@@ -3368,12 +3368,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// if the product with ID equal to $wp_id is variable, $woo_product will be the first child
 		$woo_product = new WC_Facebook_Product( current( $products ) );
-
-		// This is a generalized function used elsewhere
-		// Cannot call is_hidden for VC_Product_Variable Object
-		if ( $woo_product->is_hidden() ) {
-			return null;
-		}
 
 		$fb_retailer_id = WC_Facebookcommerce_Utils::get_fb_retailer_id( $woo_product );
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1017,6 +1017,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			return;
 		}
 
+		if ( ! $this->should_update_visibility_for_product_status_change( $new_status, $old_status ) ) {
+			return;
+		}
+
 		$visibility = $new_status === 'publish' ? self::FB_SHOP_PRODUCT_VISIBLE : self::FB_SHOP_PRODUCT_HIDDEN;
 
 		$product = wc_get_product( $post->ID );
@@ -1031,12 +1035,26 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			return;
 		}
 
-		// change from publish status -> unpublish status (e.g. trash, draft, etc.)
-		// change from trash status -> publish status
-		// no need to update for change from trash <-> unpublish status
-		if ( ( $old_status === 'publish' && $new_status !== 'publish' ) || ( $old_status === 'trash' && $new_status === 'publish' ) ) {
-			$this->update_fb_visibility( $product, $visibility );
-		}
+		$this->update_fb_visibility( $product, $visibility );
+	}
+
+
+	/**
+	 * Determines whether the product visibility needs to be updated for the given status change.
+	 *
+	 * Change from publish status -> unpublish status (e.g. trash, draft, etc.)
+	 * Change from trash status -> publish status
+	 * No need to update for change from trash <-> unpublish status
+	 *
+	 * @since 2.0.2-dev.1
+	 *
+	 * @param string $new_status
+	 * @param string $old_status
+	 * @return bool
+	 */
+	private function should_update_visibility_for_product_status_change( $new_status, $old_status ) {
+
+		return ( $old_status === 'publish' && $new_status !== 'publish' ) || ( $old_status === 'trash' && $new_status === 'publish' );
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -964,7 +964,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @see ajax_delete_fb_product()
 		 */
 		if ( ( ! is_ajax() || ! isset( $_POST['action'] ) || 'ajax_delete_fb_product' !== $_POST['action'] )
-		     && ! Products::product_should_be_synced( $product ) ) {
+		     && ! Products::published_product_should_be_synced( $product ) ) {
 
 			return;
 		}
@@ -1027,7 +1027,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// variations before it gets called with the variable product. As a result, Products::product_should_be_synced()
 		// always returns false for the variable product (since all children are in the trash at that point).
 		// This causes update_fb_visibility() to be called on simple products and product variations only.
-		if ( ! $product instanceof \WC_Product || ! Products::product_should_be_synced( $product ) ) {
+		if ( ! $product instanceof \WC_Product || ! Products::published_product_should_be_synced( $product ) ) {
 			return;
 		}
 
@@ -3337,7 +3337,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	public function on_quick_and_bulk_edit_save( $product ) {
 
 		// bail if not a product or product is not enabled for sync
-		if ( ! $product instanceof \WC_Product || ! Products::product_should_be_synced( $product ) ) {
+		if ( ! $product instanceof \WC_Product || ! Products::published_product_should_be_synced( $product ) ) {
 			return;
 		}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1209,27 +1209,16 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Determines whether the product with the given ID should be synced.
 	 *
-	 * TODO: can we move this logic into Products::product_should_be_synced()? {WV 2020-05-22}
-	 *
 	 * @since 2.0.0
 	 *
 	 * @param \WC_Product|false $product product object
 	 */
 	public function product_should_be_synced( $product ) {
 
-		$should_be_synced = true;
-
-		if ( ! $this->is_product_sync_enabled() ) {
-			$should_be_synced = false;
-		}
+		$should_be_synced = $this->is_product_sync_enabled();
 
 		// can't sync if we don't have a valid product object
 		if ( $should_be_synced && ! $product instanceof \WC_Product ) {
-			$should_be_synced = false;
-		}
-
-		// only published product should be synced
-		if ( $should_be_synced && 'publish' !== get_post_status( $product->get_id() ) ) {
 			$should_be_synced = false;
 		}
 

--- a/includes/Integrations/Bookings.php
+++ b/includes/Integrations/Bookings.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Integrations;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * Integration with WooCommerce Bookings.
+ *
+ * @since 2.0.0-dev.1
+ */
+class Bookings {
+
+
+	/**
+	 * Integration constructor.
+	 *
+	 * @since 2.0.0-dev.3
+	 */
+	public function __construct() {
+
+		add_action( 'init', [ $this, 'add_hooks' ] );
+	}
+
+
+	/**
+	 * Adds integration hooks.
+	 *
+	 * @since 2.0.0-dev.3
+	 */
+	public function add_hooks() {
+
+		if ( facebook_for_woocommerce()->is_plugin_active( 'woocommerce-bookings.php') ) {
+			add_filter( 'wc_facebook_product_price', [ $this, 'get_product_price' ], 10, 3 );
+		}
+	}
+
+
+	/**
+	 * Filters the product price user for Facebook sync for Bookable products.
+	 *
+	 * @internal
+	 *
+	 * @since 2.0.0-dev.3
+	 *
+	 * @param int $price product price in cents
+	 * @param float $facebook_price user defined facebook price
+	 * @param \WC_Product $product product object
+	 * @return int
+	 */
+	public function get_product_price( $price, $facebook_price, $product ) {
+
+		if ( ! $facebook_price && $product instanceof \WC_Product && $this->is_bookable_product( $product ) ) {
+
+			$product      = new \WC_Product_Booking( $product );
+			$display_cost = is_callable( [ $product, 'get_display_cost' ] ) ? $product->get_display_cost() : 0;
+
+			$price = (int) round( wc_get_price_to_display( $product, [ 'price' => $display_cost ] ) * 100 );
+		}
+
+		return $price;
+	}
+
+
+	/**
+	 * Determines whether the current product is a WooCommerce Bookings product.
+	 *
+	 * @since 2.0.0-dev.3
+	 *
+	 * @param \WC_Product $product product object
+	 * @return bool
+	 */
+	private function is_bookable_product( \WC_Product $product ) {
+
+		return class_exists( 'WC_Product_Booking' ) && is_callable( 'is_wc_booking_product' ) && is_wc_booking_product( $product );
+	}
+
+
+}
+

--- a/includes/Integrations/Integrations.php
+++ b/includes/Integrations/Integrations.php
@@ -53,6 +53,7 @@ class Integrations {
 
 		$registered_integrations = [
 			'WC_Facebook_WPML_Injector' => '/includes/fbwpml.php',
+			Bookings::class             => '/includes/Integrations/Bookings.php',
 		];
 
 		foreach ( $registered_integrations as $class_name => $path ) {

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -191,10 +191,6 @@ class Products {
 
 		$should_sync = self::is_sync_enabled_for_product( $product );
 
-		// exclude products that qualify to be removed from the catalog
-		if ( $should_sync && self::product_should_be_deleted( $product ) ) {
-			$should_sync = false;
-		}
 
 		// define the product to check terms on
 		if ( $should_sync ) {

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -403,11 +403,6 @@ class Products {
 
 				$price = get_option( 'woocommerce_tax_display_shop' ) === 'incl' ? $product->get_composite_price_including_tax() : $product->get_composite_price();
 
-			} elseif ( class_exists( 'WC_Product_Booking' ) && function_exists( 'is_wc_booking_product' ) && is_wc_booking_product( $product ) ) {
-
-				$booking = new \WC_Product_Booking( $product );
-				$price   = wc_get_price_to_display( $booking, [ 'price' => $booking->get_display_cost() ] );
-
 			} else {
 
 				$price = wc_get_price_to_display( $product, [ 'price' => $product->get_regular_price() ] );

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -195,7 +195,6 @@ class Products {
 
 		$should_sync = self::is_sync_enabled_for_product( $product );
 
-
 		// define the product to check terms on
 		if ( $should_sync ) {
 			$terms_product = $product->is_type( 'variation' ) ? wc_get_product( $product->get_parent_id() ) : $product;

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -390,9 +390,12 @@ class Products {
 	 */
 	public static function get_product_price( \WC_Product $product ) {
 
+		$facebook_price = $product->get_meta( WC_Facebook_Product::FB_PRODUCT_PRICE );
+
 		if ( ! isset( self::$products_price[ $product->get_id() ] ) ) {
 
-			if ( is_numeric( $facebook_price = $product->get_meta( WC_Facebook_Product::FB_PRODUCT_PRICE ) ) ) {
+			// use the user defined Facebook price if set
+			if ( is_numeric( $facebook_price ) ) {
 
 				$price = $facebook_price;
 
@@ -419,9 +422,10 @@ class Products {
 		 * @since 2.0.0-dev.1
 		 *
 		 * @param int $price product price in cents
+		 * @param float $facebook_price user defined facebook price
 		 * @param \WC_Product $product product object
 		 */
-		return (int) apply_filters( 'wc_facebook_product_price', self::$products_price[ $product->get_id() ], $product );
+		return (int) apply_filters( 'wc_facebook_product_price', self::$products_price[ $product->get_id() ], (float) $facebook_price, $product );
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -162,9 +162,7 @@ class Products {
 	/**
 	 * Determines whether the given product should be synced.
 	 *
-	 * If a product is enabled for sync, but belongs to an excluded term, it will return as excluded from sync:
-	 * @see Products::is_sync_enabled_for_product()
-	 * @see Products::is_sync_excluded_for_product_terms()
+	 * @see Products::published_product_should_be_synced()
 	 *
 	 * @since 1.10.0
 	 *
@@ -173,7 +171,25 @@ class Products {
 	 */
 	public static function product_should_be_synced( \WC_Product $product ) {
 
-		$should_sync = 'publish' === $product->get_status() && self::is_sync_enabled_for_product( $product );
+		return 'publish' === $product->get_status() && self::published_product_should_be_synced( $product );
+	}
+
+
+	/**
+	 * Determines whether the given product should be synced assuming the product is published.
+	 *
+	 * If a product is enabled for sync, but belongs to an excluded term, it will return as excluded from sync:
+	 * @see Products::is_sync_enabled_for_product()
+	 * @see Products::is_sync_excluded_for_product_terms()
+	 *
+	 * @since 2.0.0-dev.1
+	 *
+	 * @param \WC_Product $product
+	 * @return bool
+	 */
+	public static function published_product_should_be_synced( \WC_Product $product ) {
+
+		$should_sync = self::is_sync_enabled_for_product( $product );
 
 		// exclude products that qualify to be removed from the catalog
 		if ( $should_sync && self::product_should_be_deleted( $product ) ) {

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -203,6 +203,11 @@ class Products {
 			$terms_product = null;
 		}
 
+		// allow simple or variable products (and their variations) with zero or empty price - exclude other product types with zero or empty price
+		if ( $should_sync && ( ! $terms_product || ( ! self::get_product_price( $product ) && ! in_array( $terms_product->get_type(), [ 'simple', 'variable' ] ) ) ) ) {
+			$should_sync = false;
+		}
+
 		// exclude products that are excluded from the store catalog or from search results
 		if ( $should_sync && ( ! $terms_product || has_term( [ 'exclude-from-catalog', 'exclude-from-search' ], 'product_visibility', $terms_product->get_id() ) ) ) {
 			$should_sync = false;

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -108,10 +108,6 @@ class Sync {
 
 			$woo_product = new \WC_Facebook_Product( $product_id );
 
-			if ( $woo_product->is_hidden() ) {
-				continue;
-			}
-
 			// skip if we don't have a valid product object
 			if ( ! $woo_product->woo_product instanceof \WC_Product ) {
 				continue;

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -112,12 +112,17 @@ class Sync {
 				continue;
 			}
 
-			if ( get_option( 'woocommerce_hide_out_of_stock_items' ) === 'yes' && ! $woo_product->is_in_stock() ) {
+			// skip if we don't have a valid product object
+			if ( ! $woo_product->woo_product instanceof \WC_Product ) {
+				continue;
+			}
+
+			if ( Products::product_should_be_deleted( $woo_product->woo_product ) ) {
 				continue;
 			}
 
 			// skip if not enabled for sync
-			if ( $woo_product->woo_product instanceof \WC_Product && ! Products::product_should_be_synced( $woo_product->woo_product ) ) {
+			if ( ! Products::product_should_be_synced( $woo_product->woo_product ) ) {
 				continue;
 			}
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -349,24 +349,14 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 		 *
 		 * @see SkyVerge\WooCommerce\Facebook\Products\Sync::create_or_update_all_products()
 		 * @see WC_Facebook_Product_Feed::write_product_feed_file()
+		 *
+		 * @deprecated 2.0.2-dev.1
 		 */
 		public function is_hidden() {
-			$wpid = $this->id;
-			if ( WC_Facebookcommerce_Utils::is_variation_type( $this->get_type() ) ) {
-				$wpid = $this->get_parent_id();
-			}
-			$hidden_from_catalog = has_term(
-				'exclude-from-catalog',
-				'product_visibility',
-				$wpid
-			);
-			$hidden_from_search  = has_term(
-				'exclude-from-search',
-				'product_visibility',
-				$wpid
-			);
 
-			return ( $hidden_from_catalog && $hidden_from_search ) || ! $this->get_fb_price();
+			wc_deprecated_function( __METHOD__,  '2.0.2-dev.1', 'Products::product_should_be_synced()' );
+
+			return $this->woo_product instanceof \WC_Product && ! Products::product_should_be_synced( $this->woo_product );
 		}
 
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -124,46 +124,8 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 		}
 
 		public function get_fb_price() {
-			// Cache the price in this object in case of multiple calls.
-			if ( $this->fb_price ) {
-				return $this->fb_price;
-			}
 
-			$price = get_post_meta(
-				$this->id,
-				self::FB_PRODUCT_PRICE,
-				true
-			);
-
-			if ( is_numeric( $price ) ) {
-				return intval( round( $price * 100 ) );
-			}
-
-			// If product is composite product, we rely on their pricing.
-			if ( class_exists( 'WC_Product_Composite' )
-			&& $this->woo_product->get_type() === 'composite' ) {
-				$price          = get_option( 'woocommerce_tax_display_shop' ) === 'incl'
-				? $this->woo_product->get_composite_price_including_tax()
-				: $this->woo_product->get_composite_price();
-				$this->fb_price = intval( round( $price * 100 ) );
-				return $this->fb_price;
-			}
-
-			// Get regular price: regular price doesn't include sales
-			$regular_price = floatval( $this->get_regular_price() );
-
-			// If it's a bookable product, the normal price is null/0.
-			if ( ! $regular_price && $this->is_bookable_product() ) {
-
-				$product       = new WC_Product_Booking( $this->woo_product );
-				$regular_price = is_callable( [ $product, 'get_display_cost' ] ) ? $product->get_display_cost() : 0;
-			}
-
-			// Get regular price plus tax, if it's set to display and taxable
-			// whether price includes tax is based on 'woocommerce_tax_display_shop'
-			$price          = $this->get_price_plus_tax( $regular_price );
-			$this->fb_price = intval( round( $price * 100 ) );
-			return $this->fb_price;
+			return Products::get_product_price( $this->woo_product );
 		}
 
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -543,11 +543,8 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				'retailer_id'           => $retailer_id,
 				'price'                 => $this->get_fb_price(),
 				'currency'              => get_woocommerce_currency(),
-				'availability'          => $this->is_in_stock() ? 'in stock' :
-				'out of stock',
-				'visibility'            => ! $this->is_hidden()
-				? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE
-				: \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
+				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
+				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 			);
 
 			// Only use checkout URLs if they exist.

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -347,11 +347,8 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 		/**
 		 * Determines whether a product should be excluded from all-products sync or the feed file.
 		 *
-		 * The plugin also avoids trying to get the Facebook ID of products where is_hidden() returns true.
-		 *
 		 * @see SkyVerge\WooCommerce\Facebook\Products\Sync::create_or_update_all_products()
 		 * @see WC_Facebook_Product_Feed::write_product_feed_file()
-		 * @see WC_Facebookcommerce_Integration::get_product_fbid()
 		 */
 		public function is_hidden() {
 			$wpid = $this->id;

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -566,10 +566,6 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 
 					$woo_product = new WC_Facebook_Product( $wp_id );
 
-					if ( $woo_product->is_hidden() ) {
-						continue;
-					}
-
 					// skip if we don't have a valid product object
 					if ( ! $woo_product->woo_product instanceof \WC_Product ) {
 						continue;

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use SkyVerge\WooCommerce\Facebook\Products;
 use SkyVerge\WooCommerce\Facebook\Products\Feed;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
@@ -569,12 +570,17 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 						continue;
 					}
 
-					if ( get_option( 'woocommerce_hide_out_of_stock_items' ) === 'yes' && ! $woo_product->is_in_stock() ) {
+					// skip if we don't have a valid product object
+					if ( ! $woo_product->woo_product instanceof \WC_Product ) {
+						continue;
+					}
+
+					if ( Products::product_should_be_deleted( $woo_product->woo_product ) ) {
 						continue;
 					}
 
 					// skip if not enabled for sync
-					if ( $woo_product->woo_product instanceof \WC_Product && ! SkyVerge\WooCommerce\Facebook\Products::product_should_be_synced( $woo_product->woo_product ) ) {
+					if ( ! Products::product_should_be_synced( $woo_product->woo_product ) ) {
 						continue;
 					}
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -389,14 +389,22 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Background::process_item() */
+	public function test_process_item_exceptions_with_invalid_method() {
+
+		$product = new \WC_Product_Simple();
+		$product->save();
+
+		$this->check_process_item_exceptions( $product, 'INVALID' );
+	}
+
+
 	/**
 	 * Tests that process_item() throws exceptions if product or method are invalid.
 	 *
 	 * @see Background::process_item()
-	 *
-	 * @dataProvider provider_process_item_exceptions
 	 */
-	public function test_process_item_exceptions( $product, $method ) {
+	public function check_process_item_exceptions( $product, $method ) {
 
 		$this->expectException( Framework\SV_WC_Plugin_Exception::class );
 
@@ -406,22 +414,24 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see test_process_item_exceptions() */
-	public function provider_process_item_exceptions() {
+	/** @see Background::process_item() */
+	public function test_process_item_exceptions_with_invalid_product() {
 
-		$valid_product = new \WC_Product_Simple();
-		$valid_product->save();
+		// a product that hasn't been saved
+		$product = new \WC_Product_Simple();
 
-		$product_without_id = new \WC_Product_Simple();
+		$this->check_process_item_exceptions( $product, Sync::ACTION_UPDATE );
+	}
 
-		$product_variation_without_parent = new \WC_Product_Variation();
-		$product_variation_without_parent->save();
 
-		return [
-			[ $product_without_id,               Sync::ACTION_UPDATE ],
-			[ $product_variation_without_parent, Sync::ACTION_UPDATE ],
-			[ $valid_product,                    'INVALID' ],
-		];
+	/** @see Background::process_item() */
+	public function test_process_item_exceptions_with_orphan_variation() {
+
+		// product variation without a parent
+		$variation = new \WC_Product_Variation();
+		$variation->save();
+
+		$this->check_process_item_exceptions( $variation, Sync::ACTION_UPDATE );
 	}
 
 

--- a/tests/integration/Products/SyncTest.php
+++ b/tests/integration/Products/SyncTest.php
@@ -30,7 +30,7 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 		}
 
 		// create a variable product with three variations but no price
-		$this->tester->get_variable_product( [ 'children' => 3 ] );
+		$no_price_variable_product = $this->tester->get_variable_product( [ 'children' => 3 ] );
 
 		// create a simple product with price
 		$simple_product = $this->tester->get_product();
@@ -40,8 +40,8 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 		// add all eligible products to the sync queue
 		$requests = $this->create_or_update_all_products();
 
-		// test that create_or_update_all_products() added the three variations with price to the sync queue
-		foreach ( $variable_product->get_children() as $variation_id ) {
+		// test that create_or_update_all_products() added the three variations with price and three variations without price to the sync queue
+		foreach ( array_merge( $variable_product->get_children(), $no_price_variable_product->get_children() ) as $variation_id ) {
 
 			$index = Sync::PRODUCT_INDEX_PREFIX . $variation_id;
 
@@ -54,7 +54,7 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( 'UPDATE', $requests[ Sync::PRODUCT_INDEX_PREFIX . $simple_product->get_id() ] );
 
 		// test no other products or variations were added
-		$this->assertEquals( count( $variable_product->get_children() ) + 1, count( $requests ) );
+		$this->assertEquals( 7, count( $requests ) );
 	}
 
 
@@ -69,12 +69,11 @@ class SyncTest extends \Codeception\TestCase\WPTestCase {
 
 		$sync = $this->get_sync();
 
+		$this->tester->setPropertyValue( $sync, 'requests', [] );
+
 		$sync->create_or_update_all_products();
 
-		$requests_property = new \ReflectionProperty( Sync::class, 'requests' );
-		$requests_property->setAccessible( true );
-
-		return $requests_property->getValue( $sync );
+		return $this->tester->getPropertyValue( $sync, 'requests' );
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -55,6 +55,17 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @see Facebook\Products::product_should_be_synced() */
+	public function test_product_should_be_synced_with_outofstock_product() {
+
+		$product = $this->get_product( ['stock_status' => 'outofstock' ] );
+
+		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
+
+		$this->assertFalse( Facebook\Products::product_should_be_synced( $product ) );
+	}
+
+
+	/** @see Facebook\Products::product_should_be_synced() */
 	public function test_product_should_be_synced_simple_in_excluded_category() {
 
 		$product = $this->get_product();

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -38,7 +38,11 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::product_should_be_synced() */
 	public function test_product_should_be_synced_simple() {
 
-		$product = $this->get_product();
+		// used the tester's method directly to set regular_price to 0
+		$product = $this->tester->get_product( [
+			'status'        => 'publish',
+			'regular_price' => 0,
+		] );
 
 		$this->assertTrue( Facebook\Products::product_should_be_synced( $product ) );
 	}
@@ -46,7 +50,11 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::product_should_be_synced() */
 	public function test_product_should_be_synced_variation() {
 
-		$product = $this->get_variable_product();
+		// used the tester's method directly to set regular_price to 0
+		$product = $this->tester->get_variable_product( [
+			'status'        => 'publish',
+			'regular_price' => 0,
+		] );
 
 		foreach ( $product->get_children() as $child_id ) {
 			$this->assertTrue( Facebook\Products::product_should_be_synced( wc_get_product( $child_id ) ) );

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -65,6 +65,35 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * Tests that product excluded from the store catalog or from search results should not be synced.
+	 *
+	 * @see Facebook\Products::product_should_be_synced()
+	 *
+	 * @param string $term product_visibility term
+	 *
+	 * @dataProvider provider_product_should_be_synced_with_product_excluded_from_catalog
+	 */
+	public function test_product_should_be_synced_with_excluded_products( $term ) {
+
+		$product = $this->get_product();
+
+		wp_set_object_terms( $product->get_id(), $term, 'product_visibility' );
+
+		$this->assertFalse( Facebook\Products::product_should_be_synced( $product ) );
+	}
+
+
+	/** @see test_product_should_be_synced_with_excluded_products() */
+	public function provider_product_should_be_synced_with_product_excluded_from_catalog() {
+
+		return [
+			[ 'exclude-from-catalog' ],
+			[ 'exclude-from-search' ],
+		];
+	}
+
+
 	/** @see Facebook\Products::product_should_be_synced() */
 	public function test_product_should_be_synced_simple_in_excluded_category() {
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -54,17 +54,6 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Facebook\Products::product_should_be_synced() */
-	public function test_product_should_be_synced_with_outofstock_product() {
-
-		$product = $this->get_product( ['stock_status' => 'outofstock' ] );
-
-		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
-
-		$this->assertFalse( Facebook\Products::product_should_be_synced( $product ) );
-	}
-
-
 	/**
 	 * Tests that product excluded from the store catalog or from search results should not be synced.
 	 *

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -61,7 +61,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @param string $term product_visibility term
 	 *
-	 * @dataProvider provider_product_should_be_synced_with_product_excluded_from_catalog
+	 * @dataProvider provider_product_should_be_synced_with_excluded_products
 	 */
 	public function test_product_should_be_synced_with_excluded_products( $term ) {
 
@@ -74,7 +74,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @see test_product_should_be_synced_with_excluded_products() */
-	public function provider_product_should_be_synced_with_product_excluded_from_catalog() {
+	public function provider_product_should_be_synced_with_excluded_products() {
 
 		return [
 			[ 'exclude-from-catalog' ],

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -300,6 +300,19 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Facebook\Products::get_product_price() */
+	public function test_get_product_price_filter() {
+
+		$product = $this->get_product();
+
+		add_filter( 'wc_facebook_product_price', static function() {
+			return 1234;
+		} );
+
+		$this->assertSame( 1234, Facebook\Products::get_product_price( $product ) );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -1,6 +1,6 @@
 <?php
 
-use Codeception\Stub\Expected;
+use SkyVerge\WooCommerce\Facebook\Products;
 
 /**
  * Tests the Facebook product class.
@@ -29,6 +29,41 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see \WC_Facebook_Product::prepare_product()
+	 *
+	 * @param mixed $price the regular price for the product
+	 * @param bool $is_visible whether the product should visible in the Facebook Shop
+	 * @param string $visibility 'staging' or 'published'
+	 * @dataProvider provider_prepare_product_sets_product_visibility
+	 */
+	public function test_prepare_product_sets_product_visibility( $price, $is_visible, $visibility ) {
+
+		$product = $this->tester->get_product( [ 'regular_price' => $price ] );
+
+		Products::set_product_visibility( $product, $is_visible );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertSame( $visibility, $data['visibility'] );
+	}
+
+
+	/** @see test_prepare_product_sets_product_visibility() */
+	public function provider_prepare_product_sets_product_visibility() {
+
+		return [
+			[ '',    true, \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE ],
+			[ 0.00,  true, \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE ],
+			[ 14.99, true, \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE ],
+
+			[ '',    false, \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN ],
+			[ 0.00,  false, \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN ],
+			[ 14.99, false, \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN ],
+		];
+	}
 
 
 	/**

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -1213,20 +1213,24 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	}
 
 
+	/** @see \WC_Facebookcommerce_Integration::product_should_be_synced() */
+	public function test_product_should_be_synced_when_product_sync_is_disabled() {
+
+		add_filter( 'wc_facebook_is_product_sync_enabled', function() {
+			return false;
+		} );
+
+		$this->check_product_should_be_synced( null, false );
+	}
+
+
 	/**
 	 * @see \WC_Facebookcommerce_Integration::product_should_be_synced()
 	 *
-	 * @param bool $sync_enabled whether product sync is enabled at the plugin level
 	 * @param \WC_Product $product product object
 	 * @param bool $should_be_synced expected return value
-	 *
-	 * @dataProvider provider_product_should_be_synced
 	 */
-	public function test_product_should_be_synced( $sync_enabled, $product, $should_be_synced ) {
-
-		add_filter( 'wc_facebook_is_product_sync_enabled', function() use ( $sync_enabled) {
-			return $sync_enabled;
-		} );
+	public function check_product_should_be_synced( $product, $should_be_synced ) {
 
 		$method = IntegrationTester::getMethod( \WC_Facebookcommerce_Integration::class, 'product_should_be_synced' );
 
@@ -1234,29 +1238,44 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	}
 
 
-	/** @see test_product_should_be_synced */
-	public function provider_product_should_be_synced() {
+	/** @see \WC_Facebookcommerce_Integration::product_should_be_synced() */
+	public function test_product_should_be_synced_with_published_product() {
 
-		$draft_product = new \WC_Product();
-		$draft_product->set_status( 'draft');
-		$draft_product->save();
+		$product = new \WC_Product();
+		$product->set_status( 'publish' );
+		$product->save();
 
-		$product_with_sync_disabled = new \WC_Product();
-		$product_with_sync_disabled->update_meta_data( Products::SYNC_ENABLED_META_KEY, 'no' );
-		$product_with_sync_disabled->save_meta_data();
-		$product_with_sync_disabled->save();
+		$this->check_product_should_be_synced( $product, true );
+	}
 
-		$published_product = new \WC_Product();
-		$published_product->set_status( 'publish' );
-		$published_product->save();
 
-		return [
-			'sync disabled'              => [ false, null, false ],
-			'not a product'              => [ true, null, false ],
-			'draft product'              => [ true, $draft_product, false ],
-			'product with sync disabled' => [ true, $product_with_sync_disabled, false ],
-			'published product'          => [ true, $published_product, true ],
-		];
+	/** @see \WC_Facebookcommerce_Integration::product_should_be_synced() */
+	public function test_product_should_be_synced_with_draft_product() {
+
+		$product = new \WC_Product();
+		$product->set_status( 'draft');
+		$product->save();
+
+		$this->check_product_should_be_synced( $product, false );
+	}
+
+
+	/** @see \WC_Facebookcommerce_Integration::product_should_be_synced() */
+	public function test_product_should_be_synced_with_product_with_sync_disabled() {
+
+		$product = new \WC_Product();
+		$product->update_meta_data( Products::SYNC_ENABLED_META_KEY, 'no' );
+		$product->save_meta_data();
+		$product->save();
+
+		$this->check_product_should_be_synced( $product, false );
+	}
+
+
+	/** @see \WC_Facebookcommerce_Integration::product_should_be_synced() */
+	public function test_product_should_be_synced_with_invalid_product() {
+
+		$this->check_product_should_be_synced( null, false );
 	}
 
 

--- a/tests/integration/WC_Facebookcommerce_Integration_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Integration_Test.php
@@ -777,7 +777,7 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	/** @see \WC_Facebookcommerce_Integration::on_product_delete() */
 	public function test_on_product_delete_with_simple_product() {
 
-		$product = $this->tester->get_product( [ 'status' => 'publish' ] );
+		$product = $this->tester->get_product( [ 'status' => 'trash' ] );
 
 		$integration = $this->make( \WC_Facebookcommerce_Integration::class, [
 			'delete_product_item'  => Expected::once(),
@@ -797,6 +797,10 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 			'status'   => 'publish',
 		] );
 
+		$product->set_name( 'Test Name' );
+		$product->set_status( 'trash' );
+		$product->save();
+
 		$integration = $this->make( \WC_Facebookcommerce_Integration::class, [
 			'delete_product_item' => Expected::never(),
 			// get_product_fbid() is used to verify that delete_product_group() was called because we cannot set an expectation on private methods
@@ -812,7 +816,7 @@ class WC_Facebookcommerce_Integration_Test extends \Codeception\TestCase\WPTestC
 	/** @see \WC_Facebookcommerce_Integration::on_product_delete() */
 	public function test_on_product_delete_with_product_variation() {
 
-		$variation = $this->tester->get_product_variation( [ 'status' => 'publish' ] );
+		$variation = $this->tester->get_product_variation( [ 'status' => 'trash' ] );
 
 		$integration = $this->make( \WC_Facebookcommerce_Integration::class, [
 			'delete_product_item' => Expected::never(),


### PR DESCRIPTION
# Summary

This PR consolidates the logic to determine whether a product should be synced into the `Products::product_should_be_synced()` and updates the rules to allow simple and variable products (and their variations) that have zero or empty price to be synced.

### Story: [CH 50960](https://app.clubhouse.io/skyverge/story/50960)
### Release: #1467

## Details

The tests from #1422 and #1423 should ensure that existing behavior doesn't change as we update other methods to use the rules now defined in `Products::product_should_be_synced()`.

## QA

### Setup

1. Install Composite Products: https://cloud.skyver.ge/mXuANdoD
1. Install and Configure Facebook for WooCommerce 
1. Set Default customer location to Shop base address 
1. Set Prices entered with tax to `No`
1. Set Display prices in the shop to `Excluding tax`
1. Add a 10% tax that matches the shop base address

### Steps

#### Display prices excluding tax

1. Create a product with empty price
    - [x] The product is synced to Facebook with price $0.00
1. Create a product with $10 as price
    - [x] The product is synced to Facebook with price $10.00
1. Create a product with $10 as price and set Facebook price to 15
    - [x] The product is synced to Facebook with price $15.00
1. Create a variable product with:
    - Variation 1 with empty price
    - Variation 2 with $10 as price
    - Variation 3 with $10 as price and $15 as Facebook price
1. The variations are synced to Facebook
    - [x] Variation 1 is synced to Facebook with price $0.00
    - [x] Variation 2 is synced to Facebook with price $10.00
    - [x] Variation 3 is synced to Facebook with price $15.00
1. Create a Composite Product
    - Do not define a regular price or sale price
    - Add two components configured to be priced individually
1. The Composite Product is synced to Facebook
    - [x] The price of the composite product on Facebook matches the price of the product in the shop
1. Add a Bookable Product with a base cost of $5 and block cost of $2
    - [x] The price of the bookable product on Facebook is $7 

#### Display prices including tax

1. Set Display prices in the shop to `Including tax`
1. Sync products from WooCommerce > Facebook > Product sync
    - [x] The empty price product is synced to Facebook with price $0.00
    - [x] The $10 product is synced to Facebook with price $11.00
    - [x] The $15 product is synced to Facebook with price $15.00 (taxes are not applied to overwritten Facebook prices)
    - [x] Variation 1 is synced to Facebook with price $0.00
    - [x] Variation 2 is synced to Facebook with price $11.00
    - [x] Variation 3 is synced to Facebook with price $15.00 (taxes are not applied to overwritten Facebook prices)
    - [x] The price of the composite product on Facebook includes taxes and matches the price of the product in the shop
    - [x] The price of the bookable product on Facebook is $7.70

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
- [x] I have confirmed that the changes from https://github.com/facebookincubator/facebook-for-woocommerce/pull/1439 were integrated into this branch
