### PR TITLE
Move expensive sync queries into the background job

### DIFF
--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -103,27 +103,8 @@ class Sync {
 		// remove parent products because those can't be represented as Product Items
 		$product_ids = array_diff( $product_ids, $parent_product_ids );
 
-		// make sure the product should be synced and add it to the sync queue
-		foreach ( $product_ids as $product_id ) {
-
-			$woo_product = new \WC_Facebook_Product( $product_id );
-
-			// skip if we don't have a valid product object
-			if ( ! $woo_product->woo_product instanceof \WC_Product ) {
-				continue;
-			}
-
-			if ( Products::product_should_be_deleted( $woo_product->woo_product ) ) {
-				continue;
-			}
-
-			// skip if not enabled for sync
-			if ( ! Products::product_should_be_synced( $woo_product->woo_product ) ) {
-				continue;
-			}
-
-			$this->create_or_update_products( [ $product_id ] );
-		}
+		// queue up these IDs for sync. they will only be included in the final requests if they should be synced
+		$this->create_or_update_products( $product_ids );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -387,7 +387,7 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayHasKey( 'messenger_chat', $extras['business_config'] );
 		$this->assertTrue( $extras['business_config']['messenger_chat']['enabled'] );
-		$this->assertSame( home_url( '/' ), $extras['business_config']['messenger_chat']['domains'] );
+		$this->assertSame( [ home_url( '/' ) ], $extras['business_config']['messenger_chat']['domains'] );
 	}
 
 

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -424,17 +424,6 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Background::process_item() */
-	public function test_process_item_exceptions_with_orphan_variation() {
-
-		// product variation without a parent
-		$variation = new \WC_Product_Variation();
-		$variation->save();
-
-		$this->check_process_item_exceptions( $variation, Sync::ACTION_UPDATE );
-	}
-
-
 	/**
 	 * @see Background::process_item_update()
 	 *


### PR DESCRIPTION
# Summary

Moves the checks for determining a product's sync availability to the background processor.

### Story: [CH 60902](https://app.clubhouse.io/skyverge/story/60902)
### Release: #1467 

## Details

When doing a full catalog sync, the plugin first gathers all potential product IDs and filters out any that _shouldn't_ sync. After that, it creates the background job to process all of those IDs and send them to Facebook via the batch API.

If the merchant has a massive catalog, then that first step of checking the products can run out of memory because we need to instantiate the product, check meta, potentially its parent, and its terms for term exclusions.

Since we already have a background process that loops through the products and instantiates them before sending to Facebook, we can move that expensive stuff to the background so it benefits from the out of memory recovery that provides.

## UI Changes

_N/A_

## QA

- Connect the plugin
- Have a few "Sync and show" products
- Have a few "Do not sync" products

1. Trigger a catalog sync via the "Sync products" button
    - [x] The products that should sync are synced
    - [x] The products that should not sync are not synced

- [x] Integration tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version