### PR TITLE
Hook into product stock change and trigger a product sync

### DIFF
--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -54,6 +54,10 @@ class Sync {
 	public function add_hooks() {
 
 		add_action( 'shutdown', [ $this, 'schedule_sync' ] );
+
+		// stock update actions
+		add_action( 'woocommerce_product_set_stock', [ $this, 'handle_stock_update' ] );
+		add_action( 'woocommerce_variation_set_stock', [ $this, 'handle_stock_update' ] );
 	}
 
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -158,6 +158,18 @@ class Sync {
 
 
 	/**
+	 * Adds the products with stock changes to the requests array to be updated.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Product $product product object
+	 */
+	public function handle_stock_update( \WC_Product $product ) {
+
+	}
+
+
+	/**
 	 * Creates a background job to sync the products in the requests array.
 	 *
 	 * @since 2.0.0

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -166,6 +166,10 @@ class Sync {
 	 */
 	public function handle_stock_update( \WC_Product $product ) {
 
+		// bail if not connected
+		if ( ! facebook_for_woocommerce()->get_connection_handler()->is_connected() ) {
+			return;
+		}
 	}
 
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -175,6 +175,9 @@ class Sync {
 		if ( is_admin() && ! is_ajax() ) {
 			return;
 		}
+
+		// add the product to the list of products to be updated
+		$this->create_or_update_products( [ $product->get_id() ] );
 	}
 
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -170,6 +170,11 @@ class Sync {
 		if ( ! facebook_for_woocommerce()->get_connection_handler()->is_connected() ) {
 			return;
 		}
+
+		// bail if admin and not AJAX
+		if ( is_admin() && ! is_ajax() ) {
+			return;
+		}
 	}
 
 


### PR DESCRIPTION
# Summary

This PR implements the `Products\Sync::handle_stock_update()` method and hooks it into the stock update actions.

### Story: [CH 62794](https://app.clubhouse.io/skyverge/story/62794/hook-into-product-stock-change-and-trigger-a-product-sync)
### Release: #1477 

## QA

- [x] Integrations test pass

### Setup

- Have the plugin configured, connected, and with logging enabled
- Have two products with price and inventory set, sync enabled, Commerce enabled (set the post `_wc_facebook_commerce_enabled` meta data to `yes`), and a Google product category set (set the post `_wc_facebook_google_product_category`)

### Steps

#### Order with a single product

1. Place an order with one of the products
    - [x] One API call is made to update the product and it sends the `availability` and `inventory` values

#### Order with two products

1. Place an order with the two products
    - [x] One batch API call is made to update both products and it sends the `availability` and `inventory` values

#### Admin editing a single product 

1. Update the inventory for one of the products via the admin UI
    - [x] One API call is made to update the product and it sends the `availability` and `inventory` values

#### Bulk admin editing 

1. Update the inventory for both products via a bulk action
    - [x] Two API calls are made (one to update each product) and send the `availability` and `inventory` values

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version