### PR TITLE
Create the Read Order request object

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -467,6 +467,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Orders/Order.php';
 				}
 
+				if ( ! class_exists( API\Orders\Read\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Orders/Read/Request.php';
+				}
+
 				$this->api = new SkyVerge\WooCommerce\Facebook\API( $this->get_connection_handler()->get_access_token() );
 			}
 

--- a/includes/API/Orders/Read/Request.php
+++ b/includes/API/Orders/Read/Request.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Orders\Read;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Orders API read request object.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Request extends API\Request  {
+
+
+	/**
+	 * API request constructor.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id remote order ID
+	 * @param array $fields fields to be returned
+	 */
+	public function __construct( $remote_id, $fields = [] ) {
+
+		parent::__construct( "/{$remote_id}", 'GET' );
+
+		if ( ! empty( $fields ) ) {
+
+			$params['fields'] = is_array( $fields ) ? implode( ',', $fields ) : $fields;
+
+		} else {
+
+			// request all top-level fields
+			$params['fields'] = implode( ',', [
+				'id',
+				'order_status',
+				'created',
+				'last_updated',
+				'items',
+				'ship_by_date',
+				'merchant_order_id',
+				'channel',
+				'selected_shipping_option',
+				'shipping_address',
+				'estimated_payment_details',
+				'buyer_details',
+			] );
+		}
+	}
+
+
+}

--- a/includes/API/Orders/Read/Request.php
+++ b/includes/API/Orders/Read/Request.php
@@ -34,14 +34,10 @@ class Request extends API\Request  {
 
 		parent::__construct( "/{$remote_id}", 'GET' );
 
-		if ( ! empty( $fields ) ) {
-
-			$params['fields'] = is_array( $fields ) ? implode( ',', $fields ) : $fields;
-
-		} else {
+		if ( empty( $fields ) ) {
 
 			// request all top-level fields
-			$params['fields'] = implode( ',', [
+			$fields = implode( ',', [
 				'id',
 				'order_status',
 				'created',
@@ -55,7 +51,13 @@ class Request extends API\Request  {
 				'estimated_payment_details',
 				'buyer_details',
 			] );
+
+		} elseif ( is_array( $fields ) ) {
+
+			$fields = implode( ',', $fields );
 		}
+
+		$this->set_params( [ 'fields' => $fields ] );
 	}
 
 

--- a/tests/integration/API/Orders/Read/RequestTest.php
+++ b/tests/integration/API/Orders/Read/RequestTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders\Read;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Read\Request;
+
+/**
+ * Tests the API\Orders\Read\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/**
+	 * @see Request::__construct()
+	 *
+	 * @param array $fields constructor fields arg
+	 * @param array $expected_params expected request params
+	 *
+	 * @dataProvider provider_constructor
+	 */
+	public function test_constructor( $fields, $expected_params ) {
+
+		$request = new Request( '368508827392800', $fields );
+
+		$this->assertEquals( '/368508827392800', $request->get_path() );
+		$this->assertEquals( 'GET', $request->get_method() );
+		$this->assertEquals( $expected_params, $request->get_params() );
+	}
+
+
+	/** @see test_constructor */
+	public function provider_constructor() {
+
+		$all_fields = [
+			'id',
+			'order_status',
+			'created',
+			'last_updated',
+			'items',
+			'ship_by_date',
+			'merchant_order_id',
+			'channel',
+			'selected_shipping_option',
+			'shipping_address',
+			'estimated_payment_details',
+			'buyer_details',
+		];
+
+		return [
+
+			[[], [ 'fields' => implode( ',', $all_fields ) ]],
+			[[ 'id', 'order_status' ], [ 'fields' => 'id,order_status' ]],
+			[[ 'id,order_status' ], [ 'fields' => 'id,order_status' ]],
+		];
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `API\Orders\Read\Request` class.

### Story: [CH 62210](https://app.clubhouse.io/skyverge/story/62210/create-the-read-order-request-object)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version