### PR TITLE
Create the API\Orders\Order class

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -463,6 +463,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Exceptions/Request_Limit_Reached.php';
 				}
 
+				if ( ! class_exists( API\Orders\Order::class ) ) {
+					require_once __DIR__ . '/includes/API/Orders/Order.php';
+				}
+
 				$this->api = new SkyVerge\WooCommerce\Facebook\API( $this->get_connection_handler()->get_access_token() );
 			}
 

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -100,6 +100,7 @@ class Order {
 	 */
 	public function get_channel() {
 
+		return ! empty( $this->data['channel'] ) ? $this->data['channel'] : '';
 	}
 
 

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -87,6 +87,7 @@ class Order {
 	 */
 	public function get_items() {
 
+		return isset( $this->data['items'] ) ? $this->data['items'] : [];
 	}
 
 

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -115,6 +115,7 @@ class Order {
 	 */
 	public function get_selected_shipping_option() {
 
+		return isset( $this->data['selected_shipping_option'] ) ? $this->data['selected_shipping_option'] : [];
 	}
 
 

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Orders;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * Orders API order handler.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Order {
+
+}

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -33,4 +33,8 @@ class Order {
 	const STATUS_COMPLETED = 'COMPLETED';
 
 
+	/** @var array order data */
+	protected $data;
+
+
 }

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -37,4 +37,122 @@ class Order {
 	protected $data;
 
 
+	/**
+	 * Orders API order handler constructor.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param array $response_data response data from the API
+	 */
+	public function __construct( $response_data ) {
+
+	}
+
+
+	/**
+	 * Gets the order’s ID.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+
+	}
+
+
+	/**
+	 * Gets the order’s status.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_status() {
+
+	}
+
+
+	/**
+	 * Gets the items' data.
+	 *
+	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/order-api#item
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_items() {
+
+	}
+
+
+	/**
+	 * Gets the channel name.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_channel() {
+
+	}
+
+
+	/**
+	 * Gets the shipping details.
+	 *
+	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/order-api#selected_shipping_option
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_selected_shipping_option() {
+
+	}
+
+
+	/**
+	 * Gets the shipping address.
+	 *
+	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/order-api#shipping_address
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_shipping_address() {
+
+	}
+
+
+	/**
+	 * Gets the payment details.
+	 *
+	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/order-api#estimated_payment_details
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_estimated_payment_details() {
+
+	}
+
+
+	/**
+	 * Gets the buyer details.
+	 *
+	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/order-api#buyer_details
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_buyer_details() {
+
+	}
+
+
 }

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -145,6 +145,7 @@ class Order {
 	 */
 	public function get_estimated_payment_details() {
 
+		return isset( $this->data['estimated_payment_details'] ) ? $this->data['estimated_payment_details'] : [];
 	}
 
 

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -19,4 +19,18 @@ defined( 'ABSPATH' ) or exit;
  */
 class Order {
 
+
+	/** @var string API state meaning Facebook is still processing the order and no action is possible */
+	const STATUS_PROCESSING = 'FB_PROCESSING';
+
+	/** @var string API state meaning Facebook has processed the orders and the seller needs to acknowledge it */
+	const STATUS_CREATED = 'CREATED';
+
+	/** @var string API state meaning the order was acknowledged and is now being processed in WC */
+	const STATUS_IN_PROGRESS = 'IN_PROGRESS';
+
+	/** @var string API state meaning all items in the order are shipped and/or cancelled */
+	const STATUS_COMPLETED = 'COMPLETED';
+
+
 }

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -46,6 +46,7 @@ class Order {
 	 */
 	public function __construct( $response_data ) {
 
+		$this->data = $response_data;
 	}
 
 

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -160,6 +160,7 @@ class Order {
 	 */
 	public function get_buyer_details() {
 
+		return isset( $this->data['buyer_details'] ) ? $this->data['buyer_details'] : [];
 	}
 
 

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -130,6 +130,7 @@ class Order {
 	 */
 	public function get_shipping_address() {
 
+		return isset( $this->data['shipping_address'] ) ? $this->data['shipping_address'] : [];
 	}
 
 

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -72,6 +72,7 @@ class Order {
 	 */
 	public function get_status() {
 
+		return ! empty( $this->data['order_status'] ) && ! empty( $this->data['order_status']['state'] ) ? $this->data['order_status']['state'] : '';
 	}
 
 

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -59,6 +59,7 @@ class Order {
 	 */
 	public function get_id() {
 
+		return ! empty( $this->data['id'] ) ? $this->data['id'] : '';
 	}
 
 

--- a/tests/integration/API/Orders/OrderTest.php
+++ b/tests/integration/API/Orders/OrderTest.php
@@ -94,6 +94,21 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Order::get_shipping_address() */
+	public function test_get_shipping_address() {
+
+		$test_response_data = $this->get_test_response_data();
+		$order_handler      = new Order( $test_response_data );
+
+		$this->assertEquals( $test_response_data['shipping_address'], $order_handler->get_shipping_address() );
+
+		unset( $test_response_data['shipping_address'] );
+		$order_handler = new Order( $test_response_data );
+
+		$this->assertEquals( [], $order_handler->get_shipping_address() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/API/Orders/OrderTest.php
+++ b/tests/integration/API/Orders/OrderTest.php
@@ -64,6 +64,21 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Order::get_channel() */
+	public function test_get_channel() {
+
+		$test_response_data = $this->get_test_response_data();
+		$order_handler      = new Order( $test_response_data );
+
+		$this->assertEquals( $test_response_data['channel'], $order_handler->get_channel() );
+
+		unset( $test_response_data['channel'] );
+		$order_handler = new Order( $test_response_data );
+
+		$this->assertEquals( '', $order_handler->get_channel() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 
@@ -110,7 +125,7 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 			],
 			'ship_by_date'              => '2019-01-16',
 			'merchant_order_id'         => '46192',
-			'channel'                   => 'instagram',
+			'channel'                   => 'Instagram',
 			'selected_shipping_option'  => [
 				'name'                    => 'Standard',
 				'price'                   => [

--- a/tests/integration/API/Orders/OrderTest.php
+++ b/tests/integration/API/Orders/OrderTest.php
@@ -124,6 +124,21 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Order::get_buyer_details() */
+	public function test_get_buyer_details() {
+
+		$test_response_data = $this->get_test_response_data();
+		$order_handler      = new Order( $test_response_data );
+
+		$this->assertEquals( $test_response_data['buyer_details'], $order_handler->get_buyer_details() );
+
+		unset( $test_response_data['buyer_details'] );
+		$order_handler = new Order( $test_response_data );
+
+		$this->assertEquals( [], $order_handler->get_buyer_details() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/API/Orders/OrderTest.php
+++ b/tests/integration/API/Orders/OrderTest.php
@@ -49,6 +49,21 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Order::get_items() */
+	public function test_get_items() {
+
+		$test_response_data = $this->get_test_response_data();
+		$order_handler      = new Order( $test_response_data );
+
+		$this->assertEquals( $test_response_data['items'], $order_handler->get_items() );
+
+		unset( $test_response_data['items'] );
+		$order_handler = new Order( $test_response_data );
+
+		$this->assertEquals( [], $order_handler->get_items() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/API/Orders/OrderTest.php
+++ b/tests/integration/API/Orders/OrderTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Order;
+
+/**
+ * Tests the API\Orders\Order class.
+ */
+class OrderTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Order::get_id() */
+	public function test_get_id() {
+
+		$test_response_data = $this->get_test_response_data();
+		$order_handler      = new Order( $test_response_data );
+
+		$this->assertEquals( $test_response_data['id'], $order_handler->get_id() );
+	}
+
+
+	/** Helper methods **************************************************************************************************/
+
+
+	/**
+	 * Gets the response test data.
+	 *
+	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/order-api#get_orders
+	 *
+	 * @param string $order_status order status
+	 * @return array
+	 */
+	private function get_test_response_data( $order_status = Order::STATUS_CREATED ) {
+
+		return [
+			'id'                        => '335211597203390',
+			'order_status'              => [
+				'state' => $order_status,
+			],
+			'created'                   => '2019-01-14T19:17:31+00:00',
+			'last_updated'              => '2019-01-14T19:47:35+00:00',
+			'items'                     => [
+				0 => [
+					'id'             => '2082596341811586',
+					'product_id'     => '1213131231',
+					'retailer_id'    => 'external_product_1234',
+					'quantity'       => 2,
+					'price_per_unit' => [
+						'amount'   => '20.00',
+						'currency' => 'USD',
+					],
+					'tax_details'    => [
+						'estimated_tax' => [
+							'amount'   => '0.30',
+							'currency' => 'USD',
+						],
+						'captured_tax'  => [
+							'total_tax' => [
+								'amount'   => '0.30',
+								'currency' => 'USD',
+							],
+						],
+					],
+				],
+			],
+			'ship_by_date'              => '2019-01-16',
+			'merchant_order_id'         => '46192',
+			'channel'                   => 'instagram',
+			'selected_shipping_option'  => [
+				'name'                    => 'Standard',
+				'price'                   => [
+					'amount'   => '10.00',
+					'currency' => 'USD',
+				],
+				'calculated_tax'          => [
+					'amount'   => '0.15',
+					'currency' => 'USD',
+				],
+				'estimated_shipping_time' => [
+					'min_days' => 3,
+					'max_days' => 15,
+				],
+			],
+			'shipping_address'          => [
+				'name'        => 'ABC company',
+				'street1'     => '123 Main St',
+				'street2'     => 'Unit 200',
+				'city'        => 'Boston',
+				'state'       => 'MA',
+				'postal_code' => '02110',
+				'country'     => 'US',
+			],
+			'estimated_payment_details' => [
+				'subtotal'     => [
+					'items'    => [
+						'amount'   => '20.00',
+						'currency' => 'USD',
+					],
+					'shipping' => [
+						'amount'   => '10.00',
+						'currency' => 'USD',
+					],
+				],
+				'tax'          => [
+					'amount'   => '0.45',
+					'currency' => 'USD',
+				],
+				'total_amount' => [
+					'amount'   => '20.45',
+					'currency' => 'USD',
+				],
+				'tax_remitted' => true,
+			],
+			'buyer_details'             => [
+				'name'                     => 'John Doe',
+				'email'                    => 'johndoe@example.com',
+				'email_remarketing_option' => false,
+			],
+		];
+	}
+
+
+}

--- a/tests/integration/API/Orders/OrderTest.php
+++ b/tests/integration/API/Orders/OrderTest.php
@@ -79,6 +79,21 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Order::get_selected_shipping_option() */
+	public function test_get_selected_shipping_option() {
+
+		$test_response_data = $this->get_test_response_data();
+		$order_handler      = new Order( $test_response_data );
+
+		$this->assertEquals( $test_response_data['selected_shipping_option'], $order_handler->get_selected_shipping_option() );
+
+		unset( $test_response_data['selected_shipping_option'] );
+		$order_handler = new Order( $test_response_data );
+
+		$this->assertEquals( [], $order_handler->get_selected_shipping_option() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/API/Orders/OrderTest.php
+++ b/tests/integration/API/Orders/OrderTest.php
@@ -109,6 +109,21 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Order::get_estimated_payment_details() */
+	public function test_get_estimated_payment_details() {
+
+		$test_response_data = $this->get_test_response_data();
+		$order_handler      = new Order( $test_response_data );
+
+		$this->assertEquals( $test_response_data['estimated_payment_details'], $order_handler->get_estimated_payment_details() );
+
+		unset( $test_response_data['estimated_payment_details'] );
+		$order_handler = new Order( $test_response_data );
+
+		$this->assertEquals( [], $order_handler->get_estimated_payment_details() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/API/Orders/OrderTest.php
+++ b/tests/integration/API/Orders/OrderTest.php
@@ -39,6 +39,16 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Order::get_status() */
+	public function test_get_status() {
+
+		$test_response_data = $this->get_test_response_data();
+		$order_handler      = new Order( $test_response_data );
+
+		$this->assertEquals( $test_response_data['order_status']['state'], $order_handler->get_status() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 


### PR DESCRIPTION
# Summary

This PR adds the `API\Orders\Order` class with its methods.

### Story: [CH 62170](https://app.clubhouse.io/skyverge/story/62170/create-the-api-orders-order-class)
### Release: #1477 

## Open questions

- [x] For consistency with the existing API classes, shouldn't we call this class `API\Orders\Order\Response`?

## QA

- [ ] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version