### PR TITLE
Create the Order Fulfillment request object

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -475,6 +475,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Orders/Acknowledge/Request.php';
 				}
 
+				if ( ! class_exists( API\Orders\Fulfillment\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Orders/Fulfillment/Request.php';
+				}
+
 				if ( ! class_exists( API\Orders\Read\Request::class ) ) {
 					require_once __DIR__ . '/includes/API/Orders/Read/Request.php';
 				}

--- a/includes/API/Orders/Fulfillment/Request.php
+++ b/includes/API/Orders/Fulfillment/Request.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Orders\Fulfillment;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Orders API fulfillment request object.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Request extends API\Request  {
+
+
+	use API\Traits\Idempotent_Request;
+
+
+}

--- a/includes/API/Orders/Fulfillment/Request.php
+++ b/includes/API/Orders/Fulfillment/Request.php
@@ -25,4 +25,22 @@ class Request extends API\Request  {
 	use API\Traits\Idempotent_Request;
 
 
+	/**
+	 * API request constructor.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id remote order ID
+	 * @param array $fulfillment_data fulfillment data
+	 */
+	public function __construct( $remote_id, $fulfillment_data ) {
+
+		parent::__construct( "/{$remote_id}/shipments", 'POST' );
+
+		$fulfillment_data['idempotency_key'] = $this->get_idempotency_key();
+
+		$this->set_data( $fulfillment_data );
+	}
+
+
 }

--- a/tests/integration/API/Orders/Fulfillment/RequestTest.php
+++ b/tests/integration/API/Orders/Fulfillment/RequestTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders\Fulfillment;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Fulfillment\Request;
+
+/**
+ * Tests the API\Orders\Fulfillment\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Request::__construct() */
+	public function test_constructor() {
+
+		$fulfillment_data = [
+			'items'         => [
+				[
+					'retailer_id' => 'FB_product_1238',
+					'quantity'    => 1,
+				],
+				[
+					'retailer_id' => 'FB_product_5624',
+					'quantity'    => 2,
+				],
+			],
+			'tracking_info' => [
+				'tracking_number'      => 'ship 1',
+				'carrier'              => 'FEDEX',
+				'shipping_method_name' => '2 Day Fedex',
+			],
+		];
+
+		$request = new Request( '368508827392800', $fulfillment_data );
+
+		$this->assertEquals( '/368508827392800/shipments', $request->get_path() );
+		$this->assertEquals( 'POST', $request->get_method() );
+
+		$expected_data                    = $fulfillment_data;
+		$expected_data['idempotency_key'] = $request->get_idempotency_key();
+		$this->assertEquals( $expected_data, $request->get_data() );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `API\Orders\Fulfillment\Request` class.

### Story: [CH 62229](https://app.clubhouse.io/skyverge/story/62229/create-the-order-fulfillment-request-object)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version