### PR TITLE
Update the base API getter to accept an access token

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -328,14 +328,20 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		 *
 		 * @since 2.0.0
 		 *
+		 * @param string $access_token access token to use for this API request
 		 * @return \SkyVerge\WooCommerce\Facebook\API
 		 * @throws Framework\SV_WC_API_Exception
 		 */
-		public function get_api() {
+		public function get_api( $access_token = '' ) {
+
+			// if none provided, use the general access token
+			if ( ! $access_token ) {
+				$access_token = $this->get_connection_handler()->get_access_token();
+			}
 
 			if ( ! is_object( $this->api ) ) {
 
-				if ( ! $this->get_connection_handler()->get_access_token() ) {
+				if ( ! $access_token ) {
 					throw new Framework\SV_WC_API_Exception( __( 'Cannot create the API instance because the access token is missing.', 'facebook-for-woocommerce' ) );
 				}
 
@@ -503,7 +509,11 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Orders/Response.php';
 				}
 
-				$this->api = new SkyVerge\WooCommerce\Facebook\API( $this->get_connection_handler()->get_access_token() );
+				$this->api = new SkyVerge\WooCommerce\Facebook\API( $access_token );
+
+			} else {
+
+				$this->api->set_access_token( $access_token );
 			}
 
 			return $this->api;

--- a/includes/API.php
+++ b/includes/API.php
@@ -41,6 +41,8 @@ class API extends Framework\SV_WC_API_Base {
 	 * Constructor.
 	 *
 	 * @since 2.0.0
+	 *
+	 * @param string $access_token access token to use for API requests
 	 */
 	public function __construct( $access_token ) {
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -58,6 +58,32 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Gets the access token being used for API requests.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_access_token() {
+
+		return $this->access_token;
+	}
+
+
+	/**
+	 * Sets the access token to use for API requests.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $access_token access token to set
+	 */
+	public function set_access_token( $access_token ) {
+
+		$this->access_token = $access_token;
+	}
+
+
+	/**
 	 * Validates a response after it has been parsed and instantiated.
 	 *
 	 * Throws an exception if a rate limit or general API error is included in the response.

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -46,6 +46,24 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
+	/** @see API::get_access_token() */
+	public function test_get_access_token() {
+
+		$this->assertEquals( 'access_token', ( new API( 'access_token' ) )->get_access_token() );
+	}
+
+
+	/** @see API::set_access_token() */
+	public function test_set_access_token() {
+
+		$api = new API( 'access_token' );
+
+		$api->set_access_token( 'new_access_token' );
+
+		$this->assertEquals( 'new_access_token', $api->get_access_token() );
+	}
+
+
 	/**
 	 * @see API::do_post_parse_response_validation()
 	 *

--- a/tests/integration/WC_Facebookcommerce_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Test.php
@@ -21,9 +21,9 @@ class WC_Facebookcommerce_Test extends \Codeception\TestCase\WPTestCase {
 
 		parent::_before();
 
-		if ( ! class_exists( API::class ) ) {
-			require_once 'includes/API.php';
-		}
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( '1234' );
+
+		facebook_for_woocommerce()->get_api();
 	}
 
 
@@ -32,8 +32,6 @@ class WC_Facebookcommerce_Test extends \Codeception\TestCase\WPTestCase {
 
 	/** @see \WC_Facebookcommerce::get_api() */
 	public function test_get_api() {
-
-		facebook_for_woocommerce()->get_connection_handler()->update_access_token( '1234' );
 
 		$this->assertInstanceOf( API::class, facebook_for_woocommerce()->get_api() );
 	}

--- a/tests/integration/WC_Facebookcommerce_Test.php
+++ b/tests/integration/WC_Facebookcommerce_Test.php
@@ -55,6 +55,13 @@ class WC_Facebookcommerce_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see \WC_Facebookcommerce::get_api() */
+	public function test_get_api_with_access_token() {
+
+		$this->assertSame( 'new_access_token', facebook_for_woocommerce()->get_api( 'new_access_token' )->get_access_token() );
+	}
+
+
 	/** @see \WC_Facebookcommerce::get_connection_handler() */
 	public function test_get_connection_handler() {
 


### PR DESCRIPTION
# Summary

Allow passing a specific access token to the API when getting its instance.

### Story: [CH 62622](https://app.clubhouse.io/skyverge/story/62622)
### Release: #1477

## Details

Provides an easy way to set specific access tokens for different types of API requests. The plugin stores a user, system user, and now page access token. While almost all requests need the system user access token, there are a few requests for the Orders API that require the page access token instead. When making those calls, we can specify the token we need.

In the future if we find that there are many instances of needing to pass different tokens in, we can consider dedicated API methods, e.g. `get_catalog_api()` etc...

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version