### PR TITLE
Implement the Products::get_google_product_category_id() method

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -110,6 +110,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 				require_once __DIR__ . '/includes/Handlers/Connection.php';
 				require_once __DIR__ . '/includes/Integrations/Integrations.php';
+				require_once __DIR__ . '/includes/Product_Categories.php';
 				require_once __DIR__ . '/includes/Products.php';
 				require_once __DIR__ . '/includes/Products/Feed.php';
 				require_once __DIR__ . '/includes/Products/Sync.php';

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -534,7 +534,15 @@ class Products {
 		$google_product_category_id = '';
 
 		// get all categories for the product
-		$categories = get_the_terms( $product->get_id(), 'product_cat' );
+		if ( $product->is_type( 'variation' ) ) {
+
+			$parent_product = wc_get_product( $product->get_parent_id() );
+			$categories     = $parent_product instanceof \WC_Product ? get_the_terms( $parent_product->get_id(), 'product_cat' ) : [];
+
+		} else {
+
+			$categories = get_the_terms( $product->get_id(), 'product_cat' );
+		}
 
 		$categories_per_level = [];
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -571,7 +571,7 @@ class Products {
 			}
 
 			if ( empty( $categories_per_level[ $level ] ) ) {
-				unset ( $categories_per_level[ $level ] );
+				unset( $categories_per_level[ $level ] );
 			}
 		}
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -499,7 +499,8 @@ class Products {
 
 		// attempt to get from product or parent product metadata
 		if ( $product->is_type( 'variation' ) ) {
-			$google_product_category_id = get_post_meta( $product->get_parent_id(), self::GOOGLE_PRODUCT_CATEGORY_META_KEY, true );
+			$parent_product             = wc_get_product( $product->get_parent_id() );
+			$google_product_category_id = $parent_product instanceof \WC_Product ? $parent_product->get_meta( self::GOOGLE_PRODUCT_CATEGORY_META_KEY ) : null;
 		} else {
 			$google_product_category_id = $product->get_meta( self::GOOGLE_PRODUCT_CATEGORY_META_KEY );
 		}

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -341,7 +341,6 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		foreach ( $parent_product->get_children() as $child_product_id ) {
 
 			$product_variation = wc_get_product( $child_product_id );
-			codecept_debug($product_variation);
 			Products::update_google_product_category_id( $parent_product, '2' );
 
 			$this->assertEquals( '2', Products::get_google_product_category_id( $product_variation ) );

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -399,12 +399,35 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @see Products::get_google_product_category_id() */
+	public function test_get_google_product_category_id_product_variation_multiple_categories() {
+
+		$variable_product = $this->get_variable_product( [ 'children' => 2 ] );
+
+		$parent_category = wp_insert_term( 'Animals & Pet Supplies', 'product_cat' );
+		Product_Categories::update_google_product_category_id( $parent_category['term_id'], '8' );
+		$child_category = wp_insert_term( 'Pet Supplies', 'product_cat', [ 'parent' => $parent_category['term_id'] ] );
+		Product_Categories::update_google_product_category_id( $child_category['term_id'], '9' );
+
+		wp_set_post_terms( $variable_product->get_id(), [
+			$parent_category['term_id'],
+			$child_category['term_id'],
+		], 'product_cat' );
+
+		foreach ( $variable_product->get_children() as $child_product_id ) {
+
+			$product_variation = wc_get_product( $child_product_id );
+			$this->assertEquals( '9', Products::get_google_product_category_id( $product_variation ) );
+		}
+	}
+
+
+	/** @see Products::get_google_product_category_id() */
 	public function test_get_google_product_category_id_default() {
 
 		$product = $this->get_product();
-		facebook_for_woocommerce()->get_commerce_handler()->update_default_google_product_category_id( '7' );
+		facebook_for_woocommerce()->get_commerce_handler()->update_default_google_product_category_id( '10' );
 
-		$this->assertEquals( '7', Products::get_google_product_category_id( $product ) );
+		$this->assertEquals( '10', Products::get_google_product_category_id( $product ) );
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -336,13 +336,14 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Products::get_google_product_category_id() */
 	public function test_get_google_product_category_id_product_variation() {
 
-		$parent_product    = $this->get_variable_product();
+		$variable_product = $this->get_variable_product( [ 'children' => 2 ] );
+		Products::update_google_product_category_id( $variable_product, '2' );
+		$variable_product->save();
+		$variable_product = wc_get_product( $variable_product->get_id() );
 
-		foreach ( $parent_product->get_children() as $child_product_id ) {
+		foreach ( $variable_product->get_children() as $child_product_id ) {
 
 			$product_variation = wc_get_product( $child_product_id );
-			Products::update_google_product_category_id( $parent_product, '2' );
-
 			$this->assertEquals( '2', Products::get_google_product_category_id( $product_variation ) );
 		}
 	}


### PR DESCRIPTION
# Summary

This PR implements the `Products::get_google_product_category_id()` method.

### Story: [CH 62194](https://app.clubhouse.io/skyverge/story/62194/implement-the-products-get-google-product-category-id-method)
### Release: #1477 

## Details

Attempts to get the Google product category ID from the product or parent product (if the product is a variation) metadata. If not set, gets it from the highest level (the highest leaf level) product category. If not set or if there are multiple categories on the same level with conflicting Google product category IDs, falls back to the plugin-level option.

## QA

- [x] Integrations test pass 

**Note**: some tests are failing because some required code was not merged yet:
- `test_get_google_product_category_id_product_single_category` and `test_get_google_product_category_id_product_multiple_categories`: require code from #1480
- `test_get_google_product_category_id_default`: requires code from #1479 

We can wait for these to be merged to QA this one.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version