### PR TITLE
Implement the API::fulfill_order() method

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -634,6 +634,28 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Issues a fulfillment request for the given order.
+	 *
+	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/fulfillment-api#attach_shipment
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id remote order ID
+	 * @param array $fulfillment_data fulfillment data to be sent on the request
+	 * @return API\Response
+	 * @throws Framework\SV_WC_API_Exception
+	 */
+	public function fulfill_order( $remote_id, $fulfillment_data ) {
+
+		$request = new API\Orders\Fulfillment\Request( $remote_id, $fulfillment_data );
+
+		$this->set_response_handler( API\Response::class );
+
+		return $this->perform_request( $request );
+	}
+
+
+	/**
 	 * Returns a new request object.
 	 *
 	 * @since 2.0.0


### PR DESCRIPTION
# Summary

This PR implements the `API::fulfill_order()` method.

### Story: [CH 62245](https://app.clubhouse.io/skyverge/story/62245/implement-the-api-fulfill-order-method)
### Release: #1477 

## Details

The retry logic mentioned [here](https://docs.google.com/document/d/1et7Nbp2E2Vwv7HgkyOI-cz2io95ZI8CJhpCiqwdDrM0/edit#heading=h.b61maie1epct) will be added in a separate story.

I've branched off of CH 62243 to avoid conflicts. Please merge that one first.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version