### PR TITLE
Implement the size methods

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -803,17 +803,17 @@ class Products {
 	 *
 	 * @param \WC_Product $product the product object
 	 * @param string $attribute_name the attribute to be used to store the size
-	 * @throws \Exception
+	 * @throws SV_WC_Plugin_Exception
 	 */
 	public static function update_product_size_attribute( \WC_Product $product, $attribute_name ) {
 
 		// check if the name matches an available attribute
 		if ( ! self::product_has_attribute( $product, $attribute_name ) ) {
-			throw new \Exception( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
+			throw new SV_WC_Plugin_Exception( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
 
 		if ( $attribute_name !== self::get_product_size_attribute( $product ) && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
-			throw new \Exception( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
+			throw new SV_WC_Plugin_Exception( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
 		}
 
 		$product->update_meta_data( self::SIZE_ATTRIBUTE_META_KEY, $attribute_name );

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -833,8 +833,19 @@ class Products {
 	 */
 	public static function get_product_size( \WC_Product $product ) {
 
-		// TODO: implement
-		return '';
+		$size_value     = '';
+		$size_attribute = self::get_product_size_attribute( $product );
+
+		if ( ! empty( $size_attribute ) ) {
+			$size_value = $product->get_attribute( $size_attribute );
+		}
+
+		if ( empty( $size_value ) && $product->is_type( 'variation' ) ) {
+			$parent_product = wc_get_product( $product->get_parent_id() );
+			$size_value     = self::get_product_size( $parent_product );
+		}
+
+		return $size_value;
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -803,10 +803,21 @@ class Products {
 	 *
 	 * @param \WC_Product $product the product object
 	 * @param string $attribute_name the attribute to be used to store the size
+	 * @throws \Exception
 	 */
 	public static function update_product_size_attribute( \WC_Product $product, $attribute_name ) {
 
-		// TODO: implement
+		// check if the name matches an available attribute
+		if ( ! self::product_has_attribute( $product, $attribute_name ) ) {
+			throw new \Exception( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
+		}
+
+		if ( $attribute_name !== self::get_product_size_attribute( $product ) && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
+			throw new \Exception( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
+		}
+
+		$product->update_meta_data( self::SIZE_ATTRIBUTE_META_KEY, $attribute_name );
+		$product->save_meta_data();
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -844,7 +844,7 @@ class Products {
 
 		if ( empty( $size_value ) && $product->is_type( 'variation' ) ) {
 			$parent_product = wc_get_product( $product->get_parent_id() );
-			$size_value     = self::get_product_size( $parent_product );
+			$size_value     = $parent_product instanceof \WC_Product ? self::get_product_size( $parent_product ) : '';
 		}
 
 		return $size_value;

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -768,26 +768,28 @@ class Products {
 		if ( $product->is_type( 'variation' ) ) {
 
 			// get the attribute from the parent
-			$parent_product = wc_get_product( $product->get_parent_id() );
-
-			return self::get_product_size_attribute( $parent_product );
+			$product = wc_get_product( $product->get_parent_id() );
 		}
 
-		$meta_value     = $product->get_meta( self::SIZE_ATTRIBUTE_META_KEY );
 		$attribute_name = '';
 
-		// check if an attribute with that name exists
-		if ( self::product_has_attribute( $product, $meta_value ) ) {
-			$attribute_name = $meta_value;
-		}
+		if ( $product ) {
 
-		if ( empty( $attribute_name ) ) {
-			// try to find a matching attribute
-			foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+			$meta_value = $product->get_meta( self::SIZE_ATTRIBUTE_META_KEY );
 
-				if ( stripos( $attribute->get_name(), 'size' ) !== false ) {
-					$attribute_name = $attribute->get_name();
-					break;
+			// check if an attribute with that name exists
+			if ( self::product_has_attribute( $product, $meta_value ) ) {
+				$attribute_name = $meta_value;
+			}
+
+			if ( empty( $attribute_name ) ) {
+				// try to find a matching attribute
+				foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+
+					if ( stripos( $attribute->get_name(), 'size' ) !== false ) {
+						$attribute_name = $attribute->get_name();
+						break;
+					}
 				}
 			}
 		}

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -765,8 +765,34 @@ class Products {
 	 */
 	public static function get_product_size_attribute( \WC_Product $product ) {
 
-		// TODO: implement the validations
-		return $product->get_meta( self::SIZE_ATTRIBUTE_META_KEY );
+		if ( $product->is_type( 'variation' ) ) {
+
+			// get the attribute from the parent
+			$parent_product = wc_get_product( $product->get_parent_id() );
+
+			return self::get_product_size_attribute( $parent_product );
+		}
+
+		$meta_value     = $product->get_meta( self::SIZE_ATTRIBUTE_META_KEY );
+		$attribute_name = '';
+
+		// check if an attribute with that name exists
+		if ( self::product_has_attribute( $product, $meta_value ) ) {
+			$attribute_name = $meta_value;
+		}
+
+		if ( empty( $attribute_name ) ) {
+			// try to find a matching attribute
+			foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+
+				if ( stripos( $attribute->get_name(), 'size' ) !== false ) {
+					$attribute_name = $attribute->get_name();
+					break;
+				}
+			}
+		}
+
+		return $attribute_name;
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -857,7 +857,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 		$product = $this->get_product( [ 'attributes' => [ $size_attribute ] ] );
 
-		$this->expectException( \Exception::class );
+		$this->expectException( SV_WC_Plugin_Exception::class );
 
 		Products::update_product_size_attribute( $product, 'height' );
 
@@ -882,7 +882,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		// get a fresh product object
 		$product = wc_get_product( $product->get_id() );
 
-		$this->expectException( \Exception::class );
+		$this->expectException( SV_WC_Plugin_Exception::class );
 
 		Products::update_product_size_attribute( $product, $color_attribute->get_name() );
 


### PR DESCRIPTION
# Summary

This PR implements the `Products::get_product_size_attribute()`, `Products::update_product_size_attribute()` and `Products::get_product_size()` methods.

### Story: [CH 62196](https://app.clubhouse.io/skyverge/story/62196/implement-the-size-methods)
### Release: #1477 

## Details

The expected return for the `Products::get_product_size()` may be a bit confusing, similarly to `Products::get_product_color()`. There is some additional info on [this thread](https://skyverge.slack.com/archives/CR8VDB4G7/p1598306800027700). 

Any changes required on #1488 are probably needed on this PR as well.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version