### PR TITLE
Implement the API::get_new_orders() method

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -575,6 +575,7 @@ class API extends Framework\SV_WC_API_Base {
 	 *
 	 * @param string $page_id page ID
 	 * @return API\Orders\Response
+	 * @throws Framework\SV_WC_API_Exception
 	 */
 	public function get_new_orders( $page_id ) {
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -12,6 +12,7 @@ namespace SkyVerge\WooCommerce\Facebook;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Facebook\API\Orders\Order;
 use SkyVerge\WooCommerce\Facebook\API\Request;
 use SkyVerge\WooCommerce\Facebook\API\Response;
 use SkyVerge\WooCommerce\Facebook\Events\Event;
@@ -564,6 +565,31 @@ class API extends Framework\SV_WC_API_Base {
 		}
 
 		return $next_response;
+	}
+
+
+	/**
+	 * Gets all new orders.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $page_id page ID
+	 * @return API\Orders\Response
+	 */
+	public function get_new_orders( $page_id ) {
+
+		$request_args = [
+			'state' => [
+				Order::STATUS_PROCESSING,
+				Order::STATUS_CREATED,
+			]
+		];
+
+		$request = new API\Orders\Request( $page_id, $request_args );
+
+		$this->set_response_handler( API\Orders\Response::class );
+
+		return $this->perform_request( $request );
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -633,6 +633,46 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see API::get_new_orders() */
+	public function test_get_new_orders() {
+
+		// test will fail if do_remote_request() is not called once
+		$api = $this->make( API::class, [
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
+		] );
+
+		$api->get_new_orders( '1234' );
+
+		$this->assertInstanceOf( API\Orders\Request::class, $api->get_request() );
+		$this->assertEquals( 'GET', $api->get_request()->get_method() );
+		$this->assertEquals( '/1234/commerce_orders', $api->get_request()->get_path() );
+		$this->assertEquals( [], $api->get_request()->get_data() );
+		$expected_params = [
+			'state'  => implode( ',', [
+				API\Orders\Order::STATUS_PROCESSING,
+				API\Orders\Order::STATUS_CREATED,
+			] ),
+			'fields' => implode( ',', [
+				'id',
+				'order_status',
+				'created',
+				'last_updated',
+				'items',
+				'ship_by_date',
+				'merchant_order_id',
+				'channel',
+				'selected_shipping_option',
+				'shipping_address',
+				'estimated_payment_details',
+				'buyer_details',
+			] ),
+		];
+		$this->assertEquals( $expected_params, $api->get_request()->get_params() );
+
+		$this->assertInstanceOf( API\Orders\Response::class, $api->get_response() );
+	}
+
+
 	/**
 	 * @see API::get_new_request()
 	 *


### PR DESCRIPTION
# Summary

This PR implements the `API::get_new_orders()` method.

### Story: [CH 62268](https://app.clubhouse.io/skyverge/story/62268/implement-the-api-get-new-orders-method)
### Release: #1477 

## Details

The retry logic mentioned [here](https://docs.google.com/document/d/1et7Nbp2E2Vwv7HgkyOI-cz2io95ZI8CJhpCiqwdDrM0/edit#heading=h.b61maie1epct) will be added in a separate story.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version