### PR TITLE
Implement the gender methods

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -639,8 +639,17 @@ class Products {
 	 */
 	public static function get_product_gender( \WC_Product $product ) {
 
-		// TODO: implement
-		return '';
+		if ( $product->is_type( 'variation' ) ) {
+			$gender = get_post_meta( $product->get_parent_id(), self::GENDER_META_KEY, true );
+		} else {
+			$gender = $product->get_meta( self::GENDER_META_KEY );
+		}
+
+		if ( ! in_array( $gender, [ 'female', 'male', 'unisex' ] ) ) {
+			$gender = 'unisex';
+		}
+
+		return $gender;
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -641,7 +641,7 @@ class Products {
 
 		if ( $product->is_type( 'variation' ) ) {
 			$parent_product = wc_get_product( $product->get_parent_id() );
-			$gender         = $parent_product->get_meta( self::GENDER_META_KEY );
+			$gender         = $parent_product instanceof \WC_Product ? $parent_product->get_meta( self::GENDER_META_KEY ) : null;
 		} else {
 			$gender = $product->get_meta( self::GENDER_META_KEY );
 		}

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -664,6 +664,7 @@ class Products {
 	public static function update_product_gender( \WC_Product $product, $gender ) {
 
 		$product->update_meta_data( Products::GENDER_META_KEY, $gender );
+		$product->save_meta_data();
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -663,7 +663,7 @@ class Products {
 	 */
 	public static function update_product_gender( \WC_Product $product, $gender ) {
 
-		// TODO: implement
+		$product->update_meta_data( Products::GENDER_META_KEY, $gender );
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -640,7 +640,8 @@ class Products {
 	public static function get_product_gender( \WC_Product $product ) {
 
 		if ( $product->is_type( 'variation' ) ) {
-			$gender = get_post_meta( $product->get_parent_id(), self::GENDER_META_KEY, true );
+			$parent_product = wc_get_product( $product->get_parent_id() );
+			$gender         = $parent_product->get_meta( self::GENDER_META_KEY );
 		} else {
 			$gender = $product->get_meta( self::GENDER_META_KEY );
 		}

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -609,6 +609,35 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * @see Products::update_product_gender()
+	 *
+	 * @param string $gender gender
+	 *
+	 * @dataProvider provider_update_product_gender
+	 */
+	public function test_update_product_gender( $gender ) {
+
+		$product = $this->get_product();
+
+		Products::update_product_gender( $product, $gender );
+
+		$this->assertEquals( $gender, $product->get_meta( Products::GENDER_META_KEY ) );
+	}
+
+
+	/** @see test_update_product_gender */
+	public function provider_update_product_gender() {
+
+		return [
+			[ 'female' ],
+			[ 'male' ],
+			[ 'unisex' ],
+			[ '' ],
+		];
+	}
+
+
 	/** @see Facebook\Products::get_available_product_attributes() */
 	public function test_get_available_product_attributes() {
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -622,6 +622,9 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 		Products::update_product_gender( $product, $gender );
 
+		// get a fresh product object
+		$product = wc_get_product( $product->get_id() );
+
 		$this->assertEquals( $gender, $product->get_meta( Products::GENDER_META_KEY ) );
 	}
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -574,6 +574,41 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * @see Products::get_product_gender
+	 *
+	 * @param string $meta_value meta value
+	 * @param string $expected_result expected result
+	 *
+	 * @dataProvider provider_get_product_gender
+	 */
+	public function test_get_product_gender( $meta_value, $expected_result ) {
+
+		$product = $this->get_product();
+		if ( null === $meta_value ) {
+			$product->delete_meta_data( Products::GENDER_META_KEY );
+		} else {
+			$product->update_meta_data( Products::GENDER_META_KEY, $meta_value );
+		}
+
+		$this->assertSame( $expected_result, Products::get_product_gender( $product ) );
+	}
+
+
+	/** @see test_get_product_gender */
+	public function provider_get_product_gender() {
+
+		return [
+			[ null, 'unisex' ],
+			[ 'female', 'female' ],
+			[ 'male', 'male' ],
+			[ 'unisex', 'unisex' ],
+			[ '', 'unisex' ],
+			[ 'invalid', 'unisex' ],
+		];
+	}
+
+
 	/** @see Facebook\Products::get_available_product_attributes() */
 	public function test_get_available_product_attributes() {
 


### PR DESCRIPTION
# Summary

This PR implements the `Products::get_product_gender()` and `Products:update_product_gender()` methods.

### Story: [CH 62182](https://app.clubhouse.io/skyverge/story/62182/implement-the-gender-methods)
### Release: #1477 

## Details

Validation is done on the getter. The setter allows you to save whatever value you want.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version