### PR TITLE
Add the full acknowledge endpoint URL

### DIFF
--- a/includes/API/Orders/Acknowledge/Request.php
+++ b/includes/API/Orders/Acknowledge/Request.php
@@ -35,7 +35,7 @@ class Request extends API\Request  {
 	 */
 	public function __construct( $remote_id, $merchant_order_reference ) {
 
-		parent::__construct( "/{$remote_id}", 'POST' );
+		parent::__construct( "/{$remote_id}/acknowledge_order", 'POST' );
 
 		$this->set_data( [
 			'merchant_order_reference' => $merchant_order_reference,

--- a/tests/integration/API/Orders/Acknowledge/RequestTest.php
+++ b/tests/integration/API/Orders/Acknowledge/RequestTest.php
@@ -34,7 +34,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 
 		$request = new Request( '368508827392800', '63135' );
 
-		$this->assertEquals( '/368508827392800', $request->get_path() );
+		$this->assertEquals( '/368508827392800/acknowledge_order', $request->get_path() );
 		$this->assertEquals( 'POST', $request->get_method() );
 
 		$expected_data = [


### PR DESCRIPTION
# Summary

Adds the required `/acknowledge_order` endpoint to the request URL.

### Story: [CH 63037](https://app.clubhouse.io/skyverge/story/63037)
### Release: #1477 

## Details

Implementation doc corrected as well.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version