### PR TITLE
Create the Acknowledge Order request object

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -471,6 +471,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Orders/Order.php';
 				}
 
+				if ( ! class_exists( API\Orders\Acknowledge\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Orders/Acknowledge/Request.php';
+				}
+
 				if ( ! class_exists( API\Orders\Read\Request::class ) ) {
 					require_once __DIR__ . '/includes/API/Orders/Read/Request.php';
 				}

--- a/includes/API/Orders/Acknowledge/Request.php
+++ b/includes/API/Orders/Acknowledge/Request.php
@@ -25,4 +25,23 @@ class Request extends API\Request  {
 	use API\Traits\Idempotent_Request;
 
 
+	/**
+	 * API request constructor.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id remote order ID
+	 * @param string $merchant_order_reference WC order ID
+	 */
+	public function __construct( $remote_id, $merchant_order_reference ) {
+
+		parent::__construct( "/{$remote_id}", 'POST' );
+
+		$this->set_data( [
+			'merchant_order_reference' => $merchant_order_reference,
+			'idempotency_key'          => $this->get_idempotency_key(),
+		] );
+	}
+
+
 }

--- a/includes/API/Orders/Acknowledge/Request.php
+++ b/includes/API/Orders/Acknowledge/Request.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Orders\Acknowledge;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Orders API acknowledge request object.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Request extends API\Request  {
+
+
+}

--- a/includes/API/Orders/Acknowledge/Request.php
+++ b/includes/API/Orders/Acknowledge/Request.php
@@ -22,4 +22,7 @@ use SkyVerge\WooCommerce\Facebook\API;
 class Request extends API\Request  {
 
 
+	use API\Traits\Idempotent_Request;
+
+
 }

--- a/tests/integration/API/Orders/Acknowledge/RequestTest.php
+++ b/tests/integration/API/Orders/Acknowledge/RequestTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders\Acknowledge;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Acknowledge\Request;
+
+/**
+ * Tests the API\Orders\Acknowledge\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Request::__construct() */
+	public function test_constructor() {
+
+		$request = new Request( '368508827392800', '63135' );
+
+		$this->assertEquals( '/368508827392800', $request->get_path() );
+		$this->assertEquals( 'POST', $request->get_method() );
+
+		$expected_data = [
+			'merchant_order_reference' => '63135',
+			'idempotency_key'          => $request->get_idempotency_key(),
+		];
+		$this->assertEquals( $expected_data, $request->get_data() );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `API\Orders\Acknowledge\Request` class.

### Story: [CH 62225](https://app.clubhouse.io/skyverge/story/62225/create-the-acknowledge-order-request-object)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version