### PR TITLE
Create the List Orders response object

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -475,6 +475,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Orders/Request.php';
 				}
 
+				if ( ! class_exists( API\Orders\Response::class ) ) {
+					require_once __DIR__ . '/includes/API/Orders/Response.php';
+				}
+
 				$this->api = new SkyVerge\WooCommerce\Facebook\API( $this->get_connection_handler()->get_access_token() );
 			}
 

--- a/includes/API/Orders/Response.php
+++ b/includes/API/Orders/Response.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Orders;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Orders API list response object.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Response extends API\Response {
+
+
+	use API\Traits\Paginated_Response;
+
+
+}

--- a/includes/API/Orders/Response.php
+++ b/includes/API/Orders/Response.php
@@ -25,4 +25,23 @@ class Response extends API\Response {
 	use API\Traits\Paginated_Response;
 
 
+	/**
+	 * Gets an array of order objects from the response data.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return \SkyVerge\WooCommerce\Facebook\API\Orders\Order[]
+	 */
+	public function get_orders() {
+
+		$orders = [];
+
+		foreach ( $this->get_data() as $order_data ) {
+			$orders[] = new Order( $order_data );
+		}
+
+		return $orders;
+	}
+
+
 }

--- a/includes/API/Orders/Response.php
+++ b/includes/API/Orders/Response.php
@@ -37,7 +37,7 @@ class Response extends API\Response {
 		$orders = [];
 
 		foreach ( $this->get_data() as $order_data ) {
-			$orders[] = new Order( $order_data );
+			$orders[] = new Order( json_decode( json_encode( $order_data ), true ) );
 		}
 
 		return $orders;

--- a/tests/integration/API/Orders/ResponseTest.php
+++ b/tests/integration/API/Orders/ResponseTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Order;
+use SkyVerge\WooCommerce\Facebook\API\Orders\Response;
+
+/**
+ * Tests the API\Orders\Response class.
+ */
+class ResponseTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Response::get_orders() */
+	public function test_get_orders_empty() {
+
+		$response = new Response( json_encode( [ 'data' => [] ] ) );
+
+		$this->assertEquals( [], $response->get_orders() );
+	}
+
+
+	/** @see Response::get_orders() */
+	public function test_get_orders_not_empty() {
+
+		$response_data = [
+			'data' => [
+				0 => [
+					'id'                        => '335211597203390',
+					'order_status'              => [
+						'state' => 'CREATED',
+					],
+					'created'                   => '2019-01-14T19:17:31+00:00',
+					'last_updated'              => '2019-01-14T19:47:35+00:00',
+					'items'                     => [
+						0 => [
+							'id'             => '2082596341811586',
+							'product_id'     => '1213131231',
+							'retailer_id'    => 'external_product_1234',
+							'quantity'       => 2,
+							'price_per_unit' => [
+								'amount'   => '20.00',
+								'currency' => 'USD',
+							],
+							'tax_details'    => [
+								'estimated_tax' => [
+									'amount'   => '0.30',
+									'currency' => 'USD',
+								],
+								'captured_tax'  => [
+									'total_tax' => [
+										'amount'   => '0.30',
+										'currency' => 'USD',
+									],
+								],
+							],
+						],
+					],
+					'ship_by_date'              => '2019-01-16',
+					'merchant_order_id'         => '46192',
+					'channel'                   => 'Instagram',
+					'selected_shipping_option'  => [
+						'name'                    => 'Standard',
+						'price'                   => [
+							'amount'   => '10.00',
+							'currency' => 'USD',
+						],
+						'calculated_tax'          => [
+							'amount'   => '0.15',
+							'currency' => 'USD',
+						],
+						'estimated_shipping_time' => [
+							'min_days' => 3,
+							'max_days' => 15,
+						],
+					],
+					'shipping_address'          => [
+						'name'        => 'ABC company',
+						'street1'     => '123 Main St',
+						'street2'     => 'Unit 200',
+						'city'        => 'Boston',
+						'state'       => 'MA',
+						'postal_code' => '02110',
+						'country'     => 'US',
+					],
+					'estimated_payment_details' => [
+						'subtotal'     => [
+							'items'    => [
+								'amount'   => '20.00',
+								'currency' => 'USD',
+							],
+							'shipping' => [
+								'amount'   => '10.00',
+								'currency' => 'USD',
+							],
+						],
+						'tax'          => [
+							'amount'   => '0.45',
+							'currency' => 'USD',
+						],
+						'total_amount' => [
+							'amount'   => '20.45',
+							'currency' => 'USD',
+						],
+						'tax_remitted' => true,
+					],
+					'buyer_details'             => [
+						'name'                     => 'John Doe',
+						'email'                    => 'johndoe@example.com',
+						'email_remarketing_option' => false,
+					],
+				],
+			],
+		];
+
+		$response = new Response( json_encode( $response_data ) );
+		$orders   = $response->get_orders();
+
+		$this->assertIsArray( $orders );
+		$this->assertCount( 1, $orders );
+		$this->assertArrayHasKey( 0, $orders );
+
+		$first_order = $orders[0];
+
+		$this->assertInstanceOf( Order::class, $first_order );
+
+		foreach ( $response_data['data'][0] as $key => $value ) {
+
+			if ( 'order_status' === $key ) {
+
+				$this->assertEquals( $value['state'], $first_order->get_status() );
+
+			} elseif ( ! in_array( $key, [ 'created', 'last_updated', 'ship_by_date', 'merchant_order_id' ] ) ) {
+
+				$method = "get_$key";
+				$this->assertEquals( $value, $first_order->$method() );
+			}
+		}
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `API\Orders\Response` class.

### Story: [CH 62205](https://app.clubhouse.io/skyverge/story/62205/create-the-list-orders-response-object)
### Release: #1477 

## Details

As discussed on [Slack](https://skyverge.slack.com/archives/CR8VDB4G7/p1598465101045400), I had to tweak the class namespace because `List` is a reserved word.

Also I had to encode and decode the data used to instantiate each `Order` object, because I've implemented all the getters assuming the data would be an associative array (without objects). Let me know if you think this is a bad move and I can refactor the `Order` class to get all the values from objects instead.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version