### PR TITLE
Create the Cancel Order request object

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -475,6 +475,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Orders/Acknowledge/Request.php';
 				}
 
+				if ( ! class_exists( API\Orders\Cancel\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Orders/Cancel/Request.php';
+				}
+
 				if ( ! class_exists( API\Orders\Read\Request::class ) ) {
 					require_once __DIR__ . '/includes/API/Orders/Read/Request.php';
 				}

--- a/includes/API/Orders/Cancel/Request.php
+++ b/includes/API/Orders/Cancel/Request.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Orders\Cancel;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Orders API cancel request object.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Request extends API\Request  {
+
+
+	use API\Traits\Idempotent_Request;
+
+
+}

--- a/includes/API/Orders/Cancel/Request.php
+++ b/includes/API/Orders/Cancel/Request.php
@@ -25,4 +25,20 @@ class Request extends API\Request  {
 	use API\Traits\Idempotent_Request;
 
 
+	/** @var string customer requested cancellation */
+	const REASON_CUSTOMER_REQUESTED = 'CUSTOMER_REQUESTED';
+
+	/** @var string out of stock cancellation */
+	const REASON_OUT_OF_STOCK = 'OUT_OF_STOCK';
+
+	/** @var string invalid address cancellation */
+	const REASON_INVALID_ADDRESS = 'INVALID_ADDRESS';
+
+	/** @var string suspicious order cancellation */
+	const REASON_SUSPICIOUS_ORDER = 'SUSPICIOUS_ORDER';
+
+	/** @var string other reason cancellation */
+	const REASON_OTHER = 'CANCEL_REASON_OTHER';
+
+
 }

--- a/includes/API/Orders/Cancel/Request.php
+++ b/includes/API/Orders/Cancel/Request.php
@@ -41,4 +41,27 @@ class Request extends API\Request  {
 	const REASON_OTHER = 'CANCEL_REASON_OTHER';
 
 
+	/**
+	 * API request constructor.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id remote order ID
+	 * @param string $reason cancellation reason code
+	 * @param bool $restock_items whether or not the items were restocked
+	 */
+	public function __construct( $remote_id, $reason, $restock_items = true ) {
+
+		parent::__construct( "/{$remote_id}/cancellations", 'POST' );
+
+		$this->set_data( [
+			'cancel_reason'   => [
+				'reason_code' => $reason,
+			],
+			'restock_items'   => $restock_items,
+			'idempotency_key' => $this->get_idempotency_key(),
+		] );
+	}
+
+
 }

--- a/tests/integration/API/Orders/Cancel/RequestTest.php
+++ b/tests/integration/API/Orders/Cancel/RequestTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders\Cancel;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Cancel\Request;
+
+/**
+ * Tests the API\Orders\Cancel\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Request::__construct() */
+	public function test_constructor() {
+
+		$request = new Request( '368508827392800', Request::REASON_CUSTOMER_REQUESTED, false );
+
+		$this->assertEquals( '/368508827392800/cancellations', $request->get_path() );
+		$this->assertEquals( 'POST', $request->get_method() );
+
+		$expected_data = [
+			'cancel_reason'   => [
+				'reason_code' => Request::REASON_CUSTOMER_REQUESTED,
+			],
+			'restock_items'   => false,
+			'idempotency_key' => $request->get_idempotency_key(),
+		];
+		$this->assertEquals( $expected_data, $request->get_data() );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `API\Orders\Cancel\Request` class.

### Story: [CH 62238](https://app.clubhouse.io/skyverge/story/62238/create-the-cancel-order-request-object)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version