### PR TITLE
Implement the pattern methods

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -940,7 +940,7 @@ class Products {
 
 		if ( empty( $pattern_value ) && $product->is_type( 'variation' ) ) {
 			$parent_product = wc_get_product( $product->get_parent_id() );
-			$pattern_value  = self::get_product_pattern( $parent_product );
+			$pattern_value  = $parent_product instanceof \WC_Product ? self::get_product_pattern( $parent_product ) : '';
 		}
 
 		return $pattern_value;

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -861,8 +861,34 @@ class Products {
 	 */
 	public static function get_product_pattern_attribute( \WC_Product $product ) {
 
-		// TODO: implement the validations
-		return $product->get_meta( self::PATTERN_ATTRIBUTE_META_KEY );
+		if ( $product->is_type( 'variation' ) ) {
+
+			// get the attribute from the parent
+			$parent_product = wc_get_product( $product->get_parent_id() );
+
+			return self::get_product_pattern_attribute( $parent_product );
+		}
+
+		$meta_value     = $product->get_meta( self::PATTERN_ATTRIBUTE_META_KEY );
+		$attribute_name = '';
+
+		// check if an attribute with that name exists
+		if ( self::product_has_attribute( $product, $meta_value ) ) {
+			$attribute_name = $meta_value;
+		}
+
+		if ( empty( $attribute_name ) ) {
+			// try to find a matching attribute
+			foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+
+				if ( stripos( $attribute->get_name(), 'pattern' ) !== false ) {
+					$attribute_name = $attribute->get_name();
+					break;
+				}
+			}
+		}
+
+		return $attribute_name;
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -864,26 +864,28 @@ class Products {
 		if ( $product->is_type( 'variation' ) ) {
 
 			// get the attribute from the parent
-			$parent_product = wc_get_product( $product->get_parent_id() );
-
-			return self::get_product_pattern_attribute( $parent_product );
+			$product = wc_get_product( $product->get_parent_id() );
 		}
 
-		$meta_value     = $product->get_meta( self::PATTERN_ATTRIBUTE_META_KEY );
 		$attribute_name = '';
 
-		// check if an attribute with that name exists
-		if ( self::product_has_attribute( $product, $meta_value ) ) {
-			$attribute_name = $meta_value;
-		}
+		if ( $product ) {
 
-		if ( empty( $attribute_name ) ) {
-			// try to find a matching attribute
-			foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+			$meta_value = $product->get_meta( self::PATTERN_ATTRIBUTE_META_KEY );
 
-				if ( stripos( $attribute->get_name(), 'pattern' ) !== false ) {
-					$attribute_name = $attribute->get_name();
-					break;
+			// check if an attribute with that name exists
+			if ( self::product_has_attribute( $product, $meta_value ) ) {
+				$attribute_name = $meta_value;
+			}
+
+			if ( empty( $attribute_name ) ) {
+				// try to find a matching attribute
+				foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+
+					if ( stripos( $attribute->get_name(), 'pattern' ) !== false ) {
+						$attribute_name = $attribute->get_name();
+						break;
+					}
 				}
 			}
 		}

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -899,17 +899,17 @@ class Products {
 	 *
 	 * @param \WC_Product $product the product object
 	 * @param string $attribute_name the attribute to be used to store the pattern
-	 * @throws \Exception
+	 * @throws SV_WC_Plugin_Exception
 	 */
 	public static function update_product_pattern_attribute( \WC_Product $product, $attribute_name ) {
 
 		// check if the name matches an available attribute
 		if ( ! self::product_has_attribute( $product, $attribute_name ) ) {
-			throw new \Exception( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
+			throw new SV_WC_Plugin_Exception( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
 
 		if ( $attribute_name !== self::get_product_pattern_attribute( $product ) && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
-			throw new \Exception( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
+			throw new SV_WC_Plugin_Exception( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
 		}
 
 		$product->update_meta_data( self::PATTERN_ATTRIBUTE_META_KEY, $attribute_name );

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -929,8 +929,19 @@ class Products {
 	 */
 	public static function get_product_pattern( \WC_Product $product ) {
 
-		// TODO: implement
-		return '';
+		$pattern_value     = '';
+		$pattern_attribute = self::get_product_pattern_attribute( $product );
+
+		if ( ! empty( $pattern_attribute ) ) {
+			$pattern_value = $product->get_attribute( $pattern_attribute );
+		}
+
+		if ( empty( $pattern_value ) && $product->is_type( 'variation' ) ) {
+			$parent_product = wc_get_product( $product->get_parent_id() );
+			$pattern_value  = self::get_product_pattern( $parent_product );
+		}
+
+		return $pattern_value;
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -899,10 +899,21 @@ class Products {
 	 *
 	 * @param \WC_Product $product the product object
 	 * @param string $attribute_name the attribute to be used to store the pattern
+	 * @throws \Exception
 	 */
 	public static function update_product_pattern_attribute( \WC_Product $product, $attribute_name ) {
 
-		// TODO: implement
+		// check if the name matches an available attribute
+		if ( ! self::product_has_attribute( $product, $attribute_name ) ) {
+			throw new \Exception( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
+		}
+
+		if ( $attribute_name !== self::get_product_pattern_attribute( $product ) && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
+			throw new \Exception( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
+		}
+
+		$product->update_meta_data( self::PATTERN_ATTRIBUTE_META_KEY, $attribute_name );
+		$product->save_meta_data();
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -1046,7 +1046,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 		$product = $this->get_product( [ 'attributes' => [ $pattern_attribute ] ] );
 
-		$this->expectException( \Exception::class );
+		$this->expectException( SV_WC_Plugin_Exception::class );
 
 		Products::update_product_pattern_attribute( $product, 'print' );
 
@@ -1071,7 +1071,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		// get a fresh product object
 		$product = wc_get_product( $product->get_id() );
 
-		$this->expectException( \Exception::class );
+		$this->expectException( SV_WC_Plugin_Exception::class );
 
 		Products::update_product_pattern_attribute( $product, $color_attribute->get_name() );
 	}


### PR DESCRIPTION
# Summary

This PR implements the `Products::get_product_pattern_attribute()`, `Products::update_product_pattern_attribute()` and `Products::get_product_pattern()` methods.

### Story: [CH 62201](https://app.clubhouse.io/skyverge/story/62201/implement-the-pattern-methods)
### Release: #1477 

## Details

The expected return for the `Products::get_product_pattern()` may be a bit confusing, similarly to `Products::get_product_color()` and `Products::get_product_size()`. There is some additional info on [this thread](https://skyverge.slack.com/archives/CR8VDB4G7/p1598306800027700). 

Any changes required on #1488 are probably needed on this PR as well.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version