### PR TITLE
Set the dedicated attribute fields in the prepared product group data

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -767,12 +767,28 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 						$option_values = $this->get_grouped_product_option_names( $key, $option_values );
 					}
 
-					/**
-					 * For API approach, product_field need to start with 'custom_data:'
-					 * @link https://developers.facebook.com/docs/marketing-api/reference/product-variant/
-					 * Clean up variant name (e.g. pa_color should be color):
-					 */
-					$name = \WC_Facebookcommerce_Utils::sanitize_variant_name( $name );
+					switch ( $name ) {
+
+						case Products::get_product_color_attribute( $this->woo_product ) :
+							$name = WC_Facebookcommerce_Utils::FB_VARIANT_COLOR;
+						break;
+
+						case Products::get_product_size_attribute( $this->woo_product ) :
+							$name = WC_Facebookcommerce_Utils::FB_VARIANT_SIZE;
+						break;
+
+						case Products::get_product_pattern_attribute( $this->woo_product ) :
+							$name = WC_Facebookcommerce_Utils::FB_VARIANT_PATTERN;
+						break;
+
+						default:
+
+							/**
+							 * For API approach, product_field need to start with 'custom_data:'
+							 * @link https://developers.facebook.com/docs/marketing-api/reference/product-variant/
+							 */
+							$name = \WC_Facebookcommerce_Utils::sanitize_variant_name( $name );
+					}
 
 					// for feed uploading, product field should remove prefix 'custom_data:'
 					if ( $feed_data ) {


### PR DESCRIPTION
# Summary

Updates the prepared product group data to use the new attribute methods.

### Story: [CH 62220](https://app.clubhouse.io/skyverge/story/62220)
### Release: #1477 

## Details

When we send a group's variant options over to Facebook, each attribute has a `product_field` value. For attributes that are custom, they require we append `custom_data:` to them. Otherwise, the plain field is sent, e.g. `color`.

This updates the data to use the new methods so that the configured attributes translate into their appropriate `product_field` name, or remain as `custom_data:` otherwise.

## UI Changes

_N/A_

## QA

- [x] Integration tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version