### PR TITLE
Add commerce data to the prepared product data

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -534,6 +534,11 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 			);
 
+			// add the Commerce values
+			if ( Products::is_product_ready_for_commerce( $this->woo_product ) ) {
+				$product_data['gender']    = Products::get_product_gender( $this->woo_product );
+			}
+
 			// Only use checkout URLs if they exist.
 			if ( $checkout_url ) {
 				  $product_data['checkout_url'] = $checkout_url;

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -536,8 +536,13 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 
 			// add the Commerce values
 			if ( Products::is_product_ready_for_commerce( $this->woo_product ) ) {
+
 				$product_data['gender']    = Products::get_product_gender( $this->woo_product );
 				$product_data['inventory'] = (string) $this->woo_product->get_stock_quantity();
+
+				if ( $google_product_category = Products::get_google_product_category_id( $this->woo_product ) ) {
+					$product_data['google_product_category'] = $google_product_category;
+				}
 			}
 
 			// Only use checkout URLs if they exist.

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -538,7 +538,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			if ( Products::is_product_ready_for_commerce( $this->woo_product ) ) {
 
 				$product_data['gender']    = Products::get_product_gender( $this->woo_product );
-				$product_data['inventory'] = (string) $this->woo_product->get_stock_quantity();
+				$product_data['inventory'] = $this->woo_product->get_stock_quantity();
 
 				if ( $google_product_category = Products::get_google_product_category_id( $this->woo_product ) ) {
 					$product_data['google_product_category'] = $google_product_category;

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -537,6 +537,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			// add the Commerce values
 			if ( Products::is_product_ready_for_commerce( $this->woo_product ) ) {
 				$product_data['gender']    = Products::get_product_gender( $this->woo_product );
+				$product_data['inventory'] = (string) $this->woo_product->get_stock_quantity();
 			}
 
 			// Only use checkout URLs if they exist.

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -538,7 +538,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			if ( Products::is_product_ready_for_commerce( $this->woo_product ) ) {
 
 				$product_data['gender']    = Products::get_product_gender( $this->woo_product );
-				$product_data['inventory'] = $this->woo_product->get_stock_quantity();
+				$product_data['inventory'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
 
 				if ( $google_product_category = Products::get_google_product_category_id( $this->woo_product ) ) {
 					$product_data['google_product_category'] = $google_product_category;

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -105,7 +105,7 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 
 		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
 
-		$this->assertSame( '100', $data['inventory'] );
+		$this->assertSame( 100, $data['inventory'] );
 	}
 
 

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -45,6 +45,38 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_not_ready_for_commerce_inventory() {
+
+		$product = $this->tester->get_product();
+
+		Products::enable_sync_for_products( [ $product ] );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertArrayNotHasKey( 'inventory', $data );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_ready_for_commerce_inventory() {
+
+		$product = $this->tester->get_product( [
+			'status'         => 'publish',
+			'regular_price'  => '1.00',
+			'manage_stock'   => true,
+			'stock_quantity' => 100,
+		] );
+
+		Products::enable_sync_for_products( [ $product ] );
+		Products::update_commerce_enabled_for_product( $product, true );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertSame( '100', $data['inventory'] );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
 	public function test_prepare_product_ready_for_commerce_gender() {
 
 		$product = $this->tester->get_product( [

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -31,6 +31,39 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
+	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_not_ready_for_commerce_gender() {
+
+		$product = $this->tester->get_product();
+
+		Products::enable_sync_for_products( [ $product ] );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertArrayNotHasKey( 'gender', $data );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_ready_for_commerce_gender() {
+
+		$product = $this->tester->get_product( [
+			'status'         => 'publish',
+			'regular_price'  => '1.00',
+			'manage_stock'   => true,
+			'stock_quantity' => 100,
+		] );
+
+		Products::enable_sync_for_products( [ $product ] );
+		Products::update_commerce_enabled_for_product( $product, true );
+		Products::update_product_gender( $product, 'female' );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertSame( 'female', $data['gender'] );
+	}
+
+
 	/**
 	 * @see \WC_Facebook_Product::prepare_product()
 	 *

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -58,6 +58,39 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_not_ready_for_commerce_google_product_category() {
+
+		$product = $this->tester->get_product();
+
+		Products::enable_sync_for_products( [ $product ] );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertArrayNotHasKey( 'google_product_category', $data );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_ready_for_commerce_google_product_category() {
+
+		$product = $this->tester->get_product( [
+			'status'         => 'publish',
+			'regular_price'  => '1.00',
+			'manage_stock'   => true,
+			'stock_quantity' => 100,
+		] );
+
+		Products::enable_sync_for_products( [ $product ] );
+		Products::update_commerce_enabled_for_product( $product, true );
+		Products::update_google_product_category_id( $product, '1234' );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertSame( '1234', $data['google_product_category'] );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
 	public function test_prepare_product_ready_for_commerce_inventory() {
 
 		$product = $this->tester->get_product( [

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -90,14 +90,21 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see \WC_Facebook_Product::prepare_product() */
-	public function test_prepare_product_ready_for_commerce_inventory() {
+	/**
+	 * @see \WC_Facebook_Product::prepare_product()
+	 *
+	 * @dataProvider provider_prepare_product_ready_for_commerce_inventory
+	 *
+	 * @param int|string $woo_quantity WooCommerce stock quantity
+	 * @param int $facebook_expected expected Facebook inventory value
+	 */
+	public function test_prepare_product_ready_for_commerce_inventory( $woo_quantity, $facebook_expected ) {
 
 		$product = $this->tester->get_product( [
 			'status'         => 'publish',
 			'regular_price'  => '1.00',
 			'manage_stock'   => true,
-			'stock_quantity' => 100,
+			'stock_quantity' => $woo_quantity,
 		] );
 
 		Products::enable_sync_for_products( [ $product ] );
@@ -105,7 +112,18 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 
 		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
 
-		$this->assertSame( 100, $data['inventory'] );
+		$this->assertSame( $facebook_expected, $data['inventory'] );
+	}
+
+
+	/** @see test_prepare_product_ready_for_commerce_inventory */
+	public function provider_prepare_product_ready_for_commerce_inventory() {
+
+		return [
+			'valid stock quantity'    => [ 4, 4 ],
+			'negative stock quantity' => [ -4, 0 ],
+			'invalid stock quantity'  => [ 'asdf', 0 ],
+		];
 	}
 
 


### PR DESCRIPTION
# Summary

Adds gender, inventory, and google product category values for commerce-enabled products

### Story: [CH 62213](https://app.clubhouse.io/skyverge/story/62213)
### Release: #1477 

## Details

Implements `gender` here instead of `prepare_variants_for_item()` because it's a base product value and doesn't have the potential to change per-variation.

Ensures the `inventory` value is never negative - I've confirmed that the API rejects requests with negative inventory.

## UI Changes

_N/A_

## QA

- [x] `integration WC_Facebook_Product_Test` tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version