### PR TITLE
Implement the Products methods used to check/set if Commerce is enabled and if the product is ready

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -480,7 +480,7 @@ class Products {
 	 */
 	public static function update_commerce_enabled_for_product( \WC_Product $product, $is_enabled ) {
 
-		// TODO: implement
+		$product->update_meta_data( Products::COMMERCE_ENABLED_META_KEY, wc_bool_to_string( $is_enabled ) );
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -449,7 +449,7 @@ class Products {
 	 */
 	public static function is_product_ready_for_commerce( \WC_Product $product ) {
 
-		return $product->get_manage_stock()
+		return $product->managing_stock()
 			&& self::get_product_price( $product )
 			&& self::is_commerce_enabled_for_product( $product )
 			&& self::product_should_be_synced( $product );

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -466,8 +466,7 @@ class Products {
 	 */
 	public static function is_commerce_enabled_for_product( \WC_Product $product )  {
 
-		// TODO: implement
-		return true;
+		return wc_string_to_bool( $product->get_meta( Products::COMMERCE_ENABLED_META_KEY ) );
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -481,6 +481,7 @@ class Products {
 	public static function update_commerce_enabled_for_product( \WC_Product $product, $is_enabled ) {
 
 		$product->update_meta_data( Products::COMMERCE_ENABLED_META_KEY, wc_bool_to_string( $is_enabled ) );
+		$product->save_meta_data();
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -449,8 +449,10 @@ class Products {
 	 */
 	public static function is_product_ready_for_commerce( \WC_Product $product ) {
 
-		// TODO: implement
-		return true;
+		return $product->get_manage_stock()
+			&& self::get_product_price( $product )
+			&& self::is_commerce_enabled_for_product( $product )
+			&& self::product_should_be_synced( $product );
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -415,6 +415,9 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 		Products::update_commerce_enabled_for_product( $product, $param_value );
 
+		// get a fresh product object to ensure the status is stored
+		$product = wc_get_product( $product->get_id() );
+
 		$this->assertEquals( $expected_meta_value, $product->get_meta( Products::COMMERCE_ENABLED_META_KEY ) );
 	}
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -366,6 +366,39 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * @see \SkyVerge\WooCommerce\Facebook\Products::is_commerce_enabled_for_product()
+	 *
+	 * @param string $meta_value meta value
+	 * @param bool $expected_result the expected result
+	 *
+	 * @dataProvider provider_is_commerce_enabled_for_product
+	 */
+	public function test_is_commerce_enabled_for_product( $meta_value, $expected_result ) {
+
+		$product = $this->get_product();
+
+		if ( ! empty( $meta_value ) ) {
+			$product->add_meta_data( Products::COMMERCE_ENABLED_META_KEY, $meta_value, true );
+		} else {
+			$product->delete_meta_data( Products::COMMERCE_ENABLED_META_KEY );
+		}
+
+		$this->assertEquals( $expected_result, Facebook\Products::is_commerce_enabled_for_product( $product ) );
+	}
+
+
+	/** @see test_is_commerce_enabled_for_product */
+	public function provider_is_commerce_enabled_for_product() {
+
+		return [
+			[ null, false ], // if a product does not have this meta set, Commerce is not enabled for it
+			[ 'yes',  true ],
+			[ 'no', false ],
+		];
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -379,7 +379,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		$product = $this->get_product();
 
 		if ( ! empty( $meta_value ) ) {
-			$product->add_meta_data( Products::COMMERCE_ENABLED_META_KEY, $meta_value, true );
+			$product->update_meta_data( Products::COMMERCE_ENABLED_META_KEY, $meta_value, true );
 		} else {
 			$product->delete_meta_data( Products::COMMERCE_ENABLED_META_KEY );
 		}
@@ -392,9 +392,42 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	public function provider_is_commerce_enabled_for_product() {
 
 		return [
-			[ null, false ], // if a product does not have this meta set, Commerce is not enabled for it
 			[ 'yes',  true ],
+			[ true,  true ],
 			[ 'no', false ],
+			[ false, false ],
+			[ null, false ], // if a product does not have this meta set, Commerce is not enabled for it
+		];
+	}
+
+
+	/**
+	 * @see \SkyVerge\WooCommerce\Facebook\Products::update_commerce_enabled_for_product()
+	 *
+	 * @param bool $param_value param value
+	 * @param string $expected_meta_value the expected meta value
+	 *
+	 * @dataProvider provider_update_commerce_enabled_for_product
+	 */
+	public function test_update_commerce_enabled_for_product( $param_value, $expected_meta_value ) {
+
+		$product = $this->get_product();
+
+		Products::update_commerce_enabled_for_product( $product, $param_value );
+
+		$this->assertEquals( $expected_meta_value, $product->get_meta( Products::COMMERCE_ENABLED_META_KEY ) );
+	}
+
+
+	/** @see test_update_commerce_enabled_for_product */
+	public function provider_update_commerce_enabled_for_product() {
+
+		return [
+			[ true, 'yes' ],
+			[ 'yes', 'yes' ],
+			[ false,  'no' ],
+			[ 'no',  'no' ],
+			[ '', 'no' ],
 		];
 	}
 


### PR DESCRIPTION
# Summary

This PR implements the `Products::is_product_ready_for_commerce()`, `Products::is_commerce_enabled_for_product()` and  `Products::update_commerce_enabled_for_product()` methods.

### Story: [CH 62163](https://app.clubhouse.io/skyverge/story/62163/implement-the-products-methods-used-to-check-set-if-commerce-is-enabled-and-if-the-product-is-ready)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version