### PR TITLE
Implement the API::add_order_refund() method

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -677,6 +677,28 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Issues a refund request for the given order.
+	 *
+	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/cancellation-refund-api#refund_order
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $remote_id remote order ID
+	 * @param array $refund_data refund data to be sent on the request
+	 * @return API\Response
+	 * @throws Framework\SV_WC_API_Exception
+	 */
+	public function add_order_refund( $remote_id, $refund_data ) {
+
+		$request = new API\Orders\Refund\Request( $remote_id, $refund_data );
+
+		$this->set_response_handler( API\Response::class );
+
+		return $this->perform_request( $request );
+	}
+
+
+	/**
 	 * Returns a new request object.
 	 *
 	 * @since 2.0.0

--- a/includes/API/Orders/Refund/Request.php
+++ b/includes/API/Orders/Refund/Request.php
@@ -50,15 +50,15 @@ class Request extends API\Request  {
 	 * @since 2.1.0-dev.1
 	 *
 	 * @param string $remote_id remote order ID
-	 * @param array $data refund data
+	 * @param array $refund_data refund data
 	 */
-	public function __construct( $remote_id, $data ) {
+	public function __construct( $remote_id, $refund_data ) {
 
 		parent::__construct( "/{$remote_id}/refunds", 'POST' );
 
-		$data['idempotency_key'] = $this->get_idempotency_key();
+		$refund_data['idempotency_key'] = $this->get_idempotency_key();
 
-		$this->set_data( $data );
+		$this->set_data( $refund_data );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR implements the `API::add_order_refund()` method.

### Story: [CH 62249](https://app.clubhouse.io/skyverge/story/62249/implement-the-api-add-order-refund-method)
### Release: #1477 

## Details

The retry logic mentioned [here](https://docs.google.com/document/d/1et7Nbp2E2Vwv7HgkyOI-cz2io95ZI8CJhpCiqwdDrM0/edit#heading=h.b61maie1epct) will be added in a separate story.

I've branched off of CH 62247 to avoid conflicts. Please merge that one first.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version