### PR TITLE
Implement the color methods

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -764,8 +764,8 @@ class Products {
 	 */
 	public static function get_product_size_attribute( \WC_Product $product ) {
 
-		// TODO: implement
-		return '';
+		// TODO: implement the validations
+		return $product->get_meta( self::SIZE_ATTRIBUTE_META_KEY );
 	}
 
 
@@ -810,8 +810,8 @@ class Products {
 	 */
 	public static function get_product_pattern_attribute( \WC_Product $product ) {
 
-		// TODO: implement
-		return '';
+		// TODO: implement the validations
+		return $product->get_meta( self::PATTERN_ATTRIBUTE_META_KEY );
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -748,7 +748,7 @@ class Products {
 
 		if ( empty( $color_value ) && $product->is_type( 'variation' ) ) {
 			$parent_product = wc_get_product( $product->get_parent_id() );
-			$color_value    = self::get_product_color( $parent_product );
+			$color_value    = $parent_product instanceof \WC_Product ? self::get_product_color( $parent_product ) : '';
 		}
 
 		return $color_value;

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -749,8 +749,19 @@ class Products {
 	 */
 	public static function get_product_color( \WC_Product $product ) {
 
-		// TODO: implement
-		return '';
+		$color_value     = '';
+		$color_attribute = self::get_product_color_attribute( $product );
+
+		if ( ! empty( $color_attribute ) ) {
+			$color_value = $product->get_attribute( $color_attribute );
+		}
+
+		if ( empty( $color_value ) && $product->is_type( 'variation' ) ) {
+			$parent_product = wc_get_product( $product->get_parent_id() );
+			$color_value    = self::get_product_color( $parent_product );
+		}
+
+		return $color_value;
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -672,26 +672,28 @@ class Products {
 		if ( $product->is_type( 'variation' ) ) {
 
 			// get the attribute from the parent
-			$parent_product = wc_get_product( $product->get_parent_id() );
-
-			return self::get_product_color_attribute( $parent_product );
+			$product = wc_get_product( $product->get_parent_id() );
 		}
 
-		$meta_value     = $product->get_meta( self::COLOR_ATTRIBUTE_META_KEY );
 		$attribute_name = '';
 
-		// check if an attribute with that name exists
-		if ( self::product_has_attribute( $product, $meta_value ) ) {
-			$attribute_name = $meta_value;
-		}
+		if ( $product ) {
 
-		if ( empty( $attribute_name ) ) {
-			// try to find a matching attribute
-			foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+			$meta_value = $product->get_meta( self::COLOR_ATTRIBUTE_META_KEY );
 
-				if ( stripos( $attribute->get_name(), 'color' ) !== false || stripos( $attribute->get_name(), 'colour' ) !== false ) {
-					$attribute_name = $attribute->get_name();
-					break;
+			// check if an attribute with that name exists
+			if ( self::product_has_attribute( $product, $meta_value ) ) {
+				$attribute_name = $meta_value;
+			}
+
+			if ( empty( $attribute_name ) ) {
+				// try to find a matching attribute
+				foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+
+					if ( stripos( $attribute->get_name(), 'color' ) !== false || stripos( $attribute->get_name(), 'colour' ) !== false ) {
+						$attribute_name = $attribute->get_name();
+						break;
+					}
 				}
 			}
 		}

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -709,30 +709,30 @@ class Products {
 	 * @since 2.1.0-dev.1
 	 *
 	 * @param \WC_Product $product the product object
-	 * @param string $attribute the attributed to be used to store the color
+	 * @param string $attribute_name the attribute to be used to store the color
 	 * @throws \Exception
 	 */
-	public static function update_product_color_attribute( \WC_Product $product, $attribute ) {
+	public static function update_product_color_attribute( \WC_Product $product, $attribute_name ) {
 
 		// check if the name matches an available attribute
-		$attribute_name = '';
+		$matching_attribute_name = '';
 		foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
 
-			if ( $attribute === $attribute->get_name() ) {
-				$attribute_name = $attribute;
+			if ( $attribute_name === $attribute->get_name() ) {
+				$matching_attribute_name = $attribute;
 				break;
 			}
 		}
 
-		if ( empty( $attribute_name ) ) {
-			throw new \Exception( "The provided attribute name $attribute does not match any of the available attributes for the product {$product->get_name()}" );
+		if ( empty( $matching_attribute_name ) ) {
+			throw new \Exception( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
 
-		if ( $attribute !== self::get_product_color_attribute( $product ) && in_array( $attribute, self::get_distinct_product_attributes( $product ) ) ) {
-			throw new \Exception( "The provided attribute $attribute is already used for the product {$product->get_name()}" );
+		if ( $attribute_name !== self::get_product_color_attribute( $product ) && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
+			throw new \Exception( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
 		}
 
-		$product->update_meta_data( self::COLOR_ATTRIBUTE_META_KEY, $attribute );
+		$product->update_meta_data( self::COLOR_ATTRIBUTE_META_KEY, $attribute_name );
 		$product->save_meta_data();
 	}
 
@@ -775,9 +775,9 @@ class Products {
 	 * @since 2.1.0-dev.1
 	 *
 	 * @param \WC_Product $product the product object
-	 * @param string $attribute the attributed to be used to store the size
+	 * @param string $attribute_name the attribute to be used to store the size
 	 */
-	public static function update_product_size_attribute( \WC_Product $product, $attribute ) {
+	public static function update_product_size_attribute( \WC_Product $product, $attribute_name ) {
 
 		// TODO: implement
 	}
@@ -821,9 +821,9 @@ class Products {
 	 * @since 2.1.0-dev.1
 	 *
 	 * @param \WC_Product $product the product object
-	 * @param string $attribute the attributed to be used to store the pattern
+	 * @param string $attribute_name the attribute to be used to store the pattern
 	 */
-	public static function update_product_pattern_attribute( \WC_Product $product, $attribute ) {
+	public static function update_product_pattern_attribute( \WC_Product $product, $attribute_name ) {
 
 		// TODO: implement
 	}

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -867,7 +867,7 @@ class Products {
 	 * @param string $attribute_name the attribute name
 	 * @return bool
 	 */
-	public static function product_has_attribute( \WC_Product $product, string $attribute_name ) {
+	public static function product_has_attribute( \WC_Product $product, $attribute_name ) {
 
 		$found = false;
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -710,10 +710,30 @@ class Products {
 	 *
 	 * @param \WC_Product $product the product object
 	 * @param string $attribute the attributed to be used to store the color
+	 * @throws \Exception
 	 */
 	public static function update_product_color_attribute( \WC_Product $product, $attribute ) {
 
-		// TODO: implement
+		// check if the name matches an available attribute
+		$attribute_name = '';
+		foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+
+			if ( $attribute === $attribute->get_name() ) {
+				$attribute_name = $attribute;
+				break;
+			}
+		}
+
+		if ( empty( $attribute_name ) ) {
+			throw new \Exception( "The provided attribute name $attribute does not match any of the available attributes for the product {$product->get_name()}" );
+		}
+
+		if ( $attribute !== self::get_product_color_attribute( $product ) && in_array( $attribute, self::get_distinct_product_attributes( $product ) ) ) {
+			throw new \Exception( "The provided attribute $attribute is already used for the product {$product->get_name()}" );
+		}
+
+		$product->update_meta_data( self::COLOR_ATTRIBUTE_META_KEY, $attribute );
+		$product->save_meta_data();
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -10,6 +10,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Plugin_Exception;
 use WC_Facebook_Product;
 
 defined( 'ABSPATH' ) or exit;
@@ -706,17 +707,17 @@ class Products {
 	 *
 	 * @param \WC_Product $product the product object
 	 * @param string $attribute_name the attribute to be used to store the color
-	 * @throws \Exception
+	 * @throws SV_WC_Plugin_Exception
 	 */
 	public static function update_product_color_attribute( \WC_Product $product, $attribute_name ) {
 
 		// check if the name matches an available attribute
 		if ( ! self::product_has_attribute( $product, $attribute_name ) ) {
-			throw new \Exception( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
+			throw new SV_WC_Plugin_Exception( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
 
 		if ( $attribute_name !== self::get_product_color_attribute( $product ) && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
-			throw new \Exception( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
+			throw new SV_WC_Plugin_Exception( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
 		}
 
 		$product->update_meta_data( self::COLOR_ATTRIBUTE_META_KEY, $attribute_name );

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -680,12 +680,8 @@ class Products {
 		$attribute_name = '';
 
 		// check if an attribute with that name exists
-		foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
-
-			if ( $meta_value === $attribute->get_name() ) {
-				$attribute_name = $meta_value;
-				break;
-			}
+		if ( self::product_has_attribute( $product, $meta_value ) ) {
+			$attribute_name = $meta_value;
 		}
 
 		if ( empty( $attribute_name ) ) {
@@ -715,16 +711,7 @@ class Products {
 	public static function update_product_color_attribute( \WC_Product $product, $attribute_name ) {
 
 		// check if the name matches an available attribute
-		$matching_attribute_name = '';
-		foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
-
-			if ( $attribute_name === $attribute->get_name() ) {
-				$matching_attribute_name = $attribute;
-				break;
-			}
-		}
-
-		if ( empty( $matching_attribute_name ) ) {
+		if ( ! self::product_has_attribute( $product, $attribute_name ) ) {
 			throw new \Exception( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
 
@@ -868,6 +855,31 @@ class Products {
 	public static function get_available_product_attributes( \WC_Product $product ) {
 
 		return $product->get_attributes();
+	}
+
+
+	/**
+	 * Checks if the product has an attribute with the given name.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Product $product the product object
+	 * @param string $attribute_name the attribute name
+	 * @return bool
+	 */
+	public static function product_has_attribute( \WC_Product $product, string $attribute_name ) {
+
+		$found = false;
+
+		foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+
+			if ( $attribute_name === $attribute->get_name() ) {
+				$found = true;
+				break;
+			}
+		}
+
+		return $found;
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -668,8 +668,38 @@ class Products {
 	 */
 	public static function get_product_color_attribute( \WC_Product $product ) {
 
-		// TODO: implement
-		return '';
+		if ( $product->is_type( 'variation' ) ) {
+
+			// get the attribute from the parent
+			$parent_product = wc_get_product( $product->get_parent_id() );
+
+			return self::get_product_color_attribute( $parent_product );
+		}
+
+		$meta_value     = $product->get_meta( self::COLOR_ATTRIBUTE_META_KEY );
+		$attribute_name = '';
+
+		// check if an attribute with that name exists
+		foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+
+			if ( $meta_value === $attribute->get_name() ) {
+				$attribute_name = $meta_value;
+				break;
+			}
+		}
+
+		if ( empty( $attribute_name ) ) {
+			// try to find a matching attribute
+			foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+
+				if ( stripos( $attribute->get_name(), 'color' ) !== false || stripos( $attribute->get_name(), 'colour' ) !== false ) {
+					$attribute_name = $attribute->get_name();
+					break;
+				}
+			}
+		}
+
+		return $attribute_name;
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -577,17 +577,14 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color_attribute() */
 	public function test_get_product_color_attribute_configured_valid() {
 
-		$color_attribute = new WC_Product_Attribute();
-		$color_attribute->set_name( 'color' );
-		$color_attribute->set_options( [
-			'pink',
-			'blue',
-		] );
-		$color_attribute->set_variation( true );
+		$color_attribute = self::create_color_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
+		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
+		$product->save_meta_data();
 
-		Products::update_product_color_attribute( $product, $color_attribute->get_name() );
+		// get a fresh product object
+		$product = wc_get_product( $product->get_id() );
 
 		$this->assertSame( $color_attribute->get_name(), Products::get_product_color_attribute( $product ) );
 	}
@@ -596,18 +593,15 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color_attribute() */
 	public function test_get_product_color_attribute_configured_invalid() {
 
-		$color_attribute = new WC_Product_Attribute();
-		$color_attribute->set_name( 'color' );
-		$color_attribute->set_options( [
-			'pink',
-			'blue',
-		] );
-		$color_attribute->set_variation( true );
+		$color_attribute = self::create_color_attribute();
 
 		// create the product without attributes
 		$product = $this->get_product();
+		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
+		$product->save_meta_data();
 
-		Products::update_product_color_attribute( $product, $color_attribute->get_name() );
+		// get a fresh product object
+		$product = wc_get_product( $product->get_id() );
 
 		$this->assertSame( '', Products::get_product_color_attribute( $product ) );
 	}
@@ -616,13 +610,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color_attribute() */
 	public function test_get_product_color_attribute_string_matching() {
 
-		$color_attribute = new WC_Product_Attribute();
-		$color_attribute->set_name( 'product colour' );
-		$color_attribute->set_options( [
-			'pink',
-			'blue',
-		] );
-		$color_attribute->set_variation( true );
+		$color_attribute = self::create_color_attribute( 'product colour' );
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
 
@@ -633,18 +621,15 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color_attribute() */
 	public function test_get_product_color_attribute_variation() {
 
-		$color_attribute = new WC_Product_Attribute();
-		$color_attribute->set_name( 'color' );
-		$color_attribute->set_options( [
-			'pink',
-			'blue',
-		] );
-		$color_attribute->set_variation( true );
+		$color_attribute = self::create_color_attribute( 'color', [ 'pink', 'blue' ], true );
 
 		$product = $this->get_variable_product();
-		$product->set_variation_attributes( [ $color_attribute ] );
+		$product->set_attributes( [ $color_attribute ] );
+		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
+		$product->save();
 
-		Products::update_product_color_attribute( $product, $color_attribute->get_name() );
+		// get a fresh product object
+		$product = wc_get_product( $product->get_id() );
 
 		foreach ( $product->get_children() as $child_id ) {
 
@@ -657,13 +642,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_color_attribute() */
 	public function test_update_product_color_attribute_valid() {
 
-		$color_attribute = new WC_Product_Attribute();
-		$color_attribute->set_name( 'color' );
-		$color_attribute->set_options( [
-			'pink',
-			'blue',
-		] );
-		$color_attribute->set_variation( true );
+		$color_attribute = self::create_color_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
 
@@ -679,13 +658,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_color_attribute() */
 	public function test_update_product_color_attribute_invalid() {
 
-		$color_attribute = new WC_Product_Attribute();
-		$color_attribute->set_name( 'color' );
-		$color_attribute->set_options( [
-			'pink',
-			'blue',
-		] );
-		$color_attribute->set_variation( true );
+		$color_attribute = self::create_color_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
 
@@ -703,17 +676,11 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_color_attribute() */
 	public function test_update_product_color_attribute_already_used() {
 
-		$size_attribute = new WC_Product_Attribute();
-		$size_attribute->set_name( 'size' );
-		$size_attribute->set_options( [
-			'small',
-			'medium',
-			'large',
-		] );
-		$size_attribute->set_variation( true );
+		$color_attribute = self::create_color_attribute();
+		$size_attribute  = self::create_size_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $size_attribute ] ] );
-
+		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
 		$product->update_meta_data( Products::SIZE_ATTRIBUTE_META_KEY, $size_attribute->get_name() );
 		$product->save_meta_data();
 
@@ -728,6 +695,76 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		$product = wc_get_product( $product->get_id() );
 
 		$this->assertSame( '', $product->get_meta( Products::COLOR_ATTRIBUTE_META_KEY ) );
+	}
+
+
+	/** @see Facebook\Products::get_product_color() */
+	public function test_get_product_color_simple_product_single_value() {
+
+		$color_attribute = self::create_color_attribute( 'color', [ 'pink' ] );
+
+		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
+		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
+		$product->save();
+
+		// get a fresh product object
+        $product = wc_get_product( $product->get_id() );
+
+		$this->assertSame( 'pink', Products::get_product_color( $product ) );
+	}
+
+
+	/** @see Facebook\Products::get_product_color() */
+	public function test_get_product_color_variation_with_attribute_set() {
+
+		$color_attribute = self::create_color_attribute( 'color', [ 'pink', 'blue' ], true );
+
+		$product = $this->get_variable_product();
+		$product->set_attributes( [ $color_attribute ] );
+		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
+		$product->save();
+
+		// get a fresh product object
+		$product = wc_get_product( $product->get_id() );
+
+		foreach ( $product->get_children() as $child_id ) {
+
+			$product_variation = wc_get_product( $child_id );
+
+			/**
+			 * Unlike the parent product which uses terms, variations are assigned specific attributes using name value pairs.
+			 * @see WC_Product_Variation::set_attributes()
+			 */
+			$product_variation->set_attributes( [ 'color' => 'pink' ] );
+			$product_variation->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
+			$product_variation->save();
+
+			// get a fresh product object
+			$product_variation = wc_get_product( $child_id );
+
+			$this->assertSame( 'pink', Products::get_product_color( $product_variation ) );
+		}
+	}
+
+
+	/** @see Facebook\Products::get_product_color() */
+	public function test_get_product_color_variation_without_attribute_set() {
+
+		$color_attribute = self::create_color_attribute( true );
+
+		$product = $this->get_variable_product();
+		$product->set_attributes( [ $color_attribute ] );
+		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
+		$product->save();
+
+		// get a fresh product object
+		$product = wc_get_product( $product->get_id() );
+
+		foreach ( $product->get_children() as $child_id ) {
+
+			$product_variation = wc_get_product( $child_id );
+			$this->assertSame( 'pink | blue', Products::get_product_color( $product_variation ) );
+		}
 	}
 
 
@@ -808,37 +845,72 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
+	 * Creates color attribute.
+	 *
+	 * @param string $name attribute name
+	 * @param string[] $options possible values for the attribute
+	 * @param bool $variation used for variations or not
+	 * @return \WC_Product_Attribute
+	 */
+	private function create_color_attribute( $name = 'color', $options = [ 'pink', 'blue' ], $variation = false ) {
+
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_name( $name );
+		$color_attribute->set_options( $options );
+		$color_attribute->set_variation( $variation );
+
+		return $color_attribute;
+	}
+
+
+	/**
+	 * Creates size attribute.
+	 *
+	 * @param string $name attribute name
+	 * @param string[] $options possible values for the attribute
+	 * @param bool $variation used for variations or not
+	 * @return \WC_Product_Attribute
+	 */
+	private function create_size_attribute( $name = 'size', $options = [ 'small', 'medium', 'large' ], $variation = false ) {
+
+		$size_attribute = new WC_Product_Attribute();
+		$size_attribute->set_name( $name );
+		$size_attribute->set_options( $options );
+		$size_attribute->set_variation( $variation );
+
+		return $size_attribute;
+	}
+
+
+	/**
+	 * Creates pattern attribute.
+	 *
+	 * @param string $name attribute name
+	 * @param string[] $options possible values for the attribute
+	 * @param bool $variation used for variations or not
+	 * @return \WC_Product_Attribute
+	 */
+	private function create_pattern_attribute( $name = 'pattern', $options = [ 'checked', 'floral', 'leopard' ], $variation = false ) {
+
+		$pattern_attribute = new WC_Product_Attribute();
+		$pattern_attribute->set_name( $name );
+		$pattern_attribute->set_options( $options );
+		$pattern_attribute->set_variation( $variation );
+
+		return $pattern_attribute;
+	}
+
+
+	/**
 	 * Creates product attributes.
 	 */
 	private function create_product_attributes() {
 
-		$color_attribute = new WC_Product_Attribute();
-		$color_attribute->set_name( 'color' );
-		$color_attribute->set_options( [
-			'pink',
-			'blue',
-		] );
-		$color_attribute->set_variation( true );
-
-		$size_attribute = new WC_Product_Attribute();
-		$size_attribute->set_name( 'size' );
-		$size_attribute->set_options( [
-			'small',
-			'medium',
-			'large',
-		] );
-		$size_attribute->set_variation( false );
-
-		$pattern_attribute = new WC_Product_Attribute();
-		$pattern_attribute->set_name( 'pattern' );
-		$pattern_attribute->set_options( [
-			'checked',
-			'floral',
-			'leopard',
-		] );
-		$pattern_attribute->set_variation( true );
-
-		return [ $color_attribute, $size_attribute, $pattern_attribute ];
+		return [
+			self::create_color_attribute(),
+			self::create_size_attribute(),
+			self::create_pattern_attribute(),
+		];
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -3,6 +3,7 @@
 use SkyVerge\WooCommerce\Facebook;
 use SkyVerge\WooCommerce\Facebook\Product_Categories;
 use SkyVerge\WooCommerce\Facebook\Products;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Plugin_Exception;
 
 /**
  * Tests the Products class.
@@ -662,7 +663,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
 
-		$this->expectException( \Exception::class );
+		$this->expectException( SV_WC_Plugin_Exception::class );
 
 		Products::update_product_color_attribute( $product, 'colour' );
 
@@ -687,7 +688,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		// get a fresh product object
 		$product = wc_get_product( $product->get_id() );
 
-		$this->expectException( \Exception::class );
+		$this->expectException( SV_WC_Plugin_Exception::class );
 
 		Products::update_product_color_attribute( $product, $size_attribute->get_name() );
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -574,6 +574,86 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Facebook\Products::get_product_color_attribute() */
+	public function test_get_product_color_attribute_configured_valid() {
+
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_name( 'color' );
+		$color_attribute->set_options( [
+			'pink',
+			'blue',
+		] );
+		$color_attribute->set_variation( true );
+
+		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
+
+		Products::update_product_color_attribute( $product, $color_attribute->get_name() );
+
+		$this->assertSame( $color_attribute->get_name(), Products::get_product_color_attribute( $product ) );
+	}
+
+
+	/** @see Facebook\Products::get_product_color_attribute() */
+	public function test_get_product_color_attribute_configured_invalid() {
+
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_name( 'color' );
+		$color_attribute->set_options( [
+			'pink',
+			'blue',
+		] );
+		$color_attribute->set_variation( true );
+
+		// create the product without attributes
+		$product = $this->get_product();
+
+		Products::update_product_color_attribute( $product, $color_attribute->get_name() );
+
+		$this->assertSame( '', Products::get_product_color_attribute( $product ) );
+	}
+
+
+	/** @see Facebook\Products::get_product_color_attribute() */
+	public function test_get_product_color_attribute_string_matching() {
+
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_name( 'product colour' );
+		$color_attribute->set_options( [
+			'pink',
+			'blue',
+		] );
+		$color_attribute->set_variation( true );
+
+		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
+
+		$this->assertSame( $color_attribute->get_name(), Products::get_product_color_attribute( $product ) );
+	}
+
+
+	/** @see Facebook\Products::get_product_color_attribute() */
+	public function test_get_product_color_attribute_variation() {
+
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_name( 'color' );
+		$color_attribute->set_options( [
+			'pink',
+			'blue',
+		] );
+		$color_attribute->set_variation( true );
+
+		$product = $this->get_variable_product();
+		$product->set_variation_attributes( [ $color_attribute ] );
+
+		Products::update_product_color_attribute( $product, $color_attribute->get_name() );
+
+		foreach ( $product->get_children() as $child_id ) {
+
+			$product_variation = wc_get_product( $child_id );
+			$this->assertSame( $color_attribute->get_name(), Products::get_product_color_attribute( $product_variation ) );
+		}
+	}
+
+
 	/** @see Facebook\Products::get_available_product_attributes() */
 	public function test_get_available_product_attributes() {
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -750,7 +750,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color() */
 	public function test_get_product_color_variation_without_attribute_set() {
 
-		$color_attribute = self::create_color_attribute( true );
+		$color_attribute = self::create_color_attribute( 'color', [ 'pink', 'blue' ], true );
 
 		$product = $this->get_variable_product();
 		$product->set_attributes( [ $color_attribute ] );

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -654,6 +654,83 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Facebook\Products::update_product_color_attribute() */
+	public function test_update_product_color_attribute_valid() {
+
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_name( 'color' );
+		$color_attribute->set_options( [
+			'pink',
+			'blue',
+		] );
+		$color_attribute->set_variation( true );
+
+		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
+
+		Products::update_product_color_attribute( $product, $color_attribute->get_name() );
+
+		// get a fresh product object to ensure the meta is stored
+		$product = wc_get_product( $product->get_id() );
+
+		$this->assertSame( $color_attribute->get_name(), $product->get_meta( Products::COLOR_ATTRIBUTE_META_KEY ) );
+	}
+
+
+	/** @see Facebook\Products::update_product_color_attribute() */
+	public function test_update_product_color_attribute_invalid() {
+
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_name( 'color' );
+		$color_attribute->set_options( [
+			'pink',
+			'blue',
+		] );
+		$color_attribute->set_variation( true );
+
+		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
+
+		$this->expectException( \Exception::class );
+
+		Products::update_product_color_attribute( $product, 'colour' );
+
+		// get a fresh product object
+		$product = wc_get_product( $product->get_id() );
+
+		$this->assertSame( '', $product->get_meta( Products::COLOR_ATTRIBUTE_META_KEY ) );
+	}
+
+
+	/** @see Facebook\Products::update_product_color_attribute() */
+	public function test_update_product_color_attribute_already_used() {
+
+		$size_attribute = new WC_Product_Attribute();
+		$size_attribute->set_name( 'size' );
+		$size_attribute->set_options( [
+			'small',
+			'medium',
+			'large',
+		] );
+		$size_attribute->set_variation( true );
+
+		$product = $this->get_product( [ 'attributes' => [ $size_attribute ] ] );
+
+		$product->update_meta_data( Products::SIZE_ATTRIBUTE_META_KEY, $size_attribute->get_name() );
+		$product->save_meta_data();
+
+		// get a fresh product object
+		$product = wc_get_product( $product->get_id() );
+
+		$this->expectException( \Exception::class );
+
+		Products::update_product_color_attribute( $product, $size_attribute->get_name() );
+
+		// get a fresh product object
+		$product = wc_get_product( $product->get_id() );
+
+		$this->assertSame( '', $product->get_meta( Products::COLOR_ATTRIBUTE_META_KEY ) );
+	}
+
+
 	/** @see Facebook\Products::get_available_product_attributes() */
 	public function test_get_available_product_attributes() {
 


### PR DESCRIPTION
# Summary

This PR implements the `Products::get_product_color_attribute()`, `Products::update_product_color_attribute()` and `Products::get_product_color()` methods.

### Story: [CH 62188](https://app.clubhouse.io/skyverge/story/62188/implement-the-color-methods)
### Release: #1477 

## Details

The expected return for the `Products::get_product_color()` may be a bit confusing, there is some additional info on [this thread](https://skyverge.slack.com/archives/CR8VDB4G7/p1598306800027700). I'd like to get Chase's eyes on this PR, just to make sure I understood it correctly.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version