### PR TITLE
Implement the Commerce\Orders::find_local_order() method

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -40,8 +40,21 @@ class Orders {
 	 */
 	public function find_local_order( $remote_id ) {
 
-		// TODO: implement
-		return null;
+		$order_id_array = get_posts( [
+			'post_type'   => 'shop_order',
+			'nopaging'    => true,
+			'numberposts' => 1,
+			'fields'      => 'ids',
+			'post_status' => 'any',
+			'meta_key'    => self::REMOTE_ID_META_KEY,
+			'meta_value'  => $remote_id,
+		] );
+
+		if ( ! empty( $order_id_array ) ) {
+			$order_id = current( $order_id_array );
+		}
+
+		return ! empty( $order_id ) ? wc_get_order( $order_id ) : null;
 	}
 
 

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -40,21 +40,14 @@ class Orders {
 	 */
 	public function find_local_order( $remote_id ) {
 
-		$order_id_array = get_posts( [
-			'post_type'   => 'shop_order',
-			'nopaging'    => true,
-			'numberposts' => 1,
-			'fields'      => 'ids',
-			'post_status' => 'any',
-			'meta_key'    => self::REMOTE_ID_META_KEY,
-			'meta_value'  => $remote_id,
+		$orders = wc_get_orders( [
+			'limit'      => 1,
+			'status'     => 'any',
+			'meta_key'   => self::REMOTE_ID_META_KEY,
+			'meta_value' => $remote_id,
 		] );
 
-		if ( ! empty( $order_id_array ) ) {
-			$order_id = current( $order_id_array );
-		}
-
-		return ! empty( $order_id ) ? wc_get_order( $order_id ) : null;
+		return ! empty( $orders ) ? current( $orders ) : null;
 	}
 
 

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -27,8 +27,6 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 		$order->update_meta_data( Orders::REMOTE_ID_META_KEY, $remote_id );
 		$order->save_meta_data();
 
-		$order = wc_get_order( $order->get_id() );
-
 		$this->assertInstanceOf( \WC_Order::class, $this->get_commerce_orders_handler()->find_local_order( $remote_id ) );
 		$this->assertEquals( $order->get_id(), $this->get_commerce_orders_handler()->find_local_order( $remote_id )->get_id() );
 	}

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Commerce;
+use SkyVerge\WooCommerce\Facebook\Commerce\Orders;
+
+/**
+ * Tests the general Commerce orders handler class.
+ */
+class OrdersTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Orders::find_local_order() */
+	public function test_find_local_order_found() {
+
+		$order = new \WC_Order();
+		$order->save();
+
+		$remote_id = '335211597203390';
+
+		$order->update_meta_data( Orders::REMOTE_ID_META_KEY, $remote_id );
+		$order->save_meta_data();
+
+		$order = wc_get_order( $order->get_id() );
+
+		$this->assertInstanceOf( \WC_Order::class, $this->get_commerce_orders_handler()->find_local_order( $remote_id ) );
+		$this->assertEquals( $order->get_id(), $this->get_commerce_orders_handler()->find_local_order( $remote_id )->get_id() );
+	}
+
+
+	/** @see Orders::find_local_order() */
+	public function test_find_local_order_not_found() {
+
+		$order = new \WC_Order();
+		$order->save();
+
+		$remote_id           = '435211597203390';
+		$different_remote_id = '335211597203390';
+
+		$order->update_meta_data( Orders::REMOTE_ID_META_KEY, $different_remote_id );
+		$order->save_meta_data();
+
+		$this->assertNull( $this->get_commerce_orders_handler()->find_local_order( $remote_id ) );
+	}
+
+
+	/** Helper methods **************************************************************************************************/
+
+
+	/**
+	 * Gets the Commerce orders handler instance.
+	 *
+	 * @return Orders
+	 */
+	private function get_commerce_orders_handler() {
+
+		$commerce_handler = new Commerce();
+
+		return $commerce_handler->get_orders_handler();
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR implements the `Commerce\Orders::find_local_order()` method.

### Story: [CH 62260](https://app.clubhouse.io/skyverge/story/62260/implement-the-commerce-orders-find-local-order-method)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version