### PR TITLE
Implement the Products::update_google_product_category_id() method

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -510,7 +510,7 @@ class Products {
 	 */
 	public static function update_google_product_category_id( \WC_Product $product, $category_id ) {
 
-		// TODO: implement
+		$product->update_meta_data( Products::GOOGLE_PRODUCT_CATEGORY_META_KEY, $category_id );
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -513,6 +513,7 @@ class Products {
 	public static function update_google_product_category_id( \WC_Product $product, $category_id ) {
 
 		$product->update_meta_data( Products::GOOGLE_PRODUCT_CATEGORY_META_KEY, $category_id );
+		$product->save_meta_data();
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -1,6 +1,7 @@
 <?php
 
 use SkyVerge\WooCommerce\Facebook;
+use SkyVerge\WooCommerce\Facebook\Products;
 
 /**
  * Tests the Products class.
@@ -365,6 +366,33 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		$this->excluded_category = $category['term_id'];
 
 		update_option( \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS, [ $this->excluded_category ] );
+	}
+
+
+	/**
+	 * @see \SkyVerge\WooCommerce\Facebook\Products::update_google_product_category_id()
+	 *
+	 * @param string $google_product_category_id Google product category ID
+	 *
+	 * @dataProvider provider_update_google_product_category_id
+	 */
+	public function test_update_google_product_category_id( $google_product_category_id ) {
+
+		$product = $this->get_product();
+
+		Products::update_google_product_category_id( $product, $google_product_category_id );
+
+		$this->assertEquals( $google_product_category_id, $product->get_meta( Products::GOOGLE_PRODUCT_CATEGORY_META_KEY ) );
+	}
+
+
+	/** @see test_update_google_product_category_id */
+	public function provider_update_google_product_category_id() {
+
+		return [
+			[ '3350' ],
+			[ '' ],
+		];
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -322,6 +322,33 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * @see \SkyVerge\WooCommerce\Facebook\Products::update_google_product_category_id()
+	 *
+	 * @param string $google_product_category_id Google product category ID
+	 *
+	 * @dataProvider provider_update_google_product_category_id
+	 */
+	public function test_update_google_product_category_id( $google_product_category_id ) {
+
+		$product = $this->get_product();
+
+		Products::update_google_product_category_id( $product, $google_product_category_id );
+
+		$this->assertEquals( $google_product_category_id, $product->get_meta( Products::GOOGLE_PRODUCT_CATEGORY_META_KEY ) );
+	}
+
+
+	/** @see test_update_google_product_category_id */
+	public function provider_update_google_product_category_id() {
+
+		return [
+			[ '3350' ],
+			[ '' ],
+		];
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 
@@ -366,33 +393,6 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		$this->excluded_category = $category['term_id'];
 
 		update_option( \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS, [ $this->excluded_category ] );
-	}
-
-
-	/**
-	 * @see \SkyVerge\WooCommerce\Facebook\Products::update_google_product_category_id()
-	 *
-	 * @param string $google_product_category_id Google product category ID
-	 *
-	 * @dataProvider provider_update_google_product_category_id
-	 */
-	public function test_update_google_product_category_id( $google_product_category_id ) {
-
-		$product = $this->get_product();
-
-		Products::update_google_product_category_id( $product, $google_product_category_id );
-
-		$this->assertEquals( $google_product_category_id, $product->get_meta( Products::GOOGLE_PRODUCT_CATEGORY_META_KEY ) );
-	}
-
-
-	/** @see test_update_google_product_category_id */
-	public function provider_update_google_product_category_id() {
-
-		return [
-			[ '3350' ],
-			[ '' ],
-		];
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -448,6 +448,9 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 		Products::update_google_product_category_id( $product, $google_product_category_id );
 
+		// get a fresh product object
+		$product = wc_get_product( $product->get_id() );
+
 		$this->assertEquals( $google_product_category_id, $product->get_meta( Products::GOOGLE_PRODUCT_CATEGORY_META_KEY ) );
 	}
 


### PR DESCRIPTION
# Summary

This PR implements the `Products::update_google_product_category_id()` method.

### Story: [CH 62167](https://app.clubhouse.io/skyverge/story/62167/implement-the-products-update-google-product-category-id-method)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version