### PR TITLE
Create the general Commerce orders handler

### DIFF
--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -29,6 +29,18 @@ class Commerce {
 
 
 	/**
+	 * Commerce handler constructor.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function __construct() {
+
+		require_once __DIR__ . '/includes/Commerce/Orders.php';
+
+		$this->orders = new \SkyVerge\WooCommerce\Facebook\Commerce\Orders();
+	}
+
+	/**
 	 * Gets the plugin-level fallback Google product category ID.
 	 *
 	 * This will be used when the category or product-level settings don’t override it.

--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -35,7 +35,7 @@ class Commerce {
 	 */
 	public function __construct() {
 
-		require_once __DIR__ . '/includes/Commerce/Orders.php';
+		require_once __DIR__ . '/Commerce/Orders.php';
 
 		$this->orders = new \SkyVerge\WooCommerce\Facebook\Commerce\Orders();
 	}

--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -37,7 +37,7 @@ class Commerce {
 
 		require_once __DIR__ . '/Commerce/Orders.php';
 
-		$this->orders = new \SkyVerge\WooCommerce\Facebook\Commerce\Orders();
+		$this->orders = new Commerce\Orders();
 	}
 
 

--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -40,6 +40,7 @@ class Commerce {
 		$this->orders = new \SkyVerge\WooCommerce\Facebook\Commerce\Orders();
 	}
 
+
 	/**
 	 * Gets the plugin-level fallback Google product category ID.
 	 *
@@ -130,11 +131,10 @@ class Commerce {
 	 *
 	 * @since 2.1.0-dev.1
 	 *
-	 * @return Commerce\Orders the orders handler instance
+	 * @return \SkyVerge\WooCommerce\Facebook\Commerce\Orders
 	 */
 	public function get_orders_handler() {
 
-		// TODO: implement
 		return $this->orders;
 	}
 

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -10,6 +10,8 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Commerce;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Plugin_Exception;
+
 defined( 'ABSPATH' ) or exit;
 
 /**
@@ -25,6 +27,145 @@ class Orders {
 
 	/** @var string the meta key used to store the remote order ID */
 	const REMOTE_ID_META_KEY = '_wc_facebook_commerce_remote_id';
+
+
+	/**
+	 * Finds a local order based on the Commerce ID stored in REMOTE_ID_META_KEY.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id Commerce order ID
+	 * @return \WC_Order|null
+	 */
+	public function find_local_order( $remote_id ) {
+
+		// TODO: implement
+		return null;
+	}
+
+
+	/**
+	 * Creates a local WooCommerce order based on an Orders API order object.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param API\Orders\Order $remote_order Orders API order object
+	 * @return \WC_Order
+	 * @throws SV_WC_Plugin_Exception
+	 */
+	public function create_local_order( $remote_order ) {
+
+		// TODO: implement
+		return null;
+	}
+
+
+	/**
+	 * Updates a local WooCommerce order based on an Orders API order object.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param API\Orders\Order $remote_order Orders API order object
+	 * @param \WC_Order $local_order local order object
+	 * @return \WC_Order
+	 */
+	public function update_local_order( $remote_order, $local_order ) {
+
+		// TODO: implement
+		return $local_order;
+	}
+
+
+	/**
+	 * Updates WooCommerce’s Orders by fetching orders from the API and either creating or updating local orders.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function update_local_orders() {
+
+		// TODO: implement
+	}
+
+
+	/**
+	 * Frequency in seconds that orders are updated.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return int
+	 */
+	public function get_order_update_interval() {
+
+		// TODO: implement
+		return 5 * MINUTE_IN_SECONDS;
+	}
+
+
+	/**
+	 * Schedules a recurring ACTION_FETCH_ORDERS action, if not already scheduled.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function schedule_local_orders_update() {
+
+		// TODO: implement
+	}
+
+
+	/**
+	 * Adds the necessary action & filter hooks.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function add_hooks() {
+
+		// TODO: implement
+	}
+
+
+	/**
+	 * Fulfills an order via API.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Order $order order object
+	 * @param string $tracking_number shipping tracking number
+	 * @param string $carrier shipping carrier
+	 * @throws SV_WC_Plugin_Exception
+	 */
+	public function fulfill_order( $order, $tracking_number, $carrier ) {
+
+		// TODO: implement
+	}
+
+
+	/**
+	 * Refunds an order.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Order $refund order refund object
+	 * @param mixed $args
+	 * @throws SV_WC_Plugin_Exception
+	 */
+	public function add_order_refund( $refund, $args ) {
+
+		// TODO: implement
+	}
+
+
+	/**
+	 * Cancels an order.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Order $order order object
+	 * @throws SV_WC_Plugin_Exception
+	 */
+	public function cancel_order( $order ) {
+
+		// TODO: implement
+	}
 
 
 }

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -20,4 +20,11 @@ defined( 'ABSPATH' ) or exit;
 class Orders {
 
 
+	/** @var string the fetch orders action */
+	const ACTION_FETCH_ORDERS = 'wc_facebook_commerce_fetch_orders';
+
+	/** @var string the meta key used to store the remote order ID */
+	const REMOTE_ID_META_KEY = '_wc_facebook_commerce_remote_id';
+
+
 }

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Commerce;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * General Commerce orders handler.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Orders {
+
+
+}

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -10,6 +10,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Commerce;
 
+use SkyVerge\WooCommerce\Facebook\API\Orders\Order;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Plugin_Exception;
 
 defined( 'ABSPATH' ) or exit;
@@ -49,11 +50,11 @@ class Orders {
 	 *
 	 * @since 2.1.0-dev.1
 	 *
-	 * @param API\Orders\Order $remote_order Orders API order object
+	 * @param Order $remote_order Orders API order object
 	 * @return \WC_Order
 	 * @throws SV_WC_Plugin_Exception
 	 */
-	public function create_local_order( $remote_order ) {
+	public function create_local_order( Order $remote_order ) {
 
 		// TODO: implement
 		return null;
@@ -65,11 +66,11 @@ class Orders {
 	 *
 	 * @since 2.1.0-dev.1
 	 *
-	 * @param API\Orders\Order $remote_order Orders API order object
+	 * @param Order $remote_order Orders API order object
 	 * @param \WC_Order $local_order local order object
 	 * @return \WC_Order
 	 */
-	public function update_local_order( $remote_order, $local_order ) {
+	public function update_local_order( Order $remote_order, \WC_Order $local_order ) {
 
 		// TODO: implement
 		return $local_order;
@@ -133,7 +134,7 @@ class Orders {
 	 * @param string $carrier shipping carrier
 	 * @throws SV_WC_Plugin_Exception
 	 */
-	public function fulfill_order( $order, $tracking_number, $carrier ) {
+	public function fulfill_order( \WC_Order $order, $tracking_number, $carrier ) {
 
 		// TODO: implement
 	}
@@ -162,7 +163,7 @@ class Orders {
 	 * @param \WC_Order $order order object
 	 * @throws SV_WC_Plugin_Exception
 	 */
-	public function cancel_order( $order ) {
+	public function cancel_order( \WC_Order $order ) {
 
 		// TODO: implement
 	}

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -145,11 +145,11 @@ class Orders {
 	 *
 	 * @since 2.1.0-dev.1
 	 *
-	 * @param \WC_Order $refund order refund object
+	 * @param \WC_Order_Refund $refund order refund object
 	 * @param mixed $args
 	 * @throws SV_WC_Plugin_Exception
 	 */
-	public function add_order_refund( $refund, $args ) {
+	public function add_order_refund( \WC_Order_Refund $refund, $args ) {
 
 		// TODO: implement
 	}

--- a/tests/integration/CommerceTest.php
+++ b/tests/integration/CommerceTest.php
@@ -160,6 +160,13 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Commerce::get_orders_handler() */
+	public function test_get_orders_handler() {
+
+		$this->assertInstanceOf( Commerce\Orders::class, $this->get_commerce_handler()->get_orders_handler() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 


### PR DESCRIPTION
# Summary

This PR adds the `Commerce\Orders` class, initializes it on the `Commerce` handler, and implements the `Commerce::get_orders_handler()` method.

### Story: [CH 62156](https://app.clubhouse.io/skyverge/story/62156/create-the-general-commerce-orders-handler)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version