### PR TITLE
Implement the schedule local orders update method

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -144,6 +144,8 @@ class Orders {
 
 		// schedule a recurring ACTION_FETCH_ORDERS action, if not already scheduled
 		add_action( 'init', [ $this, 'schedule_local_orders_update' ] );
+
+		add_action( self::ACTION_FETCH_ORDERS, [ $this, 'update_local_orders' ] );
 	}
 
 

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -31,6 +31,17 @@ class Orders {
 
 
 	/**
+	 * Orders constructor.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function __construct() {
+
+		$this->add_hooks();
+	}
+
+
+	/**
 	 * Finds a local order based on the Commerce ID stored in REMOTE_ID_META_KEY.
 	 *
 	 * @since 2.1.0-dev.1

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -131,7 +131,8 @@ class Orders {
 	 */
 	public function add_hooks() {
 
-		// TODO: implement
+		// schedule a recurring ACTION_FETCH_ORDERS action, if not already scheduled
+		add_action( 'init', [ $this, 'schedule_local_orders_update' ] );
 	}
 
 

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -115,7 +115,12 @@ class Orders {
 	 */
 	public function schedule_local_orders_update() {
 
-		// TODO: implement
+		if ( false === as_next_scheduled_action( self::ACTION_FETCH_ORDERS, [], \WC_Facebookcommerce::PLUGIN_ID ) ) {
+
+			$interval = $this->get_order_update_interval();
+
+			as_schedule_recurring_action( time() + $interval, $interval, self::ACTION_FETCH_ORDERS, [], \WC_Facebookcommerce::PLUGIN_ID );
+		}
 	}
 
 

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -122,6 +122,8 @@ class Orders {
 	/**
 	 * Schedules a recurring ACTION_FETCH_ORDERS action, if not already scheduled.
 	 *
+	 * @internal
+	 *
 	 * @since 2.1.0-dev.1
 	 */
 	public function schedule_local_orders_update() {

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -27,13 +27,6 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
-	/** @see Orders::schedule_local_orders_update() */
-	public function test_schedule_local_orders_update() {
-
-		$this->assertNotFalse( as_next_scheduled_action( Orders::ACTION_FETCH_ORDERS, [], \WC_Facebookcommerce::PLUGIN_ID ) );
-	}
-
-
 	/** @see Orders::find_local_order() */
 	public function test_find_local_order_found() {
 
@@ -114,6 +107,13 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 			'filter value too short' => [ 5, 120 ],
 			'filter value invalid'   => [ '1 billion seconds', 300 ],
 		];
+	}
+
+
+	/** @see Orders::schedule_local_orders_update() */
+	public function test_schedule_local_orders_update() {
+
+		$this->assertNotFalse( as_next_scheduled_action( Orders::ACTION_FETCH_ORDERS, [], \WC_Facebookcommerce::PLUGIN_ID ) );
 	}
 
 

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -16,6 +16,13 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
+	/** @see Orders::schedule_local_orders_update() */
+	public function test_schedule_local_orders_update() {
+
+		$this->assertNotFalse( as_next_scheduled_action( Orders::ACTION_FETCH_ORDERS, [], \WC_Facebookcommerce::PLUGIN_ID ) );
+	}
+
+
 	/** @see Orders::find_local_order() */
 	public function test_find_local_order_found() {
 


### PR DESCRIPTION
# Summary

This PR implements the `Commerce\Orders::schedule_local_orders_update()` method.

### Story: [CH 62272](https://app.clubhouse.io/skyverge/story/62272)
### Release: #1477 

## QA

- [x] Integrations test pass

- [x] In Scheduled actions, the new action has been scheduled for every 5 minutes

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version