### PR TITLE
Implement the Connection page access token methods

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -173,6 +173,24 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 
 		/**
+		 * Gets deprecated and removed hooks.
+		 *
+		 * @since 2.1.0-dev.1
+		 *
+		 * @return array
+		 */
+		protected function get_deprecated_hooks() {
+
+			return [
+				'wc_facebook_page_access_token' => [
+					'version'     => '2.1.0-dev.1',
+					'replacement' => false,
+				],
+			];
+		}
+
+
+		/**
 		 * Adds the plugin admin notices.
 		 *
 		 * @since 1.11.0

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2749,15 +2749,18 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Updates the Facebook page access token.
 	 *
+	 * TODO: remove this method by version 3.0.0 or by 2021-08-21 {WV 2020-08-21}
+	 *
 	 * @since 1.10.0
+	 * @deprecated 2.1.0-dev.1
 	 *
 	 * @param string $value page access token value
 	 */
 	public function update_page_access_token( $value ) {
 
-		$this->page_access_token = $this->sanitize_facebook_credential( $value );
+		wc_deprecated_function( __METHOD__, '2.1.0-dev.1', Connection::class . '::update_page_access_token()' );
 
-		update_option( self::OPTION_PAGE_ACCESS_TOKEN, $this->page_access_token );
+		facebook_for_woocommerce()->get_connection_handler()->update_page_access_token( $value );
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -24,7 +24,10 @@ require_once 'facebook-commerce-pixel-event.php';
 class WC_Facebookcommerce_Integration extends WC_Integration {
 
 
-	/** @var string the WordPress option name where the page access token is stored */
+	/**
+	 * @var string the WordPress option name where the page access token is stored
+	 * @deprecated 2.1.0-dev.1
+	 */
 	const OPTION_PAGE_ACCESS_TOKEN = 'wc_facebook_page_access_token';
 
 	/** @var string the WordPress option name where the product catalog ID is stored */

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -104,9 +104,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	const ACTION_HOOK_SCHEDULED_RESYNC = 'sync_all_fb_products_using_feed';
 
 
-	/** @var string|null the configured page access token */
-	private $page_access_token;
-
 	/** @var string|null the configured product catalog ID */
 	public $product_catalog_id;
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -9,9 +9,10 @@
  */
 
 use SkyVerge\WooCommerce\Facebook\Admin;
-use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
 use SkyVerge\WooCommerce\Facebook\Products;
 use SkyVerge\WooCommerce\Facebook\Products\Feed;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -2306,18 +2307,18 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Gets the page access token.
 	 *
+	 * TODO: remove this method by version 3.0.0 or by 2021-08-21 {WV 2020-08-21}
+	 *
 	 * @since 1.10.0
+	 * @deprecated 2.1.0-dev.1
 	 *
 	 * @return string
 	 */
 	public function get_page_access_token() {
 
-		if ( ! is_string( $this->page_access_token ) ) {
+		wc_deprecated_function( __METHOD__, '2.1.0-dev.1', Connection::class . '::get_page_access_token()' );
 
-			$value = get_option( self::OPTION_PAGE_ACCESS_TOKEN, '' );
-
-			$this->page_access_token = is_string( $value ) ? $value : '';
-		}
+		$access_token = facebook_for_woocommerce()->get_connection_handler()->get_page_access_token();
 
 		/**
 		 * Filters the Facebook page access token.
@@ -2327,7 +2328,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @param string $page_access_token Facebook page access token
 		 * @param \WC_Facebookcommerce_Integration $integration the integration instance
 		 */
-		return (string) apply_filters( 'wc_facebook_page_access_token', ! $this->is_feed_migrated() ? $this->page_access_token : '', $this );
+		return (string) apply_filters( 'wc_facebook_page_access_token', ! $this->is_feed_migrated() ? $access_token : '', $this );
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2324,6 +2324,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * Filters the Facebook page access token.
 		 *
 		 * @since 1.10.0
+		 * @deprecated 2.1.0-dev.1
 		 *
 		 * @param string $page_access_token Facebook page access token
 		 * @param \WC_Facebookcommerce_Integration $integration the integration instance

--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -99,7 +99,7 @@ class Commerce {
 	 */
 	public function is_connected() {
 
-		$connected = (bool) strlen( facebook_for_woocommerce()->get_integration()->get_page_access_token() );
+		$connected = (bool) strlen( facebook_for_woocommerce()->get_connection_handler()->get_page_access_token() );
 
 		/**
 		 * Filters whether the site is connected.

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -777,6 +777,19 @@ class Connection {
 
 
 	/**
+	 * Stores the given page access token.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $value the access token
+	 */
+	public function update_page_access_token( $value ) {
+
+		update_option( self::OPTION_PAGE_ACCESS_TOKEN, $value );
+	}
+
+
+	/**
 	 * Determines whether the site is connected.
 	 *
 	 * A site is connected if there is an access token stored.

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -369,6 +369,29 @@ class Connection {
 
 
 	/**
+	 * Gets the page access token.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_page_access_token() {
+
+		$access_token = get_option( self::OPTION_PAGE_ACCESS_TOKEN, '' );
+
+		/**
+		 * Filters the page access token.
+		 *
+		 * @since 2.1.0-dev.1
+		 *
+		 * @param string $access_token page access token
+		 * @param Connection $connection connection handler instance
+		 */
+		return (string) apply_filters( 'wc_facebook_connection_page_access_token', $access_token, $this );
+	}
+
+
+	/**
 	 * Gets the URL to start the connection flow.
 	 *
 	 * @since 2.0.0

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -55,6 +55,9 @@ class Connection {
 	/** @var string the merchant access token option name */
 	const OPTION_MERCHANT_ACCESS_TOKEN = 'wc_facebook_merchant_access_token';
 
+	/** @var string the page access token option name */
+	const OPTION_PAGE_ACCESS_TOKEN = 'wc_facebook_page_access_token';
+
 	/** @var string|null the generated external merchant settings ID */
 	private $external_business_id;
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -785,7 +785,7 @@ class Connection {
 	 */
 	public function update_page_access_token( $value ) {
 
-		update_option( self::OPTION_PAGE_ACCESS_TOKEN, $value );
+		update_option( self::OPTION_PAGE_ACCESS_TOKEN, is_string( $value ) ? $value : '' );
 	}
 
 

--- a/tests/integration/CommerceTest.php
+++ b/tests/integration/CommerceTest.php
@@ -126,7 +126,7 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_is_connected( $access_token, $is_connected ) {
 
-		facebook_for_woocommerce()->get_integration()->update_page_access_token( $access_token );
+		facebook_for_woocommerce()->get_connection_handler()->update_page_access_token( $access_token );
 
 		$this->assertSame( $is_connected, $this->get_commerce_handler()->is_connected() );
 	}

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -72,6 +72,15 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_page_access_token() */
+	public function test_get_page_access_token() {
+
+		update_option( Connection::OPTION_PAGE_ACCESS_TOKEN, '123456' );
+
+		$this->assertSame( '123456', $this->get_connection()->get_page_access_token() );
+	}
+
+
 	/** @see Connection::get_connect_url() */
 	public function test_get_connect_url() {
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -81,6 +81,17 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_page_access_token() */
+	public function test_get_page_access_token_filter() {
+
+		add_filter( 'wc_facebook_connection_page_access_token', static function() {
+			return 'filtered';
+		} );
+
+		$this->assertSame( 'filtered', $this->get_connection()->get_page_access_token() );
+	}
+
+
 	/** @see Connection::get_connect_url() */
 	public function test_get_connect_url() {
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -575,6 +575,18 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::update_page_access_token() */
+	public function test_update_page_access_token() {
+
+		$access_token = '123456';
+
+		$this->get_connection()->update_page_access_token( $access_token );
+
+		$this->assertSame( $access_token, get_option( Connection::OPTION_PAGE_ACCESS_TOKEN, '' ) );
+		$this->assertSame( $access_token, $this->get_connection()->get_page_access_token() );
+	}
+
+
 	/** @see Connection::is_connected() */
 	public function test_is_not_connected_without_access_token() {
 


### PR DESCRIPTION
# Summary

This PR implements the `get_page_access_token()` and `update_page_access_token()` methods to the `Connection` handler and deprecates the methods with the same names in the integration class.

### Story: [CH 62318](https://app.clubhouse.io/skyverge/story/62318)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version