### PR TITLE
Create the Read Order response object

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -471,6 +471,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Orders/Read/Request.php';
 				}
 
+				if ( ! class_exists( API\Orders\Read\Response::class ) ) {
+					require_once __DIR__ . '/includes/API/Orders/Read/Response.php';
+				}
+
 				if ( ! class_exists( API\Orders\Request::class ) ) {
 					require_once __DIR__ . '/includes/API/Orders/Request.php';
 				}

--- a/includes/API/Orders/Read/Response.php
+++ b/includes/API/Orders/Read/Response.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Orders\Read;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Orders API read response object.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Response extends API\Response {
+
+
+}

--- a/includes/API/Orders/Read/Response.php
+++ b/includes/API/Orders/Read/Response.php
@@ -13,6 +13,7 @@ namespace SkyVerge\WooCommerce\Facebook\API\Orders\Read;
 defined( 'ABSPATH' ) or exit;
 
 use SkyVerge\WooCommerce\Facebook\API;
+use SkyVerge\WooCommerce\Facebook\API\Orders\Order;
 
 /**
  * Orders API read response object.
@@ -20,6 +21,19 @@ use SkyVerge\WooCommerce\Facebook\API;
  * @since 2.1.0-dev.1
  */
 class Response extends API\Response {
+
+
+	/**
+	 * Gets an order object from the response data.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return \SkyVerge\WooCommerce\Facebook\API\Orders\Order
+	 */
+	public function get_order() {
+
+		return new Order( json_decode( json_encode( $this->response_data ), true ) );
+	}
 
 
 }

--- a/tests/integration/API/Orders/Read/ResponseTest.php
+++ b/tests/integration/API/Orders/Read/ResponseTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders\Read;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Order;
+use SkyVerge\WooCommerce\Facebook\API\Orders\Read\Response;
+
+/**
+ * Tests the API\Orders\Read\Response class.
+ */
+class ResponseTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Response::get_order() */
+	public function test_get_order() {
+
+		$response_data = [
+			'id'                        => '335211597203390',
+			'order_status'              => [
+				'state' => 'CREATED',
+			],
+			'created'                   => '2019-01-14T19:17:31+00:00',
+			'last_updated'              => '2019-01-14T19:47:35+00:00',
+			'items'                     => [
+				0 => [
+					'id'             => '2082596341811586',
+					'product_id'     => '1213131231',
+					'retailer_id'    => 'external_product_1234',
+					'quantity'       => 2,
+					'price_per_unit' => [
+						'amount'   => '20.00',
+						'currency' => 'USD',
+					],
+					'tax_details'    => [
+						'estimated_tax' => [
+							'amount'   => '0.30',
+							'currency' => 'USD',
+						],
+						'captured_tax'  => [
+							'total_tax' => [
+								'amount'   => '0.30',
+								'currency' => 'USD',
+							],
+						],
+					],
+				],
+			],
+			'ship_by_date'              => '2019-01-16',
+			'merchant_order_id'         => '46192',
+			'channel'                   => 'Instagram',
+			'selected_shipping_option'  => [
+				'name'                    => 'Standard',
+				'price'                   => [
+					'amount'   => '10.00',
+					'currency' => 'USD',
+				],
+				'calculated_tax'          => [
+					'amount'   => '0.15',
+					'currency' => 'USD',
+				],
+				'estimated_shipping_time' => [
+					'min_days' => 3,
+					'max_days' => 15,
+				],
+			],
+			'shipping_address'          => [
+				'name'        => 'ABC company',
+				'street1'     => '123 Main St',
+				'street2'     => 'Unit 200',
+				'city'        => 'Boston',
+				'state'       => 'MA',
+				'postal_code' => '02110',
+				'country'     => 'US',
+			],
+			'estimated_payment_details' => [
+				'subtotal'     => [
+					'items'    => [
+						'amount'   => '20.00',
+						'currency' => 'USD',
+					],
+					'shipping' => [
+						'amount'   => '10.00',
+						'currency' => 'USD',
+					],
+				],
+				'tax'          => [
+					'amount'   => '0.45',
+					'currency' => 'USD',
+				],
+				'total_amount' => [
+					'amount'   => '20.45',
+					'currency' => 'USD',
+				],
+				'tax_remitted' => true,
+			],
+			'buyer_details'             => [
+				'name'                     => 'John Doe',
+				'email'                    => 'johndoe@example.com',
+				'email_remarketing_option' => false,
+			],
+		];
+
+		$response = new Response( json_encode( $response_data ) );
+		$order    = $response->get_order();
+
+		$this->assertInstanceOf( Order::class, $order );
+
+		foreach ( $response_data as $key => $value ) {
+
+			if ( 'order_status' === $key ) {
+
+				$this->assertEquals( $value['state'], $order->get_status() );
+
+			} elseif ( ! in_array( $key, [ 'created', 'last_updated', 'ship_by_date', 'merchant_order_id' ] ) ) {
+
+				$method = "get_$key";
+				$this->assertEquals( $value, $order->$method() );
+			}
+		}
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `API\Orders\Read\Response` class.

### Story: [CH 62215](https://app.clubhouse.io/skyverge/story/62215/create-the-read-order-response-object)
### Release: #1477 

## Details

I had to encode and decode the data used to instantiate the `Order` object, because I've implemented all the getters assuming the data would be an associative array (without objects). Let me know if you think this is a bad move and I can refactor the `Order` class to get all the values from objects instead.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version