### PR TITLE
Create the List Orders request object

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -467,6 +467,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Orders/Order.php';
 				}
 
+				if ( ! class_exists( API\Orders\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Orders/Request.php';
+				}
+
 				$this->api = new SkyVerge\WooCommerce\Facebook\API( $this->get_connection_handler()->get_access_token() );
 			}
 

--- a/includes/API/Orders/List/Request.php
+++ b/includes/API/Orders/List/Request.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Orders\List;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Orders API list request object.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Request extends API\Request  {
+
+
+	/**
+	 * API request constructor.
+	 *
+	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/order-api#get_orders
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $page_id page ID
+	 * @param array $args optional additional arguments
+	 */
+	public function __construct( $page_id, $args = [] ) {
+
+		parent::__construct( "/{$page_id}/commerce_orders", 'GET' );
+
+		$params = [];
+
+		if ( isset( $args['updated_before'] ) ) {
+
+			$params['updated_before'] = $args['updated_before'];
+		}
+
+		if ( isset( $args['updated_after'] ) ) {
+
+			$params['updated_after'] = $args['updated_after'];
+		}
+
+		if ( isset( $args['state'] ) ) {
+
+			$params['state'] = is_array( $args['state'] ) ? implode( ',', $args['state'] ) : $args['state'];
+		}
+
+		if ( isset( $args['filters'] ) ) {
+
+			$params['filters'] = is_array( $args['filters'] ) ? implode( ',', $args['filters'] ) : $args['filters'];
+		}
+
+		if ( ! empty( $args['fields'] ) ) {
+
+			$params['fields'] = is_array( $args['fields'] ) ? implode( ',', $args['fields'] ) : $args['fields'];
+
+		} else {
+
+			// request all top-level fields
+			$params['fields'] = implode( ',', [
+				'id',
+				'order_status',
+				'created',
+				'last_updated',
+				'items',
+				'ship_by_date',
+				'merchant_order_id',
+				'channel',
+				'selected_shipping_option',
+				'shipping_address',
+				'estimated_payment_details',
+				'buyer_details',
+			] );
+		}
+
+		$this->set_params( $params );
+	}
+
+
+}

--- a/includes/API/Orders/Request.php
+++ b/includes/API/Orders/Request.php
@@ -8,7 +8,7 @@
  * @package FacebookCommerce
  */
 
-namespace SkyVerge\WooCommerce\Facebook\API\Orders\List;
+namespace SkyVerge\WooCommerce\Facebook\API\Orders;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/tests/integration/API/Orders/RequestTest.php
+++ b/tests/integration/API/Orders/RequestTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Request;
+
+/**
+ * Tests the API\Orders\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see Request::__construct()
+	 *
+	 * @param array $args constructor args
+	 * @param array $expected_params expected request params
+	 *
+	 * @dataProvider provider_constructor
+	 */
+	public function test_constructor( $args, $expected_params ) {
+
+		$request = new Request( '1234', $args );
+
+		$this->assertEquals( '/1234/commerce_orders', $request->get_path() );
+		$this->assertEquals( 'GET', $request->get_method() );
+		$this->assertEquals( $expected_params, $request->get_params() );
+	}
+
+
+	/** @see test_constructor */
+	public function provider_constructor() {
+
+		$all_fields = [
+			'id',
+			'order_status',
+			'created',
+			'last_updated',
+			'items',
+			'ship_by_date',
+			'merchant_order_id',
+			'channel',
+			'selected_shipping_option',
+			'shipping_address',
+			'estimated_payment_details',
+			'buyer_details',
+		];
+
+		return [
+
+			[[], [ 'fields' => implode( ',', $all_fields ) ]],
+			[[ 'updated_before' => '1565728779' ], [ 'updated_before' => '1565728779', 'fields' => implode( ',', $all_fields ) ]],
+			[[ 'updated_after' => '1565728779' ], [ 'updated_after' => '1565728779', 'fields' => implode( ',', $all_fields ) ]],
+			[[ 'state' => 'CREATED' ], [ 'state' => 'CREATED', 'fields' => implode( ',', $all_fields ) ]],
+			[[ 'state' => [ 'CREATED', 'IN_PROGRESS' ] ], [ 'state' => 'CREATED,IN_PROGRESS', 'fields' => implode( ',', $all_fields ) ]],
+			[[ 'state' => 'CREATED,IN_PROGRESS' ], [ 'state' => 'CREATED,IN_PROGRESS', 'fields' => implode( ',', $all_fields ) ]],
+			[[ 'filters' => 'no_shipments' ], [ 'filters' => 'no_shipments', 'fields' => implode( ',', $all_fields ) ]],
+			[[ 'filters' => [ 'no_shipments', 'has_cancellations' ] ], [ 'filters' => 'no_shipments,has_cancellations', 'fields' => implode( ',', $all_fields ) ]],
+			[[ 'filters' => 'no_shipments,has_cancellations' ], [ 'filters' => 'no_shipments,has_cancellations', 'fields' => implode( ',', $all_fields ) ]],
+			[[ 'fields' => [ 'id' ] ], [ 'fields' => 'id' ]],
+			[[ 'fields' => [ 'id', 'order_status' ] ], [ 'fields' => 'id,order_status' ]],
+			[[ 'fields' => 'id,order_status' ], [ 'fields' => 'id,order_status' ]],
+		];
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `API\Orders\Request` class.

### Story: [CH 62191](https://app.clubhouse.io/skyverge/story/62191/create-the-list-orders-request-object)
### Release: #1477 

## Details

As discussed on [Slack](https://skyverge.slack.com/archives/CR8VDB4G7/p1598465101045400), I had to tweak the class namespace because `List` is a reserved word.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version