### PR TITLE
Implement the Products methods to get available/distinct product attributes

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -709,8 +709,11 @@ class Products {
 	 */
 	public static function get_distinct_product_attributes( \WC_Product $product ) {
 
-		// TODO: implement
-		return [];
+		return [
+			'color'   => self::get_product_color_attribute( $product ),
+			'size'    => self::get_product_size_attribute( $product ),
+			'pattern' => self::get_product_pattern_attribute( $product ),
+		];
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -710,9 +710,9 @@ class Products {
 	public static function get_distinct_product_attributes( \WC_Product $product ) {
 
 		return [
-			'color'   => self::get_product_color_attribute( $product ),
-			'size'    => self::get_product_size_attribute( $product ),
-			'pattern' => self::get_product_pattern_attribute( $product ),
+			self::get_product_color_attribute( $product ),
+			self::get_product_size_attribute( $product ),
+			self::get_product_pattern_attribute( $product ),
 		];
 	}
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -695,8 +695,7 @@ class Products {
 	 */
 	public static function get_available_product_attributes( \WC_Product $product ) {
 
-		// TODO: implement
-		return [];
+		return $product->get_attributes();
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -711,11 +711,11 @@ class Products {
 	 */
 	public static function get_distinct_product_attributes( \WC_Product $product ) {
 
-		return [
+		return array_filter( [
 			self::get_product_color_attribute( $product ),
 			self::get_product_size_attribute( $product ),
 			self::get_product_pattern_attribute( $product ),
-		];
+		] );
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -461,9 +461,9 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 			Products::get_product_size_attribute( $product ),
 			Products::get_product_pattern_attribute( $product ),
 		] ), Products::get_distinct_product_attributes( $product ) );
-  }
-  
-  
+	}
+
+
 	/**
 	 * @see \SkyVerge\WooCommerce\Facebook\Products::update_google_product_category_id()
 	 *

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -344,9 +344,9 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		Products::update_product_pattern_attribute( $product, $pattern_attribute->get_name() );
 
 		$this->assertSame( [
-			'color'   => Products::get_product_color_attribute( $product ),
-			'size'    => Products::get_product_size_attribute( $product ),
-			'pattern' => Products::get_product_pattern_attribute( $product ),
+			Products::get_product_color_attribute( $product ),
+			Products::get_product_size_attribute( $product ),
+			Products::get_product_pattern_attribute( $product ),
 		], Products::get_distinct_product_attributes( $product ) );
 	}
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -325,26 +325,29 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_available_product_attributes() */
 	public function test_get_available_product_attributes() {
 
-		$color_attribute = new WC_Product_Attribute();
-		$color_attribute->set_name( 'color' );
-		$color_attribute->set_options( [
-			'pink',
-			'blue',
-		] );
-		$color_attribute->set_variation( true );
-
-		$size_attribute = new WC_Product_Attribute();
-		$size_attribute->set_name( 'size' );
-		$size_attribute->set_options( [
-			'small',
-			'medium',
-			'large',
-		] );
-		$size_attribute->set_variation( false );
-
-		$product = $this->get_product( [ 'attributes' => [ $color_attribute, $size_attribute ] ] );
+		$product = $this->get_product( [ 'attributes' => self::create_product_attributes() ] );
 
 		$this->assertSame( $product->get_attributes(), Products::get_available_product_attributes( $product ) );
+	}
+
+
+	/** @see Facebook\Products::get_distinct_product_attributes() */
+	public function test_get_distinct_product_attributes() {
+
+		$attributes = self::create_product_attributes();
+		$product    = $this->get_product( [ 'attributes' => $attributes ] );
+
+		list( $color_attribute, $size_attribute, $pattern_attribute ) = $attributes;
+
+		Products::update_product_color_attribute( $product, $color_attribute->get_name() );
+		Products::update_product_size_attribute( $product, $size_attribute->get_name() );
+		Products::update_product_pattern_attribute( $product, $pattern_attribute->get_name() );
+
+		$this->assertSame( [
+			'color'   => Products::get_product_color_attribute( $product ),
+			'size'    => Products::get_product_size_attribute( $product ),
+			'pattern' => Products::get_product_pattern_attribute( $product ),
+		], Products::get_distinct_product_attributes( $product ) );
 	}
 
 
@@ -392,6 +395,41 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		$this->excluded_category = $category['term_id'];
 
 		update_option( \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS, [ $this->excluded_category ] );
+	}
+
+
+	/**
+	 * Creates product attributes.
+	 */
+	private function create_product_attributes() {
+
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_name( 'color' );
+		$color_attribute->set_options( [
+			'pink',
+			'blue',
+		] );
+		$color_attribute->set_variation( true );
+
+		$size_attribute = new WC_Product_Attribute();
+		$size_attribute->set_name( 'size' );
+		$size_attribute->set_options( [
+			'small',
+			'medium',
+			'large',
+		] );
+		$size_attribute->set_variation( false );
+
+		$pattern_attribute = new WC_Product_Attribute();
+		$pattern_attribute->set_name( 'pattern' );
+		$pattern_attribute->set_options( [
+			'checked',
+			'floral',
+			'leopard',
+		] );
+		$pattern_attribute->set_variation( true );
+
+		return [ $color_attribute, $size_attribute, $pattern_attribute ];
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -1,6 +1,7 @@
 <?php
 
 use SkyVerge\WooCommerce\Facebook;
+use SkyVerge\WooCommerce\Facebook\Products;
 
 /**
  * Tests the Products class.
@@ -318,6 +319,32 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		} );
 
 		$this->assertSame( 1234, Facebook\Products::get_product_price( $product ) );
+	}
+
+
+	/** @see Facebook\Products::get_available_product_attributes() */
+	public function test_get_available_product_attributes() {
+
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_name( 'color' );
+		$color_attribute->set_options( [
+			'pink',
+			'blue',
+		] );
+		$color_attribute->set_variation( true );
+
+		$size_attribute = new WC_Product_Attribute();
+		$size_attribute->set_name( 'size' );
+		$size_attribute->set_options( [
+			'small',
+			'medium',
+			'large',
+		] );
+		$size_attribute->set_variation( false );
+
+		$product = $this->get_product( [ 'attributes' => [ $color_attribute, $size_attribute ] ] );
+
+		$this->assertSame( $product->get_attributes(), Products::get_available_product_attributes( $product ) );
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -456,11 +456,11 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		Products::update_product_size_attribute( $product, $size_attribute->get_name() );
 		Products::update_product_pattern_attribute( $product, $pattern_attribute->get_name() );
 
-		$this->assertSame( [
+		$this->assertSame( array_filter( [
 			Products::get_product_color_attribute( $product ),
 			Products::get_product_size_attribute( $product ),
 			Products::get_product_pattern_attribute( $product ),
-		], Products::get_distinct_product_attributes( $product ) );
+		] ), Products::get_distinct_product_attributes( $product ) );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR implements the `Products::get_available_product_attributes()` and `Products::get_distinct_product_attributes()` methods.

### Story: [CH 62185](https://app.clubhouse.io/skyverge/story/62185/implement-the-products-methods-to-get-available-distinct-product-attributes)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version