### PR TITLE
Implement the API::cancel_order() method

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -656,6 +656,27 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Cancels the given order.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id remote order ID
+	 * @param string $reason cancellation reason
+	 * @param bool $restock_items whether to restock items remotely
+	 * @return API\Response
+	 * @throws Framework\SV_WC_API_Exception
+	 */
+	public function cancel_order( $remote_id, $reason, $restock_items = true ) {
+
+		$request = new API\Orders\Cancel\Request( $remote_id, $reason, $restock_items );
+
+		$this->set_response_handler( API\Response::class );
+
+		return $this->perform_request( $request );
+	}
+
+
+	/**
 	 * Returns a new request object.
 	 *
 	 * @since 2.0.0

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -773,6 +773,33 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see API::cancel_order() */
+	public function test_cancel_order() {
+
+		// test will fail if do_remote_request() is not called once
+		$api = $this->make( API::class, [
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
+		] );
+
+		$api->cancel_order( '335211597203390', API\Orders\Cancel\Request::REASON_CUSTOMER_REQUESTED, true );
+
+		$this->assertInstanceOf( API\Orders\Cancel\Request::class, $api->get_request() );
+		$this->assertEquals( 'POST', $api->get_request()->get_method() );
+		$this->assertEquals( '/335211597203390/cancellations', $api->get_request()->get_path() );
+		$expected_data = [
+			'cancel_reason'   => [
+				'reason_code' => API\Orders\Cancel\Request::REASON_CUSTOMER_REQUESTED,
+			],
+			'restock_items'   => true,
+			'idempotency_key' => $api->get_request()->get_idempotency_key(),
+		];
+		$this->assertEquals( $expected_data, $api->get_request()->get_data() );
+		$this->assertEquals( [], $api->get_request()->get_params() );
+
+		$this->assertInstanceOf( API\Response::class, $api->get_response() );
+	}
+
+
 	/**
 	 * @see API::get_new_request()
 	 *


### PR DESCRIPTION
# Summary

This PR implements the `API::cancel_order()` method.

### Story: [CH 62247](https://app.clubhouse.io/skyverge/story/62247/implement-the-api-cancel-order-method)
### Release: #1477 

## Details

The retry logic mentioned [here](https://docs.google.com/document/d/1et7Nbp2E2Vwv7HgkyOI-cz2io95ZI8CJhpCiqwdDrM0/edit#heading=h.b61maie1epct) will be added in a separate story.

I've branched off of CH 62245 to avoid conflicts. Please merge that one first.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version