### PR TITLE
Implement the update local orders callback method

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -124,7 +124,7 @@ class Orders {
 					$local_order = $this->update_local_order( $remote_order, $local_order );
 				}
 
-			} catch ( SV_WC_Plugin_Exception $exception ) {
+			} catch ( \Exception $exception ) {
 
 				if ( ! empty( $local_order ) ) {
 					// add note to order

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -101,7 +101,7 @@ class Orders {
 
 		try {
 
-			$response = facebook_for_woocommerce()->get_api()->get_new_orders( $page_id );
+			$response = facebook_for_woocommerce()->get_api( facebook_for_woocommerce()->get_connection_handler()->get_page_access_token() )->get_new_orders( $page_id );
 
 		} catch ( SV_WC_API_Exception $exception ) {
 
@@ -140,7 +140,7 @@ class Orders {
 
 				// acknowledge the order
 				try {
-					facebook_for_woocommerce()->get_api()->acknowledge_order( $remote_order->get_id(), $local_order->get_id() );
+					facebook_for_woocommerce()->get_api( facebook_for_woocommerce()->get_connection_handler()->get_page_access_token() )->acknowledge_order( $remote_order->get_id(), $local_order->get_id() );
 				} catch ( SV_WC_API_Exception $exception ) {
 					$local_order->add_order_note( 'Error acknowledging the order: ' . $exception->getMessage() );
 				}

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -136,7 +136,7 @@ class Orders {
 				return;
 			}
 
-			if ( Order::STATUS_CREATED === $remote_order->get_status() ) {
+			if ( ! empty( $local_order ) && Order::STATUS_CREATED === $remote_order->get_status() ) {
 
 				// acknowledge the order
 				try {

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -11,6 +11,7 @@
 namespace SkyVerge\WooCommerce\Facebook\Commerce;
 
 use SkyVerge\WooCommerce\Facebook\API\Orders\Order;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Exception;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Plugin_Exception;
 
 defined( 'ABSPATH' ) or exit;
@@ -96,7 +97,43 @@ class Orders {
 	 */
 	public function update_local_orders() {
 
-		// TODO: implement
+		$page_id = facebook_for_woocommerce()->get_integration()->get_facebook_page_id();
+
+		try {
+
+			$response = facebook_for_woocommerce()->get_api()->get_new_orders( $page_id );
+
+		} catch ( SV_WC_API_Exception $exception ) {
+
+			facebook_for_woocommerce()->log( 'Error fetching Commerce orders from the Orders API: ' . $exception->getMessage() );
+
+			return;
+		}
+
+		$remote_orders = $response->get_orders();
+
+		foreach ( $remote_orders as $remote_order ) {
+
+			$local_order = $this->find_local_order( $remote_order->get_id() );
+
+			try {
+
+				if ( empty( $local_order ) ) {
+					$local_order = $this->create_local_order( $remote_order );
+				} else {
+					$local_order = $this->update_local_order( $remote_order, $local_order );
+				}
+
+			} catch ( SV_WC_Plugin_Exception $exception ) {
+
+				if ( ! empty( $local_order ) ) {
+					// add note to order
+					$local_order->add_order_note( 'Error updating local order from Commerce order from the Orders API: ' . $exception->getMessage() );
+				} else {
+					facebook_for_woocommerce()->log( 'Error creating local order from Commerce order from the Orders API: ' . $exception->getMessage() );
+				}
+			}
+		}
 	}
 
 

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -133,7 +133,7 @@ class Orders {
 					facebook_for_woocommerce()->log( 'Error creating local order from Commerce order from the Orders API: ' . $exception->getMessage() );
 				}
 
-				return;
+				continue;
 			}
 
 			if ( ! empty( $local_order ) && Order::STATUS_CREATED === $remote_order->get_status() ) {

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -132,6 +132,18 @@ class Orders {
 				} else {
 					facebook_for_woocommerce()->log( 'Error creating local order from Commerce order from the Orders API: ' . $exception->getMessage() );
 				}
+
+				return;
+			}
+
+			if ( Order::STATUS_CREATED === $remote_order->get_status() ) {
+
+				// acknowledge the order
+				try {
+					facebook_for_woocommerce()->get_api()->acknowledge_order( $remote_order->get_id(), $local_order->get_id() );
+				} catch ( SV_WC_API_Exception $exception ) {
+					$local_order->add_order_note( 'Error acknowledging the order: ' . $exception->getMessage() );
+				}
 			}
 		}
 	}

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -114,10 +114,9 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 		$response_data = $this->get_test_response_data( Order::STATUS_CREATED, (string) $product->get_id() );
 
-		// mock the API to return a test response and so that the test fails if acknowledge_order() is not called once
+		// mock the API to return a test response
 		$api = $this->make( API::class, [
 			'get_new_orders' => new API\Orders\Response( json_encode( [ 'data' => [ $response_data ] ] ) ),
-			'acknowledge_order' => \Codeception\Stub\Expected::once(),
 		] );
 
 		// replace the API property
@@ -148,10 +147,9 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 		$order->add_meta_data( Orders::REMOTE_ID_META_KEY, $remote_id );
 		$order->save_meta_data();
 
-		// mock the API to return a test response and so that the test fails if acknowledge_order() is not called once
+		// mock the API to return a test response
 		$api = $this->make( API::class, [
 			'get_new_orders' => new API\Orders\Response( json_encode( [ 'data' => [ $response_data ] ] ) ),
-			'acknowledge_order' => \Codeception\Stub\Expected::once(),
 		] );
 
 		// replace the API property
@@ -169,6 +167,28 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Orders::update_local_orders() */
+	public function test_update_local_orders_acknowledge() {
+
+		$product = $this->tester->get_product();
+
+		$response_data = $this->get_test_response_data( Order::STATUS_CREATED, (string) $product->get_id() );
+
+		// mock the API to return a test response and so that the test fails if acknowledge_order() is not called once
+		$api = $this->make( API::class, [
+			'get_new_orders'    => new API\Orders\Response( json_encode( [ 'data' => [ $response_data ] ] ) ),
+			'acknowledge_order' => \Codeception\Stub\Expected::once(),
+		] );
+
+		// replace the API property
+		$property = new ReflectionProperty( \WC_Facebookcommerce::class, 'api' );
+		$property->setAccessible( true );
+		$property->setValue( facebook_for_woocommerce(), $api );
+
+		$this->get_commerce_orders_handler()->update_local_orders();
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 
@@ -179,9 +199,7 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	private function get_commerce_orders_handler() {
 
-		$commerce_handler = new Commerce();
-
-		return $commerce_handler->get_orders_handler();
+		return facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler();
 	}
 
 

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -74,6 +74,10 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Orders::update_local_orders() */
+	public function test_update_local_orders_error_fetching() {
+
+
 	/** Helper methods **************************************************************************************************/
 
 

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -112,11 +112,12 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 		$product = $this->tester->get_product();
 
-		$response_data = $this->get_test_response_data( Order::STATUS_PROCESSING, (string) $product->get_id() );
+		$response_data = $this->get_test_response_data( Order::STATUS_CREATED, (string) $product->get_id() );
 
-		// mock the API to return a test response
+		// mock the API to return a test response and so that the test fails if acknowledge_order() is not called once
 		$api = $this->make( API::class, [
 			'get_new_orders' => new API\Orders\Response( json_encode( [ 'data' => [ $response_data ] ] ) ),
+			'acknowledge_order' => \Codeception\Stub\Expected::once(),
 		] );
 
 		// replace the API property
@@ -141,15 +142,16 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 		$order = new \WC_Order();
 		$order->save();
 
-		$response_data = $this->get_test_response_data( Order::STATUS_PROCESSING, (string) $product->get_id(), (string) $order->get_id() );
+		$response_data = $this->get_test_response_data( Order::STATUS_CREATED, (string) $product->get_id(), (string) $order->get_id() );
 
 		$remote_id = $response_data['id'];
 		$order->add_meta_data( Orders::REMOTE_ID_META_KEY, $remote_id );
 		$order->save_meta_data();
 
-		// mock the API to return a test response
+		// mock the API to return a test response and so that the test fails if acknowledge_order() is not called once
 		$api = $this->make( API::class, [
 			'get_new_orders' => new API\Orders\Response( json_encode( [ 'data' => [ $response_data ] ] ) ),
+			'acknowledge_order' => \Codeception\Stub\Expected::once(),
 		] );
 
 		// replace the API property


### PR DESCRIPTION
# Summary

This PR implements the `Commerce\Orders::update_local_orders()` method.

### Story: [CH 62692](https://app.clubhouse.io/skyverge/story/62692/implement-the-update-local-orders-callback-method)
### Release: #1477 

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version