### PR TITLE
Implement the Commerce\Orders::create_local_order() method

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -58,12 +58,18 @@ class Orders {
 	 *
 	 * @param Order $remote_order Orders API order object
 	 * @return \WC_Order
-	 * @throws SV_WC_Plugin_Exception
+	 * @throws SV_WC_Plugin_Exception|\WC_Data_Exception
 	 */
 	public function create_local_order( Order $remote_order ) {
 
-		// TODO: implement
-		return null;
+		$local_order = new \WC_Order();
+		$local_order->set_created_via( $remote_order->get_channel() );
+		$local_order->set_status( 'pending' );
+		$local_order->save();
+
+		$this->update_local_order( $remote_order, $local_order );
+
+		return $local_order;
 	}
 
 

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -67,7 +67,7 @@ class Orders {
 		$local_order->set_status( 'pending' );
 		$local_order->save();
 
-		$this->update_local_order( $remote_order, $local_order );
+		$local_order = $this->update_local_order( $remote_order, $local_order );
 
 		return $local_order;
 	}

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -60,7 +60,7 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @see Orders::create_local_order() */
-	public function test_create_local_order_fb_processing() {
+	public function test_create_local_order() {
 
 		$product = $this->tester->get_product();
 
@@ -71,21 +71,6 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertInstanceOf( \WC_Order::class, $local_order );
 		$this->assertEquals( $response_data['channel'], $local_order->get_created_via() );
 		$this->assertEquals( 'pending', $local_order->get_status() );
-	}
-
-
-	/** @see Orders::create_local_order() */
-	public function test_create_local_order_created() {
-
-		$product = $this->tester->get_product();
-
-		$response_data = $this->get_test_response_data( Order::STATUS_CREATED, (string) $product->get_id() );
-		$remote_order  = new Order( $response_data );
-
-		$local_order = $this->get_commerce_orders_handler()->create_local_order( $remote_order );
-		$this->assertInstanceOf( \WC_Order::class, $local_order );
-		$this->assertEquals( $response_data['channel'], $local_order->get_created_via() );
-		$this->assertEquals( 'processing', $local_order->get_status() );
 	}
 
 

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace SkyVerge\WooCommerce\Facebook\Tests\Commerce;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Order;
 use SkyVerge\WooCommerce\Facebook\Commerce;
 use SkyVerge\WooCommerce\Facebook\Commerce\Orders;
 
@@ -11,6 +14,14 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 	/** @var \IntegrationTester */
 	protected $tester;
+
+
+	public function _before() {
+
+		if ( ! class_exists( SkyVerge\WooCommerce\Facebook\API\Orders\Order::class ) ) {
+			require_once facebook_for_woocommerce()->get_plugin_path() . '/includes/API/Orders/Order.php';
+		}
+	}
 
 
 	/** Test methods **************************************************************************************************/
@@ -48,6 +59,36 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Orders::create_local_order() */
+	public function test_create_local_order_fb_processing() {
+
+		$product = $this->tester->get_product();
+
+		$response_data = $this->get_test_response_data( Order::STATUS_PROCESSING, (string) $product->get_id() );
+		$remote_order  = new Order( $response_data );
+
+		$local_order = $this->get_commerce_orders_handler()->create_local_order( $remote_order );
+		$this->assertInstanceOf( \WC_Order::class, $local_order );
+		$this->assertEquals( $response_data['channel'], $local_order->get_created_via() );
+		$this->assertEquals( 'pending', $local_order->get_status() );
+	}
+
+
+	/** @see Orders::create_local_order() */
+	public function test_create_local_order_created() {
+
+		$product = $this->tester->get_product();
+
+		$response_data = $this->get_test_response_data( Order::STATUS_CREATED, (string) $product->get_id() );
+		$remote_order  = new Order( $response_data );
+
+		$local_order = $this->get_commerce_orders_handler()->create_local_order( $remote_order );
+		$this->assertInstanceOf( \WC_Order::class, $local_order );
+		$this->assertEquals( $response_data['channel'], $local_order->get_created_via() );
+		$this->assertEquals( 'processing', $local_order->get_status() );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 
@@ -61,6 +102,105 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 		$commerce_handler = new Commerce();
 
 		return $commerce_handler->get_orders_handler();
+	}
+
+
+	/**
+	 * Gets the response test data.
+	 *
+	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/order-api#get_orders
+	 *
+	 * @param string $order_status order status
+	 * @param string $product_retailer_id WC product ID
+	 * @return array
+	 */
+	private function get_test_response_data( $order_status = Order::STATUS_CREATED, $product_retailer_id = '' ) {
+
+		return [
+			'id'                        => '335211597203390',
+			'order_status'              => [
+				'state' => $order_status,
+			],
+			'created'                   => '2019-01-14T19:17:31+00:00',
+			'last_updated'              => '2019-01-14T19:47:35+00:00',
+			'items'                     => [
+				0 => [
+					'id'             => '2082596341811586',
+					'product_id'     => '1213131231',
+					'retailer_id'    => ! empty( $product_retailer_id ) ? $product_retailer_id : 'external_product_1234',
+					'quantity'       => 2,
+					'price_per_unit' => [
+						'amount'   => '20.00',
+						'currency' => 'USD',
+					],
+					'tax_details'    => [
+						'estimated_tax' => [
+							'amount'   => '0.30',
+							'currency' => 'USD',
+						],
+						'captured_tax'  => [
+							'total_tax' => [
+								'amount'   => '0.30',
+								'currency' => 'USD',
+							],
+						],
+					],
+				],
+			],
+			'ship_by_date'              => '2019-01-16',
+			'merchant_order_id'         => '46192',
+			'channel'                   => 'Instagram',
+			'selected_shipping_option'  => [
+				'name'                    => 'Standard',
+				'price'                   => [
+					'amount'   => '10.00',
+					'currency' => 'USD',
+				],
+				'calculated_tax'          => [
+					'amount'   => '0.15',
+					'currency' => 'USD',
+				],
+				'estimated_shipping_time' => [
+					'min_days' => 3,
+					'max_days' => 15,
+				],
+			],
+			'shipping_address'          => [
+				'name'        => 'ABC company',
+				'street1'     => '123 Main St',
+				'street2'     => 'Unit 200',
+				'city'        => 'Boston',
+				'state'       => 'MA',
+				'postal_code' => '02110',
+				'country'     => 'US',
+			],
+			'estimated_payment_details' => [
+				'subtotal'     => [
+					'items'    => [
+						'amount'   => '20.00',
+						'currency' => 'USD',
+					],
+					'shipping' => [
+						'amount'   => '10.00',
+						'currency' => 'USD',
+					],
+				],
+				'tax'          => [
+					'amount'   => '0.45',
+					'currency' => 'USD',
+				],
+				'total_amount' => [
+					'amount'   => '20.45',
+					'currency' => 'USD',
+				],
+				'tax_remitted' => true,
+			],
+			'buyer_details'             => [
+				'name'                     => 'John Doe',
+				'email'                    => 'johndoe@example.com',
+				'email_remarketing_option' => false,
+			],
+		];
 	}
 
 


### PR DESCRIPTION
# Summary

This PR implements the `Commerce\Orders::create_local_order()` method.

### Story: [CH 62264](https://app.clubhouse.io/skyverge/story/62264/implement-the-commerce-orders-create-local-order-method)
### Release: #1477 

## Details

Branched off CH 62262, please merge that one first.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version