### PR TITLE
Implement the Product_Categories methods

### DIFF
--- a/includes/Product_Categories.php
+++ b/includes/Product_Categories.php
@@ -46,7 +46,7 @@ class Product_Categories {
 	 */
 	public static function update_google_product_category_id( $id, $category_id ) {
 
-		add_term_meta( $id, Products::GOOGLE_PRODUCT_CATEGORY_META_KEY, $category_id, true );
+		update_term_meta( $id, Products::GOOGLE_PRODUCT_CATEGORY_META_KEY, $category_id );
 	}
 
 

--- a/includes/Product_Categories.php
+++ b/includes/Product_Categories.php
@@ -46,7 +46,7 @@ class Product_Categories {
 	 */
 	public static function update_google_product_category_id( $id, $category_id ) {
 
-		// TODO: implement
+		add_term_meta( $id, Products::GOOGLE_PRODUCT_CATEGORY_META_KEY, $category_id, true );
 	}
 
 

--- a/includes/Product_Categories.php
+++ b/includes/Product_Categories.php
@@ -32,8 +32,7 @@ class Product_Categories {
 	 */
 	public static function get_google_product_category_id( $category_id ) {
 
-		// TODO: implement
-		return '';
+		return get_term_meta( $category_id, Products::GOOGLE_PRODUCT_CATEGORY_META_KEY, true );
 	}
 
 

--- a/tests/integration/Product_Categories_Test.php
+++ b/tests/integration/Product_Categories_Test.php
@@ -41,4 +41,13 @@ class Product_Categories_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Product_Categories::update_google_product_category_id() */
+	public function test_update_google_product_category_id() {
+
+		Product_Categories::update_google_product_category_id( $this->category_id, '3530' );
+
+		$this->assertEquals( '3530', get_term_meta( $this->category_id, Products::GOOGLE_PRODUCT_CATEGORY_META_KEY, true ) );
+	}
+
+
 }

--- a/tests/integration/Product_Categories_Test.php
+++ b/tests/integration/Product_Categories_Test.php
@@ -1,0 +1,44 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Product_Categories;
+use SkyVerge\WooCommerce\Facebook\Products;
+
+/**
+ * Tests the Product_Categories class.
+ */
+class Product_Categories_Test extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+	/** @var int category ID */
+	protected $category_id;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		if ( ! class_exists( Product_Categories::class ) ) {
+			require_once 'includes/Product_Categories.php';
+		}
+
+		$category          = wp_insert_term( 'New category', 'product_cat' );
+		$this->category_id = $category['term_id'];
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Product_Categories::get_google_product_category_id() */
+	public function test_get_google_product_category_id() {
+
+		add_term_meta( $this->category_id, Products::GOOGLE_PRODUCT_CATEGORY_META_KEY, '3367', true );
+
+		$this->assertEquals( '3367', Product_Categories::get_google_product_category_id( $this->category_id ) );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR implements the `Product_Categories::get_google_product_category_id()` and `Product_Categories::update_google_product_category_id()` methods.

### Story: [CH 62153](https://app.clubhouse.io/skyverge/story/62153/implement-the-product-categories-methods)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version