### PR TITLE
Implement the fulfill order method

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -188,6 +188,12 @@ class Orders {
 	/**
 	 * Fulfills an order via API.
 	 *
+	 * In addition to the exceptions we throw for missing data, the API request will also fail if:
+	 * - The stored remote ID is invalid
+	 * - The order has an item with a retailer ID that was not originally part of the order
+	 * - An item has a different quantity than what was originally ordered
+	 * - The remote order was already fulfilled
+	 *
 	 * @since 2.1.0-dev.1
 	 *
 	 * @param \WC_Order $order order object
@@ -197,7 +203,52 @@ class Orders {
 	 */
 	public function fulfill_order( \WC_Order $order, $tracking_number, $carrier ) {
 
-		// TODO: implement
+		try {
+
+			$remote_id = $order->get_meta( self::REMOTE_ID_META_KEY );
+
+			if ( ! $remote_id ) {
+				throw new SV_WC_Plugin_Exception( __( 'Remote ID not found.', 'facebook-for-woocommerce' ) );
+			}
+
+			$items = [];
+
+			/** @var \WC_Order_Item_Product $item */
+			foreach ( $order->get_items() as $item ) {
+
+				if ( $product = $item->get_product() ) {
+
+					$items[] = [
+						'retailer_id' => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
+						'quantity'    => $item->get_quantity(),
+					];
+				}
+			}
+
+			if ( empty( $items ) ) {
+				throw new SV_WC_Plugin_Exception( __( 'No valid Facebook products were found.', 'facebook-for-woocommerce' ) );
+			}
+
+			$fulfillment_data = [
+				'items'         => $items,
+				'tracking_info' => [
+					'carrier'         => $carrier,
+					'tracking_number' => $tracking_number,
+				],
+			];
+
+			$plugin = facebook_for_woocommerce();
+
+			$plugin->get_api( $plugin->get_connection_handler()->get_page_access_token() )->fulfill_order( $remote_id, $fulfillment_data );
+
+			$order->add_order_note( __( 'Remote order fulfilled.', 'facebook-for-woocommerce' ) );
+
+		} catch ( SV_WC_Plugin_Exception $exception ) {
+
+			$order->add_order_note( sprintf( __( 'Remote order could not be fulfilled. %s', 'facebook-for-woocommerce' ), $exception->getMessage() ) );
+
+			throw $exception;
+		}
 	}
 
 

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -189,6 +189,71 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Orders::fulfill_order() */
+	public function test_fulfill_order_no_remote_id() {
+
+		$order = new \WC_Order();
+		$order->save();
+
+		$this->expectException( SV_WC_Plugin_Exception::class );
+		$this->expectExceptionMessage( 'Remote ID not found.' );
+
+		$this->get_commerce_orders_handler()->fulfill_order( $order, '1234', 'FEDEX' );
+	}
+
+
+	/** @see Orders::fulfill_order() */
+	public function test_fulfill_order_no_valid_items() {
+
+		$order = new \WC_Order();
+
+		$item = new \WC_Order_Item_Product();
+		$item->set_name( 'Test' );
+		$item->set_quantity( 2 );
+		$item->set_total( 1.00 );
+
+		$order->add_item( $item );
+		$order->update_meta_data( Orders::REMOTE_ID_META_KEY, '1234' );
+		$order->save();
+
+		$this->expectException( SV_WC_Plugin_Exception::class );
+		$this->expectExceptionMessage( 'No valid Facebook products were found.' );
+
+		$this->get_commerce_orders_handler()->fulfill_order( $order, '1234', 'FEDEX' );
+	}
+
+
+	/** @see Orders::fulfill_order() */
+	public function test_fulfill_order() {
+
+		$product = $this->tester->get_product();
+
+		$order = new \WC_Order();
+
+		$item = new \WC_Order_Item_Product();
+		$item->set_name( 'Test' );
+		$item->set_quantity( 2 );
+		$item->set_total( 1.00 );
+		$item->set_product( $product );
+
+		$order->add_item( $item );
+		$order->update_meta_data( Orders::REMOTE_ID_META_KEY, '1234' );
+		$order->save();
+
+		// mock the API to return a test response
+		$api = $this->make( API::class, [
+			'fulfill_order' => new API\Orders\Response( json_encode( [ 'success' => true ] ) ),
+		] );
+
+		// replace the API property
+		$property = new ReflectionProperty( \WC_Facebookcommerce::class, 'api' );
+		$property->setAccessible( true );
+		$property->setValue( facebook_for_woocommerce(), $api );
+
+		$this->get_commerce_orders_handler()->fulfill_order( $order, '1234', 'FEDEX' );
+	}
+
+
 	/** Helper methods **************************************************************************************************/
 
 


### PR DESCRIPTION
# Summary

Implements the `Commerce\Orders::fulfill_order()` method.

### Story: [CH 62251](https://app.clubhouse.io/skyverge/story/62251)
### Release: #1477 

## Details

Based off of #1520 to avoid conflicts - do not merge until that PR is merged.

Note: the implementation originally had us validate the carrier value as part of this, but we'll be instead implementing the `Utilities\Shipment` class in the frontend implementation and will add the validation at that time. The story & implementation docs have already been updated to reflect this.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version