### PR TITLE
Implement rate limit and delay handling

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -96,7 +96,7 @@ class API extends Framework\SV_WC_API_Base {
 	public function perform_request( $request ) {
 
 		$rate_limit_id   = $request::get_rate_limit_id();
-		$delay_timestamp = $this->get_rate_limit_delay( $request::get_rate_limit_id() );
+		$delay_timestamp = $this->get_rate_limit_delay( $rate_limit_id );
 
 		// if there is a delayed timestamp in the future, throw an exception
 		if ( $delay_timestamp >= time() ) {

--- a/includes/API.php
+++ b/includes/API.php
@@ -144,6 +144,32 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Handles a throttled API request.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $rate_limit_id ID for the API request
+	 * @param int $timestamp timestamp until the delay is over
+	 * @throws API\Exceptions\Request_Limit_Reached
+	 */
+	private function handle_throttled_request( $rate_limit_id, $timestamp ) {
+
+		if ( time() > $timestamp ) {
+			return;
+		}
+
+		$exception = new API\Exceptions\Request_Limit_Reached( "{$rate_limit_id} requests are currently throttled.", 401 );
+
+		$date_time = new \DateTime();
+		$date_time->setTimestamp( $timestamp );
+
+		$exception->set_throttle_end( $date_time );
+
+		throw $exception;
+	}
+
+
+	/**
 	 * Gets the FBE installation IDs.
 	 *
 	 * @since 2.0.0

--- a/includes/API.php
+++ b/includes/API.php
@@ -85,6 +85,34 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Performs an API request.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param API\Request $request request object
+	 * @return API\Response
+	 * @throws API\Exceptions\Request_Limit_Reached|Framework\SV_WC_API_Exception
+	 */
+	public function perform_request( $request ) {
+
+		$rate_limit_id   = $request::get_rate_limit_id();
+		$delay_timestamp = $this->get_rate_limit_delay( $request::get_rate_limit_id() );
+
+		// if there is a delayed timestamp in the future, throw an exception
+		if ( $delay_timestamp >= time() ) {
+
+			$this->handle_throttled_request( $rate_limit_id, $delay_timestamp );
+
+		} else {
+
+			$this->set_rate_limit_delay( $rate_limit_id, 0 );
+		}
+
+		return parent::perform_request( $request );
+	}
+
+
+	/**
 	 * Validates a response after it has been parsed and instantiated.
 	 *
 	 * Throws an exception if a rate limit or general API error is included in the response.

--- a/includes/API/Catalog/Product_Group/Products/Read/Request.php
+++ b/includes/API/Catalog/Product_Group/Products/Read/Request.php
@@ -41,4 +41,17 @@ class Request extends API\Request {
 	}
 
 
+	/**
+	 * Gets the rate limit ID.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'ads_management';
+	}
+
+
 }

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -23,19 +23,6 @@ class Request extends API\Request {
 
 
 	/**
-	 * Gets the ID of this request for rate limiting purposes.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @return string
-	 */
-	public static function get_rate_limit_id() {
-
-		return 'wc_facebook_ads_management_api_request';
-	}
-
-
-	/**
 	 * API request constructor.
 	 *
 	 * @since 2.0.0

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -23,6 +23,19 @@ class Request extends API\Request {
 
 
 	/**
+	 * Gets the rate limit ID.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'ads_management';
+	}
+
+
+	/**
 	 * API request constructor.
 	 *
 	 * @since 2.0.0

--- a/includes/API/Catalog/Request.php
+++ b/includes/API/Catalog/Request.php
@@ -23,6 +23,19 @@ class Request extends API\Request  {
 
 
 	/**
+	 * Gets the rate limit ID.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'ads_management';
+	}
+
+
+	/**
 	 * API request constructor.
 	 *
 	 * @since 2.0.0

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -30,7 +30,7 @@ class Request extends API\Request  {
 
 
 	/**
-	 * Gets the ID of this request for rate limiting purposes.
+	 * Gets the rate limit ID.
 	 *
 	 * @since 2.0.0
 	 *
@@ -38,7 +38,7 @@ class Request extends API\Request  {
 	 */
 	public static function get_rate_limit_id() {
 
-		return 'ads_management_api_request';
+		return 'ads_management';
 	}
 
 

--- a/includes/API/Exceptions/Request_Limit_Reached.php
+++ b/includes/API/Exceptions/Request_Limit_Reached.php
@@ -22,4 +22,27 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 class Request_Limit_Reached extends Framework\SV_WC_API_Exception {
 
 
+	/** @var \DateTime date & time representing when the request limit will be lifted */
+	protected $throttle_end;
+
+
+	/**
+	 * Gets the estimated throttle end.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return \DateTime|null
+	 */
+	public function get_throttle_end() {
+
+		return $this->throttle_end;
+	}
+
+
+	public function set_throttle_end( \DateTime $date_time ) {
+
+		$this->throttle_end = $date_time;
+	}
+
+
 }

--- a/includes/API/Exceptions/Request_Limit_Reached.php
+++ b/includes/API/Exceptions/Request_Limit_Reached.php
@@ -39,6 +39,13 @@ class Request_Limit_Reached extends Framework\SV_WC_API_Exception {
 	}
 
 
+	/**
+	 * Sets the estimated throttle end.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \DateTime $date_time date time object representing when the throttle will end
+	 */
 	public function set_throttle_end( \DateTime $date_time ) {
 
 		$this->throttle_end = $date_time;

--- a/includes/API/Orders/Acknowledge/Request.php
+++ b/includes/API/Orders/Acknowledge/Request.php
@@ -44,4 +44,19 @@ class Request extends API\Request  {
 	}
 
 
+	/**
+	 * Gets the rate limit ID.
+	 *
+	 * While this is the Orders API, orders belong to pages so this is where the rate limit comes from.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'pages';
+	}
+
+
 }

--- a/includes/API/Orders/Cancel/Request.php
+++ b/includes/API/Orders/Cancel/Request.php
@@ -64,4 +64,19 @@ class Request extends API\Request  {
 	}
 
 
+	/**
+	 * Gets the rate limit ID.
+	 *
+	 * While this is the Orders API, orders belong to pages so this is where the rate limit comes from.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'pages';
+	}
+
+
 }

--- a/includes/API/Orders/Fulfillment/Request.php
+++ b/includes/API/Orders/Fulfillment/Request.php
@@ -43,4 +43,19 @@ class Request extends API\Request  {
 	}
 
 
+	/**
+	 * Gets the rate limit ID.
+	 *
+	 * While this is the Orders API, orders belong to pages so this is where the rate limit comes from.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'pages';
+	}
+
+
 }

--- a/includes/API/Orders/Read/Request.php
+++ b/includes/API/Orders/Read/Request.php
@@ -61,4 +61,19 @@ class Request extends API\Request  {
 	}
 
 
+	/**
+	 * Gets the rate limit ID.
+	 *
+	 * While this is the Orders API, orders belong to pages so this is where the rate limit comes from.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'pages';
+	}
+
+
 }

--- a/includes/API/Orders/Refund/Request.php
+++ b/includes/API/Orders/Refund/Request.php
@@ -62,4 +62,19 @@ class Request extends API\Request  {
 	}
 
 
+	/**
+	 * Gets the rate limit ID.
+	 *
+	 * While this is the Orders API, orders belong to pages so this is where the rate limit comes from.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'pages';
+	}
+
+
 }

--- a/includes/API/Orders/Request.php
+++ b/includes/API/Orders/Request.php
@@ -23,6 +23,21 @@ class Request extends API\Request  {
 
 
 	/**
+	 * Gets the rate limit ID.
+	 *
+	 * While this is the Orders API, orders belong to pages so this is where the rate limit comes from.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public static function get_rate_limit_id() {
+
+		return 'pages';
+	}
+
+
+	/**
 	 * API request constructor.
 	 *
 	 * @see https://developers.facebook.com/docs/commerce-platform/order-management/order-api#get_orders

--- a/tests/integration/API/Catalog/Product_Group/Products/Read/RequestTest.php
+++ b/tests/integration/API/Catalog/Product_Group/Products/Read/RequestTest.php
@@ -54,4 +54,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Request::get_rate_limit_id() */
+	public function test_get_rate_limit_id() {
+
+		$this->assertEquals( 'ads_management', Request::get_rate_limit_id() );
+	}
+
+
 }

--- a/tests/integration/API/Catalog/Product_Item/Find/RequestTest.php
+++ b/tests/integration/API/Catalog/Product_Item/Find/RequestTest.php
@@ -55,7 +55,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	/** @see \SkyVerge\WooCommerce\Facebook\API\Catalog\Product_Item\Find\Request::get_rate_limit_id() */
 	public function test_get_rate_limit_id() {
 
-		$this->assertEquals( 'wc_facebook_ads_management_api_request', Request::get_rate_limit_id() );
+		$this->assertEquals( 'ads_management', Request::get_rate_limit_id() );
 	}
 
 

--- a/tests/integration/API/Catalog/RequestTest.php
+++ b/tests/integration/API/Catalog/RequestTest.php
@@ -50,4 +50,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see \SkyVerge\WooCommerce\Facebook\API\Catalog\Request::get_rate_limit_id() */
+	public function test_get_rate_limit_id() {
+
+		$this->assertEquals( 'ads_management', Request::get_rate_limit_id() );
+	}
+
+
 }

--- a/tests/integration/API/Catalog/Send_Item_Updates/RequestTest.php
+++ b/tests/integration/API/Catalog/Send_Item_Updates/RequestTest.php
@@ -40,6 +40,13 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Request::get_rate_limit_id() */
+	public function test_get_rate_limit_id() {
+
+		$this->assertEquals( 'ads_management', Request::get_rate_limit_id() );
+	}
+
+
 	/** @see Request::set_requests() */
 	public function test_set_requests() {
 

--- a/tests/integration/API/Exceptions/Request_Limit_Reached_Test.php
+++ b/tests/integration/API/Exceptions/Request_Limit_Reached_Test.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Exceptions;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+/**
+ * Tests the API\Exceptions\Request_Limit_Reached_Test object.
+ */
+class Request_Limit_Reached_Test extends \Codeception\TestCase\WPTestCase {
+
+
+	/**
+	 * Runs before each test.
+	 */
+	public function _before() {
+
+		require_once( 'includes/API/Exceptions/Request_Limit_Reached.php' );
+
+		parent::_before();
+	}
+
+
+
+	/** @see API\Exceptions\Request_Limit_Reached::get_throttle_end() */
+	public function test_get_throttle_end() {
+
+		$exception = new API\Exceptions\Request_Limit_Reached( 'Help!', 500 );
+
+		$reflection = new \ReflectionClass( $exception );
+		$property = $reflection->getProperty( 'throttle_end' );
+		$property->setAccessible( true) ;
+		$property->setValue( $exception, new \DateTime() );
+
+		$this->assertInstanceOf( \DateTime::class, $exception->get_throttle_end() );
+	}
+
+
+
+	/** @see API\Exceptions\Request_Limit_Reached::set_throttle_end() */
+	public function test_set_throttle_end() {
+
+		$exception = new API\Exceptions\Request_Limit_Reached( 'Help!', 500 );
+
+		$exception->set_throttle_end( new \DateTime() );
+
+		$this->assertInstanceOf( \DateTime::class, $exception->get_throttle_end() );
+	}
+
+
+}

--- a/tests/integration/API/Exceptions/Request_Limit_Reached_Test.php
+++ b/tests/integration/API/Exceptions/Request_Limit_Reached_Test.php
@@ -3,6 +3,7 @@
 namespace SkyVerge\WooCommerce\Facebook\Tests\API\Exceptions;
 
 use SkyVerge\WooCommerce\Facebook\API;
+use SkyVerge\WooCommerce\Facebook\API\Exceptions\Request_Limit_Reached;
 
 /**
  * Tests the API\Exceptions\Request_Limit_Reached_Test object.
@@ -15,7 +16,9 @@ class Request_Limit_Reached_Test extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function _before() {
 
-		require_once( 'includes/API/Exceptions/Request_Limit_Reached.php' );
+		if ( ! class_exists( Request_Limit_Reached::class ) ) {
+			require_once( 'includes/API/Exceptions/Request_Limit_Reached.php' );
+		}
 
 		parent::_before();
 	}

--- a/tests/integration/API/Orders/Acknowledge/RequestTest.php
+++ b/tests/integration/API/Orders/Acknowledge/RequestTest.php
@@ -45,4 +45,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Request::get_rate_limit_id() */
+	public function test_get_rate_limit_id() {
+
+		$this->assertEquals( 'pages', Request::get_rate_limit_id() );
+	}
+
+
 }

--- a/tests/integration/API/Orders/Cancel/RequestTest.php
+++ b/tests/integration/API/Orders/Cancel/RequestTest.php
@@ -48,4 +48,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Request::get_rate_limit_id() */
+	public function test_get_rate_limit_id() {
+
+		$this->assertEquals( 'pages', Request::get_rate_limit_id() );
+	}
+
+
 }

--- a/tests/integration/API/Orders/Fulfillment/RequestTest.php
+++ b/tests/integration/API/Orders/Fulfillment/RequestTest.php
@@ -61,4 +61,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Request::get_rate_limit_id() */
+	public function test_get_rate_limit_id() {
+
+		$this->assertEquals( 'pages', Request::get_rate_limit_id() );
+	}
+
+
 }

--- a/tests/integration/API/Orders/Read/RequestTest.php
+++ b/tests/integration/API/Orders/Read/RequestTest.php
@@ -74,4 +74,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Request::get_rate_limit_id() */
+	public function test_get_rate_limit_id() {
+
+		$this->assertEquals( 'pages', Request::get_rate_limit_id() );
+	}
+
+
 }

--- a/tests/integration/API/Orders/Refund/RequestTest.php
+++ b/tests/integration/API/Orders/Refund/RequestTest.php
@@ -47,4 +47,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Request::get_rate_limit_id() */
+	public function test_get_rate_limit_id() {
+
+		$this->assertEquals( 'pages', Request::get_rate_limit_id() );
+	}
+
+
 }

--- a/tests/integration/API/Traits/RateLimitedAPITest.php
+++ b/tests/integration/API/Traits/RateLimitedAPITest.php
@@ -45,7 +45,7 @@ class RateLimitedAPITest extends \Codeception\TestCase\WPTestCase {
 
 		$this->api->set_rate_limit_delay( $rate_limit_id, $value );
 
-		$this->assertEquals( get_option( "wc_facebook_rate_limit_${rate_limit_id}" ), $value );
+		$this->assertEquals( get_transient( "wc_facebook_rate_limit_${rate_limit_id}" ), $value );
 	}
 
 
@@ -53,7 +53,7 @@ class RateLimitedAPITest extends \Codeception\TestCase\WPTestCase {
 	public function provider_set_rate_limit_delay() {
 
 		return [
-			[ 'ads_management_api_request', 15 ],
+			[ 'ads_management', 15 ],
 		];
 	}
 
@@ -69,7 +69,7 @@ class RateLimitedAPITest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_get_rate_limit_delay( $rate_limit_id, $option_value, $expected_value ) {
 
-		update_option( "wc_facebook_rate_limit_${rate_limit_id}", $option_value );
+		set_transient( "wc_facebook_rate_limit_${rate_limit_id}", $option_value );
 
 		$this->assertEquals( $expected_value, $this->api->get_rate_limit_delay( $rate_limit_id ) );
 	}
@@ -79,10 +79,10 @@ class RateLimitedAPITest extends \Codeception\TestCase\WPTestCase {
 	public function provider_get_rate_limit_delay() {
 
 		return [
-			[ 'ads_management_api_request', 15, 15 ],
-			[ 'ads_management_api_request', '15', 15 ],
-			[ 'ads_management_api_request', '', 0 ],
-			[ 'ads_management_api_request', false, 0 ],
+			[ 'ads_management', 15, 15 ],
+			[ 'ads_management', '15', 15 ],
+			[ 'ads_management', '', 0 ],
+			[ 'ads_management', false, 0 ],
 		];
 	}
 
@@ -111,7 +111,7 @@ class RateLimitedAPITest extends \Codeception\TestCase\WPTestCase {
 	public function provider_calculate_rate_limit_delay() {
 
 		return [
-			[ [ 'X-Business-Use-Case-Usage' => [ 'call_count' => 28, 'total_time' => 25, 'total_cputime' => 26, 'estimated_time_to_regain_access' => 15 ] ], 15 ],
+			[ [ 'X-Business-Use-Case-Usage' => [ 'call_count' => 28, 'total_time' => 25, 'total_cputime' => 26, 'estimated_time_to_regain_access' => 15 ] ], 15 * MINUTE_IN_SECONDS ],
 		];
 	}
 

--- a/tests/integration/API/Traits/RateLimitedAPITest.php
+++ b/tests/integration/API/Traits/RateLimitedAPITest.php
@@ -33,6 +33,41 @@ class RateLimitedAPITest extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
+	/** @see API::perform_request() */
+	public function test_perform_request() {
+
+		$request = new API\Orders\Acknowledge\Request( '1234', '5678' );
+
+		// mock the API to use fake data instead of making a real API call and return a valid response handler
+		$this->api = $this->make( $this->api, [
+			'do_remote_request'    => json_encode( [ 'success' => true ] ),
+			'get_response_handler' => API\Response::class,
+		] );
+
+		$response = $this->api->perform_request( $request );
+
+		$this->assertInstanceOf( API\Response::class, $response );
+	}
+
+
+	/** @see API::perform_request() */
+	public function test_perform_request_with_limit() {
+
+		$request = new API\Orders\Acknowledge\Request( '1234', '5678' );
+
+		$this->api->set_rate_limit_delay( $request::get_rate_limit_id(), time() + 60 );
+
+		// mock the API to return a valid response handler
+		$this->api = $this->make( $this->api, [
+			'get_response_handler' => API\Response::class,
+		] );
+
+		$this->expectException( API\Exceptions\Request_Limit_Reached::class );
+
+		$this->api->perform_request( $request );
+	}
+
+
 	/**
 	 * @see Rate_Limited_API::set_rate_limit_delay()
 	 *

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -721,7 +721,7 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertInstanceOf( API\Orders\Acknowledge\Request::class, $api->get_request() );
 		$this->assertEquals( 'POST', $api->get_request()->get_method() );
-		$this->assertEquals( '/335211597203390', $api->get_request()->get_path() );
+		$this->assertEquals( '/335211597203390/acknowledge_order', $api->get_request()->get_path() );
 		$expected_data = [
 			'merchant_order_reference' => '64241',
 			'idempotency_key'          => $api->get_request()->get_idempotency_key(),


### PR DESCRIPTION
# Summary

This PR implements the rate limit handling for API requests.

### Story: [CH 62619](https://app.clubhouse.io/skyverge/story/62619)
### Release: #1477 

## Details

Sets the rate limit delay timestamp whenever the associated error codes are detected, and halts future API requests of that type until the delay has passed.

Uses transients to store the delay values so that they are cleared periodically in case the options get stuck in a delayed state, so requests are at least let through every 24 hours.

Adds a `get_throttle_end()` method to the rate limit exception so that potentially in the future we can display more detailed admin notices about when requests should be re-attempted.

## QA

- [x] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version