### PR TITLE
Create the Refund Order request object

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -487,6 +487,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Orders/Read/Response.php';
 				}
 
+				if ( ! class_exists( API\Orders\Refund\Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Orders/Refund/Request.php';
+				}
+
 				if ( ! class_exists( API\Orders\Request::class ) ) {
 					require_once __DIR__ . '/includes/API/Orders/Request.php';
 				}

--- a/includes/API/Orders/Refund/Request.php
+++ b/includes/API/Orders/Refund/Request.php
@@ -44,4 +44,22 @@ class Request extends API\Request  {
 	const REASON_OTHER = 'REFUND_REASON_OTHER';
 
 
+	/**
+	 * API request constructor.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id remote order ID
+	 * @param array $data refund data
+	 */
+	public function __construct( $remote_id, $data ) {
+
+		parent::__construct( "/{$remote_id}/refunds", 'POST' );
+
+		$data['idempotency_key'] = $this->get_idempotency_key();
+
+		$this->set_data( $data );
+	}
+
+
 }

--- a/includes/API/Orders/Refund/Request.php
+++ b/includes/API/Orders/Refund/Request.php
@@ -25,4 +25,23 @@ class Request extends API\Request  {
 	use API\Traits\Idempotent_Request;
 
 
+	/** @var string buyer's remorse refund reason */
+	const REASON_BUYERS_REMORSE = 'BUYERS_REMORSE';
+
+	/** @var string damaged goods refund reason */
+	const REASON_DAMAGED_GOODS = 'DAMAGED_GOODS';
+
+	/** @var string not as described refund reason */
+	const REASON_NOT_AS_DESCRIBED = 'NOT_AS_DESCRIBED';
+
+	/** @var string quality issue refund reason */
+	const REASON_QUALITY_ISSUE = 'QUALITY_ISSUE';
+
+	/** @var string wrong item refund reason */
+	const REASON_WRONG_ITEM = 'WRONG_ITEM';
+
+	/** @var string other refund reason */
+	const REASON_OTHER = 'REFUND_REASON_OTHER';
+
+
 }

--- a/includes/API/Orders/Refund/Request.php
+++ b/includes/API/Orders/Refund/Request.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Orders\Refund;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Orders API refund request object.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Request extends API\Request  {
+
+
+	use API\Traits\Idempotent_Request;
+
+
+}

--- a/tests/integration/API/Orders/Refund/RequestTest.php
+++ b/tests/integration/API/Orders/Refund/RequestTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders\Refund;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Refund\Request;
+
+/**
+ * Tests the API\Orders\Refund\Request class.
+ */
+class RequestTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	public function _before() {
+
+		parent::_before();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Request::__construct() */
+	public function test_constructor() {
+
+		$data = [
+			'reason_code' => Request::REASON_BUYERS_REMORSE,
+		];
+
+		$request = new Request( '368508827392800', $data );
+
+		$this->assertEquals( '/368508827392800/refunds', $request->get_path() );
+		$this->assertEquals( 'POST', $request->get_method() );
+
+		$expected_data                    = $data;
+		$expected_data['idempotency_key'] = $request->get_idempotency_key();
+		$this->assertEquals( $expected_data, $request->get_data() );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `API\Orders\Refund\Request` class.

### Story: [CH 62233](https://app.clubhouse.io/skyverge/story/62233/create-the-refund-order-request-object)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version