### PR TITLE
Add the configured attribute values to prepared product data

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -467,7 +467,11 @@ class Products {
 	 */
 	public static function is_commerce_enabled_for_product( \WC_Product $product )  {
 
-		return wc_string_to_bool( $product->get_meta( Products::COMMERCE_ENABLED_META_KEY ) );
+		if ( $product->is_type( 'variation' ) ) {
+			$product = wc_get_product( $product->get_parent_id() );
+		}
+
+		return $product instanceof \WC_Product && wc_string_to_bool( $product->get_meta( self::COMMERCE_ENABLED_META_KEY ) );
 	}
 
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -622,6 +622,11 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			// For each product field type, pull the single variant
 			foreach ( $variant_names as $original_variant_name ) {
 
+				// don't handle any attributes that are designated as Commerce attributes
+				if ( in_array( str_replace( array( 'attribute_' ), '', strtolower( $original_variant_name ) ), Products::get_distinct_product_attributes( $this->woo_product ), true ) ) {
+					continue;
+				}
+
 				// Retrieve label name for attribute
 				$label = wc_attribute_label( $original_variant_name, $product );
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -540,6 +540,11 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				$product_data['gender']    = Products::get_product_gender( $this->woo_product );
 				$product_data['inventory'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
 
+				// add the known attribute values
+				$product_data[ \WC_Facebookcommerce_Utils::FB_VARIANT_COLOR ]   = Products::get_product_color( $this->woo_product );
+				$product_data[ \WC_Facebookcommerce_Utils::FB_VARIANT_SIZE ]    = Products::get_product_size( $this->woo_product );
+				$product_data[ \WC_Facebookcommerce_Utils::FB_VARIANT_PATTERN ] = Products::get_product_pattern( $this->woo_product );
+
 				if ( $google_product_category = Products::get_google_product_category_id( $this->woo_product ) ) {
 					$product_data['google_product_category'] = $google_product_category;
 				}
@@ -655,20 +660,6 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 					}
 
 					switch ( $new_name ) {
-
-						case \WC_Facebookcommerce_Utils::FB_VARIANT_SIZE:
-						case \WC_Facebookcommerce_Utils::FB_VARIANT_COLOR:
-						case \WC_Facebookcommerce_Utils::FB_VARIANT_PATTERN:
-
-							$variant_data[] = [
-								'product_field' => $new_name,
-								'label'         => $label,
-								'options'       => $option_values,
-							];
-
-							$product_data[ $new_name ] = $option_values[0];
-
-						break;
 
 						case \WC_Facebookcommerce_Utils::FB_VARIANT_GENDER:
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -653,7 +653,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 						}
 					}
 
-					if ( \WC_Facebookcommerce_Utils::FB_VARIANT_GENDER === $new_name ) {
+					if ( \WC_Facebookcommerce_Utils::FB_VARIANT_GENDER === $new_name && ! isset( $product_data[ \WC_Facebookcommerce_Utils::FB_VARIANT_GENDER ] ) ) {
 
 						// If we can't validate the gender, this will be null.
 						$product_data[ $new_name ] = \WC_Facebookcommerce_Utils::validateGender( $option_values[0] );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -623,7 +623,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			foreach ( $variant_names as $original_variant_name ) {
 
 				// don't handle any attributes that are designated as Commerce attributes
-				if ( in_array( str_replace( array( 'attribute_' ), '', strtolower( $original_variant_name ) ), Products::get_distinct_product_attributes( $this->woo_product ), true ) ) {
+				if ( in_array( str_replace( 'attribute_', '', strtolower( $original_variant_name ) ), Products::get_distinct_product_attributes( $this->woo_product ), true ) ) {
 					continue;
 				}
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -634,7 +634,7 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 			return 'id,title,description,image_link,link,product_type,' .
 			'brand,price,availability,item_group_id,checkout_url,' .
 			'additional_image_link,sale_price_effective_date,sale_price,condition,' .
-			'visibility,default_product,variant' . PHP_EOL;
+			'visibility,gender,color,size,pattern,google_product_category,default_product,variant' . PHP_EOL;
 		}
 
 
@@ -739,6 +739,8 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 				$product_data['default_product'] = '';
 			}
 
+			$google_product_category = isset( $product_data['google_product_category'] ) ? $product_data['google_product_category'] : '';
+
 			return $product_data['retailer_id'] . ',' .
 			static::format_string_for_feed( $product_data['name'] ) . ',' .
 			static::format_string_for_feed( $product_data['description'] ) . ',' .
@@ -764,6 +766,11 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 			) . ',' .
 			'new' . ',' .
 			$product_data['visibility'] . ',' .
+			$product_data['gender'] . ',' .
+			$product_data['color'] . ',' .
+			$product_data['size'] . ',' .
+			$product_data['pattern'] . ',' .
+			$google_product_category . ',' .
 			$product_data['default_product'] . ',' .
 			$product_data['variant'] . PHP_EOL;
 		}

--- a/tests/_support/IntegrationTester.php
+++ b/tests/_support/IntegrationTester.php
@@ -128,6 +128,76 @@ class IntegrationTester extends \Codeception\Actor {
 	}
 
 
+	/**
+	 * Creates color attribute.
+	 *
+	 * @param string $name attribute name
+	 * @param string[] $options possible values for the attribute
+	 * @param bool $variation used for variations or not
+	 * @return \WC_Product_Attribute
+	 */
+	public function create_color_attribute( $name = 'color', $options = [ 'pink', 'blue' ], $variation = false ) {
+
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_name( $name );
+		$color_attribute->set_options( $options );
+		$color_attribute->set_variation( $variation );
+
+		return $color_attribute;
+	}
+
+
+	/**
+	 * Creates size attribute.
+	 *
+	 * @param string $name attribute name
+	 * @param string[] $options possible values for the attribute
+	 * @param bool $variation used for variations or not
+	 * @return \WC_Product_Attribute
+	 */
+	public function create_size_attribute( $name = 'size', $options = [ 'small', 'medium', 'large' ], $variation = false ) {
+
+		$size_attribute = new WC_Product_Attribute();
+		$size_attribute->set_name( $name );
+		$size_attribute->set_options( $options );
+		$size_attribute->set_variation( $variation );
+
+		return $size_attribute;
+	}
+
+
+	/**
+	 * Creates pattern attribute.
+	 *
+	 * @param string $name attribute name
+	 * @param string[] $options possible values for the attribute
+	 * @param bool $variation used for variations or not
+	 * @return \WC_Product_Attribute
+	 */
+	public function create_pattern_attribute( $name = 'pattern', $options = [ 'checked', 'floral', 'leopard' ], $variation = false ) {
+
+		$pattern_attribute = new WC_Product_Attribute();
+		$pattern_attribute->set_name( $name );
+		$pattern_attribute->set_options( $options );
+		$pattern_attribute->set_variation( $variation );
+
+		return $pattern_attribute;
+	}
+
+
+	/**
+	 * Creates product attributes.
+	 */
+	public function create_product_attributes() {
+
+		return [
+			$this->create_color_attribute(),
+			$this->create_size_attribute(),
+			$this->create_pattern_attribute(),
+		];
+	}
+
+
 	/** Sync methods **************************************************************************************************/
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -645,7 +645,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color_attribute() */
 	public function test_get_product_color_attribute_configured_valid() {
 
-		$color_attribute = self::create_color_attribute();
+		$color_attribute = $this->tester->create_color_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
 		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
@@ -661,7 +661,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color_attribute() */
 	public function test_get_product_color_attribute_configured_invalid() {
 
-		$color_attribute = self::create_color_attribute();
+		$color_attribute = $this->tester->create_color_attribute();
 
 		// create the product without attributes
 		$product = $this->get_product();
@@ -678,7 +678,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color_attribute() */
 	public function test_get_product_color_attribute_string_matching() {
 
-		$color_attribute = self::create_color_attribute( 'product colour' );
+		$color_attribute = $this->tester->create_color_attribute( 'product colour' );
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
 
@@ -689,7 +689,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color_attribute() */
 	public function test_get_product_color_attribute_variation() {
 
-		$color_attribute = self::create_color_attribute( 'color', [ 'pink', 'blue' ], true );
+		$color_attribute = $this->tester->create_color_attribute( 'color', [ 'pink', 'blue' ], true );
 
 		$product = $this->get_variable_product();
 		$product->set_attributes( [ $color_attribute ] );
@@ -710,7 +710,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_color_attribute() */
 	public function test_update_product_color_attribute_valid() {
 
-		$color_attribute = self::create_color_attribute();
+		$color_attribute = $this->tester->create_color_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
 
@@ -726,7 +726,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_color_attribute() */
 	public function test_update_product_color_attribute_invalid() {
 
-		$color_attribute = self::create_color_attribute();
+		$color_attribute = $this->tester->create_color_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
 
@@ -744,8 +744,8 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_color_attribute() */
 	public function test_update_product_color_attribute_already_used() {
 
-		$color_attribute = self::create_color_attribute();
-		$size_attribute  = self::create_size_attribute();
+		$color_attribute = $this->tester->create_color_attribute();
+		$size_attribute  = $this->tester->create_size_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute, $size_attribute ] ] );
 		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
@@ -769,7 +769,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color() */
 	public function test_get_product_color_simple_product_single_value() {
 
-		$color_attribute = self::create_color_attribute( 'color', [ 'pink' ] );
+		$color_attribute = $this->tester->create_color_attribute( 'color', [ 'pink' ] );
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
 		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
@@ -785,7 +785,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color() */
 	public function test_get_product_color_variation_with_attribute_set() {
 
-		$color_attribute = self::create_color_attribute( 'color', [ 'pink', 'blue' ], true );
+		$color_attribute = $this->tester->create_color_attribute( 'color', [ 'pink', 'blue' ], true );
 
 		$product = $this->get_variable_product();
 		$product->set_attributes( [ $color_attribute ] );
@@ -818,7 +818,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_color() */
 	public function test_get_product_color_variation_without_attribute_set() {
 
-		$color_attribute = self::create_color_attribute( 'color', [ 'pink', 'blue' ], true );
+		$color_attribute = $this->tester->create_color_attribute( 'color', [ 'pink', 'blue' ], true );
 
 		$product = $this->get_variable_product();
 		$product->set_attributes( [ $color_attribute ] );
@@ -839,7 +839,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_size_attribute() */
 	public function test_get_product_size_attribute_configured_valid() {
 
-		$size_attribute = self::create_size_attribute();
+		$size_attribute = $this->tester->create_size_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $size_attribute ] ] );
 		$product->update_meta_data( Products::SIZE_ATTRIBUTE_META_KEY, $size_attribute->get_name() );
@@ -855,7 +855,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_size_attribute() */
 	public function test_get_product_size_attribute_configured_invalid() {
 
-		$size_attribute = self::create_size_attribute();
+		$size_attribute = $this->tester->create_size_attribute();
 
 		// create the product without attributes
 		$product = $this->get_product();
@@ -872,7 +872,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_size_attribute() */
 	public function test_get_product_size_attribute_string_matching() {
 
-		$size_attribute = self::create_size_attribute( 'product size' );
+		$size_attribute = $this->tester->create_size_attribute( 'product size' );
 
 		$product = $this->get_product( [ 'attributes' => [ $size_attribute ] ] );
 
@@ -883,7 +883,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_size_attribute() */
 	public function test_get_product_size_attribute_variation() {
 
-		$size_attribute = self::create_size_attribute( 'size', [ 'small', 'medium', 'large' ], true );
+		$size_attribute = $this->tester->create_size_attribute( 'size', [ 'small', 'medium', 'large' ], true );
 
 		$product = $this->get_variable_product();
 		$product->set_attributes( [ $size_attribute ] );
@@ -904,7 +904,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_size_attribute() */
 	public function test_update_product_size_attribute_valid() {
 
-		$size_attribute = self::create_size_attribute();
+		$size_attribute = $this->tester->create_size_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $size_attribute ] ] );
 
@@ -920,7 +920,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_size_attribute() */
 	public function test_update_product_size_attribute_invalid() {
 
-		$size_attribute = self::create_size_attribute();
+		$size_attribute = $this->tester->create_size_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $size_attribute ] ] );
 
@@ -938,8 +938,8 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_size_attribute() */
 	public function test_update_product_size_attribute_already_used() {
 
-		$color_attribute = self::create_color_attribute();
-		$size_attribute  = self::create_size_attribute();
+		$color_attribute = $this->tester->create_color_attribute();
+		$size_attribute  = $this->tester->create_size_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute, $size_attribute ] ] );
 		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
@@ -958,7 +958,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_size() */
 	public function test_get_product_size_simple_product_single_value() {
 
-		$size_attribute = self::create_size_attribute( 'size', [ 'small' ] );
+		$size_attribute = $this->tester->create_size_attribute( 'size', [ 'small' ] );
 
 		$product = $this->get_product( [ 'attributes' => [ $size_attribute ] ] );
 		$product->update_meta_data( Products::SIZE_ATTRIBUTE_META_KEY, $size_attribute->get_name() );
@@ -974,7 +974,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_size() */
 	public function test_get_product_size_variation_with_attribute_set() {
 
-		$size_attribute = self::create_size_attribute( 'size', [ 'small', 'medium', 'large' ], true );
+		$size_attribute = $this->tester->create_size_attribute( 'size', [ 'small', 'medium', 'large' ], true );
 
 		$product = $this->get_variable_product();
 		$product->set_attributes( [ $size_attribute ] );
@@ -1007,7 +1007,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_size() */
 	public function test_get_product_size_variation_without_attribute_set() {
 
-		$size_attribute = self::create_size_attribute( 'size', [ 'small', 'medium', 'large' ], true );
+		$size_attribute = $this->tester->create_size_attribute( 'size', [ 'small', 'medium', 'large' ], true );
 
 		$product = $this->get_variable_product();
 		$product->set_attributes( [ $size_attribute ] );
@@ -1028,7 +1028,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_pattern_attribute() */
 	public function test_get_product_pattern_attribute_configured_valid() {
 
-		$pattern_attribute = self::create_pattern_attribute();
+		$pattern_attribute = $this->tester->create_pattern_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $pattern_attribute ] ] );
 		$product->update_meta_data( Products::PATTERN_ATTRIBUTE_META_KEY, $pattern_attribute->get_name() );
@@ -1044,7 +1044,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_pattern_attribute() */
 	public function test_get_product_pattern_attribute_configured_invalid() {
 
-		$pattern_attribute = self::create_pattern_attribute();
+		$pattern_attribute = $this->tester->create_pattern_attribute();
 
 		// create the product without attributes
 		$product = $this->get_product();
@@ -1061,7 +1061,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_pattern_attribute() */
 	public function test_get_product_pattern_attribute_string_matching() {
 
-		$pattern_attribute = self::create_pattern_attribute( 'product pattern' );
+		$pattern_attribute = $this->tester->create_pattern_attribute( 'product pattern' );
 
 		$product = $this->get_product( [ 'attributes' => [ $pattern_attribute ] ] );
 
@@ -1072,7 +1072,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_pattern_attribute() */
 	public function test_get_product_pattern_attribute_variation() {
 
-		$pattern_attribute = self::create_pattern_attribute( 'pattern', [ 'checked', 'floral', 'leopard' ], true );
+		$pattern_attribute = $this->tester->create_pattern_attribute( 'pattern', [ 'checked', 'floral', 'leopard' ], true );
 
 		$product = $this->get_variable_product();
 		$product->set_attributes( [ $pattern_attribute ] );
@@ -1093,7 +1093,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_pattern_attribute() */
 	public function test_update_product_pattern_attribute_valid() {
 
-		$pattern_attribute = self::create_pattern_attribute();
+		$pattern_attribute = $this->tester->create_pattern_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $pattern_attribute ] ] );
 
@@ -1109,7 +1109,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_pattern_attribute() */
 	public function test_update_product_pattern_attribute_invalid() {
 
-		$pattern_attribute = self::create_pattern_attribute();
+		$pattern_attribute = $this->tester->create_pattern_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $pattern_attribute ] ] );
 
@@ -1127,8 +1127,8 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::update_product_pattern_attribute() */
 	public function test_update_product_pattern_attribute_already_used() {
 
-		$color_attribute   = self::create_color_attribute();
-		$pattern_attribute = self::create_pattern_attribute();
+		$color_attribute   = $this->tester->create_color_attribute();
+		$pattern_attribute = $this->tester->create_pattern_attribute();
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute, $pattern_attribute ] ] );
 		$product->update_meta_data( Products::COLOR_ATTRIBUTE_META_KEY, $color_attribute->get_name() );
@@ -1147,7 +1147,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_pattern() */
 	public function test_get_product_pattern_simple_product_single_value() {
 
-		$pattern_attribute = self::create_pattern_attribute( 'pattern', [ 'checked' ] );
+		$pattern_attribute = $this->tester->create_pattern_attribute( 'pattern', [ 'checked' ] );
 
 		$product = $this->get_product( [ 'attributes' => [ $pattern_attribute ] ] );
 		$product->update_meta_data( Products::PATTERN_ATTRIBUTE_META_KEY, $pattern_attribute->get_name() );
@@ -1163,7 +1163,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_pattern() */
 	public function test_get_product_pattern_variation_with_attribute_set() {
 
-		$pattern_attribute = self::create_pattern_attribute( 'pattern', [ 'checked', 'floral', 'leopard' ], true );
+		$pattern_attribute = $this->tester->create_pattern_attribute( 'pattern', [ 'checked', 'floral', 'leopard' ], true );
 
 		$product = $this->get_variable_product();
 		$product->set_attributes( [ $pattern_attribute ] );
@@ -1196,7 +1196,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_product_pattern() */
 	public function test_get_product_pattern_variation_without_attribute_set() {
 
-		$pattern_attribute = self::create_pattern_attribute( 'pattern', [ 'checked', 'floral', 'leopard' ], true );
+		$pattern_attribute = $this->tester->create_pattern_attribute( 'pattern', [ 'checked', 'floral', 'leopard' ], true );
 
 		$product = $this->get_variable_product();
 		$product->set_attributes( [ $pattern_attribute ] );
@@ -1217,7 +1217,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_available_product_attributes() */
 	public function test_get_available_product_attributes() {
 
-		$product = $this->get_product( [ 'attributes' => self::create_product_attributes() ] );
+		$product = $this->get_product( [ 'attributes' => $this->tester->create_product_attributes() ] );
 
 		$this->assertSame( $product->get_attributes(), Products::get_available_product_attributes( $product ) );
 	}
@@ -1226,7 +1226,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see Facebook\Products::get_distinct_product_attributes() */
 	public function test_get_distinct_product_attributes() {
 
-		$attributes = self::create_product_attributes();
+		$attributes = $this->tester->create_product_attributes();
 		$product    = $this->get_product( [ 'attributes' => $attributes ] );
 
 		list( $color_attribute, $size_attribute, $pattern_attribute ) = $attributes;
@@ -1287,76 +1287,6 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 		$this->excluded_category = $category['term_id'];
 
 		update_option( \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS, [ $this->excluded_category ] );
-	}
-
-
-	/**
-	 * Creates color attribute.
-	 *
-	 * @param string $name attribute name
-	 * @param string[] $options possible values for the attribute
-	 * @param bool $variation used for variations or not
-	 * @return \WC_Product_Attribute
-	 */
-	private function create_color_attribute( $name = 'color', $options = [ 'pink', 'blue' ], $variation = false ) {
-
-		$color_attribute = new WC_Product_Attribute();
-		$color_attribute->set_name( $name );
-		$color_attribute->set_options( $options );
-		$color_attribute->set_variation( $variation );
-
-		return $color_attribute;
-	}
-
-
-	/**
-	 * Creates size attribute.
-	 *
-	 * @param string $name attribute name
-	 * @param string[] $options possible values for the attribute
-	 * @param bool $variation used for variations or not
-	 * @return \WC_Product_Attribute
-	 */
-	private function create_size_attribute( $name = 'size', $options = [ 'small', 'medium', 'large' ], $variation = false ) {
-
-		$size_attribute = new WC_Product_Attribute();
-		$size_attribute->set_name( $name );
-		$size_attribute->set_options( $options );
-		$size_attribute->set_variation( $variation );
-
-		return $size_attribute;
-	}
-
-
-	/**
-	 * Creates pattern attribute.
-	 *
-	 * @param string $name attribute name
-	 * @param string[] $options possible values for the attribute
-	 * @param bool $variation used for variations or not
-	 * @return \WC_Product_Attribute
-	 */
-	private function create_pattern_attribute( $name = 'pattern', $options = [ 'checked', 'floral', 'leopard' ], $variation = false ) {
-
-		$pattern_attribute = new WC_Product_Attribute();
-		$pattern_attribute->set_name( $name );
-		$pattern_attribute->set_options( $options );
-		$pattern_attribute->set_variation( $variation );
-
-		return $pattern_attribute;
-	}
-
-
-	/**
-	 * Creates product attributes.
-	 */
-	private function create_product_attributes() {
-
-		return [
-			self::create_color_attribute(),
-			self::create_size_attribute(),
-			self::create_pattern_attribute(),
-		];
 	}
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -403,6 +403,36 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see \SkyVerge\WooCommerce\Facebook\Products::is_commerce_enabled_for_product() */
+	public function test_is_commerce_enabled_for_variation() {
+
+		$product = $this->get_variable_product();
+
+		Products::update_commerce_enabled_for_product( $product, true );
+
+		foreach ( $product->get_children() as $child_id ) {
+
+			$variation = wc_get_product( $child_id );
+
+			$this->assertTrue( Facebook\Products::is_commerce_enabled_for_product( $variation ) );
+		}
+	}
+
+
+	/** @see \SkyVerge\WooCommerce\Facebook\Products::is_commerce_enabled_for_product() */
+	public function test_is_commerce_disabled_for_variation() {
+
+		$product = $this->get_variable_product();
+
+		foreach ( $product->get_children() as $child_id ) {
+
+			$variation = wc_get_product( $child_id );
+
+			$this->assertFalse( Facebook\Products::is_commerce_enabled_for_product( $variation ) );
+		}
+	}
+
+
 	/**
 	 * @see \SkyVerge\WooCommerce\Facebook\Products::update_commerce_enabled_for_product()
 	 *

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -71,17 +71,64 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @see \WC_Facebook_Product::prepare_product() */
-	public function test_prepare_product_ready_for_commerce_google_product_category() {
+	public function test_prepare_product_not_ready_for_commerce_color() {
+
+		$attribute = $this->tester->create_color_attribute();
 
 		$product = $this->tester->get_product( [
-			'status'         => 'publish',
-			'regular_price'  => '1.00',
-			'manage_stock'   => true,
-			'stock_quantity' => 100,
+			'attributes' => [ $attribute ],
 		] );
 
 		Products::enable_sync_for_products( [ $product ] );
-		Products::update_commerce_enabled_for_product( $product, true );
+		Products::update_product_color_attribute( $product, $attribute->get_name() );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertArrayNotHasKey( 'color', $data );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_not_ready_for_commerce_size() {
+
+		$attribute = $this->tester->create_size_attribute();
+
+		$product = $this->tester->get_product( [
+			'attributes' => [ $attribute ],
+		] );
+
+		Products::enable_sync_for_products( [ $product ] );
+		Products::update_product_size_attribute( $product, $attribute->get_name() );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertArrayNotHasKey( 'size', $data );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_not_ready_for_commerce_pattern() {
+
+		$attribute = $this->tester->create_pattern_attribute();
+
+		$product = $this->tester->get_product( [
+			'attributes' => [ $attribute ],
+		] );
+
+		Products::enable_sync_for_products( [ $product ] );
+		Products::update_product_pattern_attribute( $product, $attribute->get_name() );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertArrayNotHasKey( 'pattern', $data );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_ready_for_commerce_google_product_category() {
+
+		$product = $this->get_product_ready_for_commerce();
+
 		Products::update_google_product_category_id( $product, '1234' );
 
 		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
@@ -130,20 +177,64 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 	/** @see \WC_Facebook_Product::prepare_product() */
 	public function test_prepare_product_ready_for_commerce_gender() {
 
-		$product = $this->tester->get_product( [
-			'status'         => 'publish',
-			'regular_price'  => '1.00',
-			'manage_stock'   => true,
-			'stock_quantity' => 100,
-		] );
+		$product = $this->get_product_ready_for_commerce();
 
-		Products::enable_sync_for_products( [ $product ] );
-		Products::update_commerce_enabled_for_product( $product, true );
 		Products::update_product_gender( $product, 'female' );
 
 		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
 
 		$this->assertSame( 'female', $data['gender'] );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_ready_for_commerce_color() {
+
+		$attribute = $this->tester->create_color_attribute();
+
+		$product = $this->get_product_ready_for_commerce( [ $attribute ] );
+
+		Products::enable_sync_for_products( [ $product ] );
+		Products::update_commerce_enabled_for_product( $product, true );
+		Products::update_product_color_attribute( $product, $attribute->get_name() );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertSame( 'pink | blue', $data['color'] );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_ready_for_commerce_size() {
+
+		$attribute = $this->tester->create_size_attribute();
+
+		$product = $this->get_product_ready_for_commerce( [ $attribute ] );
+
+		Products::enable_sync_for_products( [ $product ] );
+		Products::update_commerce_enabled_for_product( $product, true );
+		Products::update_product_size_attribute( $product, $attribute->get_name() );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertSame( 'small | medium | large', $data['size'] );
+	}
+
+
+	/** @see \WC_Facebook_Product::prepare_product() */
+	public function test_prepare_product_ready_for_commerce_pattern() {
+
+		$attribute = $this->tester->create_pattern_attribute();
+
+		$product = $this->get_product_ready_for_commerce( [ $attribute ] );
+
+		Products::enable_sync_for_products( [ $product ] );
+		Products::update_commerce_enabled_for_product( $product, true );
+		Products::update_product_pattern_attribute( $product, $attribute->get_name() );
+
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
+
+		$this->assertSame( 'checked | floral | leopard', $data['pattern'] );
 	}
 
 
@@ -380,6 +471,29 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 		$product->set_description( 'Standard Description.' );
 		$product->set_short_description( 'Short Description.' );
 		$product->save();
+
+		return $product;
+	}
+
+
+	/**
+	 * Gets a product that's ready for Commerce.
+	 *
+	 * @param \WC_Product_Attribute[] $attributes product attributes to set
+	 * @return \WC_Product
+	 */
+	private function get_product_ready_for_commerce( $attributes = [] ) {
+
+		$product = $this->tester->get_product( [
+			'status'         => 'publish',
+			'regular_price'  => '1.00',
+			'manage_stock'   => true,
+			'stock_quantity' => 100,
+			'attributes'     => $attributes,
+		] );
+
+		Products::enable_sync_for_products( [ $product ] );
+		Products::update_commerce_enabled_for_product( $product, true );
 
 		return $product;
 	}


### PR DESCRIPTION
# Summary

Adds the color, size, and pattern attribute values to the product data.

### Story: [CH 62218](https://app.clubhouse.io/skyverge/story/62218)
### Release: #1477 

## Details

Added to both the API updates and feed.

Note: I had to update the `Products::is_commerce_enabled_for_product()` method to handle variations, so the parent is checked.

## UI Changes

_N/A_

## QA

- [x] Integration tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version