### PR TITLE
Implement the google category methods

### DIFF
--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -62,7 +62,7 @@ class Commerce {
 	 */
 	public function update_default_google_product_category_id( $id ) {
 
-		// TODO: implement
+		update_option( self::OPTION_GOOGLE_PRODUCT_CATEGORY_ID, is_string( $id ) ? $id : '' );
 	}
 
 

--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -39,8 +39,17 @@ class Commerce {
 	 */
 	public function get_default_google_product_category_id() {
 
-		// TODO: implement
-		return '';
+		$category_id = get_option( self::OPTION_GOOGLE_PRODUCT_CATEGORY_ID, '' );
+
+		/**
+		 * Filters the plugin-level fallback Google product category ID.
+		 *
+		 * @since 2.1.0-dev.1
+		 *
+		 * @param string $category_id default Google product category ID
+		 * @param Commerce $commerce commerce handler instance
+		 */
+		return (string) apply_filters( 'wc_facebook_commerce_default_google_product_category_id', $category_id, $this );
 	}
 
 

--- a/tests/integration/CommerceTest.php
+++ b/tests/integration/CommerceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Commerce;
+
+/**
+ * Tests the Commerce handler class.
+ */
+class CommerceTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** Helper methods **************************************************************************************************/
+
+
+	/**
+	 * Gets the commerce handler instance.
+	 *
+	 * @return Commerce
+	 */
+	private function get_commerce_handler() {
+
+		return new Commerce();
+	}
+
+
+}

--- a/tests/integration/CommerceTest.php
+++ b/tests/integration/CommerceTest.php
@@ -39,6 +39,8 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @see Commerce::update_default_google_product_category_id()
 	 *
+	 * @param string $new_value new product category ID
+	 * @param string $stored_value expected stored value
 	 * @dataProvider provider_update_default_google_product_category_id
 	 */
 	public function test_update_default_google_product_category_id( $new_value, $stored_value ) {

--- a/tests/integration/CommerceTest.php
+++ b/tests/integration/CommerceTest.php
@@ -47,8 +47,7 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->get_commerce_handler()->update_default_google_product_category_id( $new_value );
 
-		$this->assertSame( $stored_value, $this->get_commerce_handler()->get_default_google_product_category_id() );
-		$this->assertSame( $stored_value, $this->get_commerce_handler()->get_default_google_product_category_id() );
+		$this->assertSame( $stored_value, get_option( Commerce::OPTION_GOOGLE_PRODUCT_CATEGORY_ID ) );
 	}
 
 

--- a/tests/integration/CommerceTest.php
+++ b/tests/integration/CommerceTest.php
@@ -15,6 +15,15 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
+	/** @see Commerce::get_default_google_product_category_id() */
+	public function test_get_default_google_product_category_id() {
+
+		update_option( Commerce::OPTION_GOOGLE_PRODUCT_CATEGORY_ID, 'default' );
+
+		$this->assertSame( 'default', $this->get_commerce_handler()->get_default_google_product_category_id() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/CommerceTest.php
+++ b/tests/integration/CommerceTest.php
@@ -24,6 +24,7 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Commerce::get_default_google_product_category_id() */
 	public function test_get_default_google_product_category_id_filter() {
 
 		add_filter( 'wc_facebook_commerce_default_google_product_category_id', static function() {
@@ -32,6 +33,32 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 		} );
 
 		$this->assertSame( 'filtered', $this->get_commerce_handler()->get_default_google_product_category_id() );
+	}
+
+
+	/**
+	 * @see Commerce::update_default_google_product_category_id()
+	 *
+	 * @dataProvider provider_update_default_google_product_category_id
+	 */
+	public function test_update_default_google_product_category_id( $new_value, $stored_value ) {
+
+		$this->get_commerce_handler()->update_default_google_product_category_id( $new_value );
+
+		$this->assertSame( $stored_value, $this->get_commerce_handler()->get_default_google_product_category_id() );
+		$this->assertSame( $stored_value, $this->get_commerce_handler()->get_default_google_product_category_id() );
+	}
+
+
+	/** @see test_update_default_google_product_category_id */
+	public function provider_update_default_google_product_category_id() {
+
+		return [
+			[ 'category_id', 'category_id' ],
+			[ '12',          '12' ],
+			[ 12,            '' ],
+			[ null,          '' ]
+		];
 	}
 
 

--- a/tests/integration/CommerceTest.php
+++ b/tests/integration/CommerceTest.php
@@ -24,6 +24,17 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	public function test_get_default_google_product_category_id_filter() {
+
+		add_filter( 'wc_facebook_commerce_default_google_product_category_id', static function() {
+
+			return 'filtered';
+		} );
+
+		$this->assertSame( 'filtered', $this->get_commerce_handler()->get_default_google_product_category_id() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 


### PR DESCRIPTION
# Summary

This PR implements the Google category methods in the Commerce handler.

### Story: [CH 62139](https://app.clubhouse.io/skyverge/story/62139/implement-the-google-category-methods)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version