### PR TITLE
Mark out-of-stock products has hidden in the feed file

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -571,10 +571,6 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 						continue;
 					}
 
-					if ( Products::product_should_be_deleted( $woo_product->woo_product ) ) {
-						continue;
-					}
-
 					// skip if not enabled for sync
 					if ( ! Products::product_should_be_synced( $woo_product->woo_product ) ) {
 						continue;
@@ -737,6 +733,11 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 				$this->no_default_product_count++;
 
 				$product_data['default_product'] = '';
+			}
+
+			// when dealing with the feed file, only set out-of-stock products as hidden
+			if ( Products::product_should_be_deleted( $woo_product->woo_product ) ) {
+				$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 			}
 
 			return $product_data['retailer_id'] . ',' .

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 = 2020.nn.nn - version 2.0.2-dev.1 =
  * Fix - Update connection parameters to use an array to pass the Messenger domain
+ * Fix - Ensure out-of-stock products are marked as such in Facebook when the feed file replacement is run
 
 = 2020.08.17 - version 2.0.1 =
  * Fix - Ensure the configured business name is never empty when connecting to Facebook


### PR DESCRIPTION
# Summary

Instead of omitting these products from the feed file, this PR changes their `visibility` value to `staging` when the Hide out of stock setting is enabled.

### Story: [CH 55890](https://app.clubhouse.io/skyverge/story/55890)
### Release: #1467 

## Details

This prevents an edge case specifically for our users who upgraded to v1.11 (FBE 1.5) and then to v2. In their case, the feed was switched to a full replace schedule, so omitting the products resulted in deleting the products, which preserved the behavior from v1.10.

However, the feed replacement does not delete omitted products from _other sources_, in this case the other source being the new v2 API. So any product that was updated via API again in v2 would not get omitted and thus not get the "out of stock" update when their feed schedule triggers.

## UI Changes

_N/A_

## QA

- Connect the plugin
- Create 2 products, set to sync with Facebook

1. Mark one of the products as Out of stock
1. Manually trigger the feed file generation via action scheduler
    - [x] The feed contains both products
    - [x] The out of stock product's `visibility` is `staging`
    - [x] The in-stock product's `visibility` is `published`

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version