### PR TITLE
Implement the API::acknowledge_order() method

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -614,6 +614,26 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Acknowledges the given order.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id remote order ID
+	 * @param string $merchant_order_reference WC order ID
+	 * @return API\Response
+	 * @throws Framework\SV_WC_API_Exception
+	 */
+	public function acknowledge_order( $remote_id, $merchant_order_reference ) {
+
+		$request = new API\Orders\Acknowledge\Request( $remote_id, $merchant_order_reference );
+
+		$this->set_response_handler( API\Response::class );
+
+		return $this->perform_request( $request );
+	}
+
+
+	/**
 	 * Returns a new request object.
 	 *
 	 * @since 2.0.0

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -709,6 +709,30 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see API::acknowledge_order() */
+	public function test_acknowledge_order() {
+
+		// test will fail if do_remote_request() is not called once
+		$api = $this->make( API::class, [
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
+		] );
+
+		$api->acknowledge_order( '335211597203390', '64241' );
+
+		$this->assertInstanceOf( API\Orders\Acknowledge\Request::class, $api->get_request() );
+		$this->assertEquals( 'POST', $api->get_request()->get_method() );
+		$this->assertEquals( '/335211597203390', $api->get_request()->get_path() );
+		$expected_data = [
+			'merchant_order_reference' => '64241',
+			'idempotency_key'          => $api->get_request()->get_idempotency_key(),
+		];
+		$this->assertEquals( $expected_data, $api->get_request()->get_data() );
+		$this->assertEquals( [], $api->get_request()->get_params() );
+
+		$this->assertInstanceOf( API\Response::class, $api->get_response() );
+	}
+
+
 	/**
 	 * @see API::get_new_request()
 	 *


### PR DESCRIPTION
# Summary

This PR implements the `API::acknowledge_order()` method.

### Story: [CH 62243](https://app.clubhouse.io/skyverge/story/62243/implement-the-api-acknowledge-order-method)
### Release: #1477 

## Details

The retry logic mentioned [here](https://docs.google.com/document/d/1et7Nbp2E2Vwv7HgkyOI-cz2io95ZI8CJhpCiqwdDrM0/edit#heading=h.b61maie1epct) will be added in a separate story.

I've branched off of CH 62270 to avoid conflicts. Please merge that one first.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version