### PR TITLE
Product bundles priced by the individual items cannot be synced

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -402,6 +402,13 @@ class Products {
 
 			$price = get_option( 'woocommerce_tax_display_shop' ) === 'incl' ? $product->get_composite_price_including_tax() : $product->get_composite_price();
 
+		} elseif ( class_exists( 'WC_Product_Bundle' )
+		     && empty( $product->get_regular_price() )
+		     && 'bundle' === $product->get_type() ) {
+
+			// if product is a product bundle with individually priced items, we rely on their pricing
+			$price = wc_get_price_to_display( $product, [ 'price' => $product->get_bundle_price() ] );
+
 		} else {
 
 			$price = wc_get_price_to_display( $product, [ 'price' => $product->get_regular_price() ] );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -152,6 +152,14 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			// Get regular price: regular price doesn't include sales
 			$regular_price = floatval( $this->get_regular_price() );
 
+			// if product is a product bundle with individually priced items, we rely on their pricing.
+			if ( class_exists( 'WC_Product_Bundle' )
+			     && empty( $regular_price )
+			     && 'bundle' === $this->woo_product->get_type() ) {
+
+				$regular_price = $this->woo_product->get_bundle_price();
+			}
+
 			// If it's a bookable product, the normal price is null/0.
 			if ( ! $regular_price && $this->is_bookable_product() ) {
 


### PR DESCRIPTION
# Summary

This PR adds code to get the price for bundled products with individually priced items.

### Story: [CH 58419](https://app.clubhouse.io/skyverge/story/58419/product-bundles-priced-by-the-individual-items-cannot-be-synced-6)
### Release: #1467

## QA

### Setup

1. Install Product Bundles: https://cloud.skyver.ge/WnuJxpky
1. Install and Configure Facebook for WooCommerce 
1. Create a product bundle that has no price set
1. Add products to the bundle that are priced individually

### Steps

#### Feed sync

1. Run the scheduled action to generate the feed
1. Grab the feed file from the `uploads\facebook_for_woocommerce` folder
    - [x] The feed file contains the product bundle

#### Sync on update

1. Edit the product bundle
    - [x] The changes are synced to Facebook

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version