### PR TITLE
Use attribute slugs for comparison & return values

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -703,10 +703,10 @@ class Products {
 
 			if ( empty( $attribute_name ) ) {
 				// try to find a matching attribute
-				foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+				foreach ( self::get_available_product_attributes( $product ) as $slug => $attribute ) {
 
 					if ( stripos( $attribute->get_name(), 'color' ) !== false || stripos( $attribute->get_name(), 'colour' ) !== false ) {
-						$attribute_name = $attribute->get_name();
+						$attribute_name = $slug;
 						break;
 					}
 				}
@@ -799,10 +799,10 @@ class Products {
 
 			if ( empty( $attribute_name ) ) {
 				// try to find a matching attribute
-				foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+				foreach ( self::get_available_product_attributes( $product ) as $slug => $attribute ) {
 
 					if ( stripos( $attribute->get_name(), 'size' ) !== false ) {
-						$attribute_name = $attribute->get_name();
+						$attribute_name = $slug;
 						break;
 					}
 				}
@@ -895,10 +895,10 @@ class Products {
 
 			if ( empty( $attribute_name ) ) {
 				// try to find a matching attribute
-				foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+				foreach ( self::get_available_product_attributes( $product ) as $slug => $attribute ) {
 
 					if ( stripos( $attribute->get_name(), 'pattern' ) !== false ) {
-						$attribute_name = $attribute->get_name();
+						$attribute_name = $slug;
 						break;
 					}
 				}
@@ -989,9 +989,10 @@ class Products {
 
 		$found = false;
 
-		foreach ( self::get_available_product_attributes( $product ) as $attribute ) {
+		foreach ( self::get_available_product_attributes( $product ) as $slug => $attribute ) {
 
-			if ( $attribute_name === $attribute->get_name() ) {
+			// taxonomy attributes have a slugged name, but custom attributes do not so we check the attribute key first
+			if ( $attribute_name === $slug ) {
 				$found = true;
 				break;
 			}

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -991,7 +991,7 @@ class Products {
 
 		foreach ( self::get_available_product_attributes( $product ) as $slug => $attribute ) {
 
-			// taxonomy attributes have a slugged name, but custom attributes do not so we check the attribute key first
+			// taxonomy attributes have a slugged name, but custom attributes do not so we check the attribute key
 			if ( $attribute_name === $slug ) {
 				$found = true;
 				break;

--- a/tests/_support/IntegrationTester.php
+++ b/tests/_support/IntegrationTester.php
@@ -136,12 +136,22 @@ class IntegrationTester extends \Codeception\Actor {
 	 * @param bool $variation used for variations or not
 	 * @return \WC_Product_Attribute
 	 */
-	public function create_color_attribute( $name = 'color', $options = [ 'pink', 'blue' ], $variation = false ) {
+	public function create_color_attribute( $name = 'color', $options = [ 'pink', 'blue' ], $variation = false, $taxonomy = false ) {
 
 		$color_attribute = new WC_Product_Attribute();
 		$color_attribute->set_name( $name );
 		$color_attribute->set_options( $options );
 		$color_attribute->set_variation( $variation );
+
+		if ( $taxonomy ) {
+
+			// create the taxonomy attribute
+			wc_create_attribute( [ $color_attribute->get_name() ] );
+
+			foreach ( $options as $option ) {
+				wp_insert_term( $option, $color_attribute->get_name() );
+			}
+		}
 
 		return $color_attribute;
 	}
@@ -155,12 +165,22 @@ class IntegrationTester extends \Codeception\Actor {
 	 * @param bool $variation used for variations or not
 	 * @return \WC_Product_Attribute
 	 */
-	public function create_size_attribute( $name = 'size', $options = [ 'small', 'medium', 'large' ], $variation = false ) {
+	public function create_size_attribute( $name = 'size', $options = [ 'small', 'medium', 'large' ], $variation = false, $taxonomy = false ) {
 
 		$size_attribute = new WC_Product_Attribute();
 		$size_attribute->set_name( $name );
 		$size_attribute->set_options( $options );
 		$size_attribute->set_variation( $variation );
+
+		if ( $taxonomy ) {
+
+			// create the taxonomy attribute
+			wc_create_attribute( [ $size_attribute->get_name() ] );
+
+			foreach ( $options as $option ) {
+				wp_insert_term( $option, $size_attribute->get_name() );
+			}
+		}
 
 		return $size_attribute;
 	}
@@ -174,12 +194,22 @@ class IntegrationTester extends \Codeception\Actor {
 	 * @param bool $variation used for variations or not
 	 * @return \WC_Product_Attribute
 	 */
-	public function create_pattern_attribute( $name = 'pattern', $options = [ 'checked', 'floral', 'leopard' ], $variation = false ) {
+	public function create_pattern_attribute( $name = 'pattern', $options = [ 'checked', 'floral', 'leopard' ], $variation = false, $taxonomy = false ) {
 
 		$pattern_attribute = new WC_Product_Attribute();
 		$pattern_attribute->set_name( $name );
 		$pattern_attribute->set_options( $options );
 		$pattern_attribute->set_variation( $variation );
+
+		if ( $taxonomy ) {
+
+			// create the taxonomy attribute
+			wc_create_attribute( [ $pattern_attribute->get_name() ] );
+
+			foreach ( $options as $option ) {
+				wp_insert_term( $option, $pattern_attribute->get_name() );
+			}
+		}
 
 		return $pattern_attribute;
 	}

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -1273,6 +1273,38 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * @see Products::product_has_attribute()
+	 *
+	 * @param string $attribute_name attribute name to check
+	 * @param bool $expected expected result
+	 *
+	 * @dataProvider provider_product_has_attribute
+	 */
+	public function test_product_has_attribute( $attribute_name, $expected ) {
+
+		$color_attribute = $this->tester->create_color_attribute( 'color', [ 'red', 'blue' ], false, true );
+		$size_attribute  = $this->tester->create_size_attribute( 'Custom attribute' );
+
+		$product = $this->get_product( [
+			'attributes' => [ $color_attribute, $size_attribute ],
+		] );
+
+		$this->assertSame( $expected, Products::product_has_attribute( $product, $attribute_name ) );
+	}
+
+
+	/** @see test_product_has_attribute */
+	public function provider_product_has_attribute() {
+
+		return [
+			'taxonomy attribute' => [ 'color', true ],
+			'custom attribute'   => [ 'custom-attribute', true ],
+			'missing attribute'  => [ 'missing', false ],
+		];
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -712,7 +712,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 		$product = $this->get_product( [ 'attributes' => [ $color_attribute ] ] );
 
-		$this->assertSame( $color_attribute->get_name(), Products::get_product_color_attribute( $product ) );
+		$this->assertSame( 'product-colour', Products::get_product_color_attribute( $product ) );
 	}
 
 
@@ -906,7 +906,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 		$product = $this->get_product( [ 'attributes' => [ $size_attribute ] ] );
 
-		$this->assertSame( $size_attribute->get_name(), Products::get_product_size_attribute( $product ) );
+		$this->assertSame( 'product-size', Products::get_product_size_attribute( $product ) );
 	}
 
 
@@ -1095,7 +1095,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 		$product = $this->get_product( [ 'attributes' => [ $pattern_attribute ] ] );
 
-		$this->assertSame( $pattern_attribute->get_name(), Products::get_product_pattern_attribute( $product ) );
+		$this->assertSame( 'product-pattern', Products::get_product_pattern_attribute( $product ) );
 	}
 
 


### PR DESCRIPTION
# Summary

Ensures the various attribute methods can be used consistently with both taxonomy & non-taxonomy attributes, regardless of their naming.

### Story: [CH 62615](https://app.clubhouse.io/skyverge/story/62615)
### Release: #1477 

## Details

Name was targeted as the value to use initially, but it turns out only the name is sanitized for taxonomy attributes. Custom attributes retain their nice name, e.g. `Custom attribute`, and can cause hidden issues when building product data.

WooCommerce stores variation attribute data using only the slug, and the existing Facebook data generation relies on the slugs as well, so we should probably stick to that.

## UI Changes

_N/A_

## QA

- [x] Integration tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version