### PR TITLE
Implement the API:: get_order() method

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -595,6 +595,25 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Gets a single order based on its remote ID.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id remote order ID
+	 * @return API\Orders\Read\Response
+	 * @throws Framework\SV_WC_API_Exception
+	 */
+	public function get_order( $remote_id ) {
+
+		$request = new API\Orders\Read\Request( $remote_id );
+
+		$this->set_response_handler( API\Orders\Read\Response::class );
+
+		return $this->perform_request( $request );
+	}
+
+
+	/**
 	 * Returns a new request object.
 	 *
 	 * @since 2.0.0

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -673,6 +673,42 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see API::get_order() */
+	public function test_get_order() {
+
+		// test will fail if do_remote_request() is not called once
+		$api = $this->make( API::class, [
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
+		] );
+
+		$api->get_order( '335211597203390' );
+
+		$this->assertInstanceOf( API\Orders\Read\Request::class, $api->get_request() );
+		$this->assertEquals( 'GET', $api->get_request()->get_method() );
+		$this->assertEquals( '/335211597203390', $api->get_request()->get_path() );
+		$this->assertEquals( [], $api->get_request()->get_data() );
+		$expected_params = [
+			'fields' => implode( ',', [
+				'id',
+				'order_status',
+				'created',
+				'last_updated',
+				'items',
+				'ship_by_date',
+				'merchant_order_id',
+				'channel',
+				'selected_shipping_option',
+				'shipping_address',
+				'estimated_payment_details',
+				'buyer_details',
+			] ),
+		];
+		$this->assertEquals( $expected_params, $api->get_request()->get_params() );
+
+		$this->assertInstanceOf( API\Orders\Read\Response::class, $api->get_response() );
+	}
+
+
 	/**
 	 * @see API::get_new_request()
 	 *


### PR DESCRIPTION
# Summary

This PR implements the `API::get_order()` method.

### Story: [CH 62270](https://app.clubhouse.io/skyverge/story/62270/implement-the-api-get-order-method)
### Release: #1477 

## Details

The retry logic mentioned [here](https://docs.google.com/document/d/1et7Nbp2E2Vwv7HgkyOI-cz2io95ZI8CJhpCiqwdDrM0/edit#heading=h.b61maie1epct) will be added in a separate story.

I've branched off of CH 62268 to avoid conflicts. Please merge that one first.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version