### PR TITLE
Implement the order update interval method

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -103,8 +103,25 @@ class Orders {
 	 */
 	public function get_order_update_interval() {
 
-		// TODO: implement
-		return 5 * MINUTE_IN_SECONDS;
+		$default_interval = 5 * MINUTE_IN_SECONDS;
+
+		/**
+		 * Filters the interval between querying Facebook for new or updated orders.
+		 *
+		 * @since 2.1.0-dev.1
+		 *
+		 * @param int $interval interval in seconds. Defaults to 5 minutes, and the minimum interval is 120 seconds.
+		 */
+		$interval = apply_filters( 'wc_facebook_commerce_order_update_interval', $default_interval );
+
+		// if given a valid number, ensure it's 120 seconds at a minimum
+		if ( is_numeric( $interval ) ) {
+			$interval = max( 2 * MINUTE_IN_SECONDS, $interval );
+		} else {
+			$interval = $default_interval; // invalid values should get the default
+		}
+
+		return $interval;
 	}
 
 

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -16,6 +16,42 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
+	/** @see Orders::get_order_update_interval() */
+	public function test_get_order_update_interval() {
+
+		$this->assertSame( 300, $this->get_commerce_orders_handler()->get_order_update_interval() );
+	}
+
+
+	/**
+	 * @see Orders::get_order_update_interval()
+	 *
+	 * @param int $filter_value filtered interval value
+	 * @param int $expected expected return value
+	 *
+	 * @dataProvider provider_get_order_update_interval_filtered
+	 */
+	public function test_get_order_update_interval_filtered( $filter_value, $expected ) {
+
+		add_filter( 'wc_facebook_commerce_order_update_interval', function() use ( $filter_value )  {
+			return $filter_value;
+		} );
+
+		$this->assertSame( $expected, $this->get_commerce_orders_handler()->get_order_update_interval() );
+	}
+
+
+	/** @see test_get_order_update_interval_filtered */
+	public function provider_get_order_update_interval_filtered() {
+
+		return [
+			'filter value longer'    => [ 600, 600 ],
+			'filter value too short' => [ 5, 120 ],
+			'filter value invalid'   => [ '1 billion seconds', 300 ],
+		];
+	}
+
+
 	/** @see Orders::find_local_order() */
 	public function test_find_local_order_found() {
 


### PR DESCRIPTION
# Summary

This PR implements the `Commerce\Orders::get_order_update_interval()` method.

### Story: [CH 62266](https://app.clubhouse.io/skyverge/story/62266)
### Release: #1477 

## Details

We allow filtering of this method, with a restriction of a minimum of 2 minutes filtered. If the filtered value is totally invalid, then we fall back to the default.

## QA

- [ ] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version