### PR TITLE
Implement retry in API requests

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -477,6 +477,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/API/Orders/Order.php';
 				}
 
+				if ( ! class_exists( API\Orders\Abstract_Request::class ) ) {
+					require_once __DIR__ . '/includes/API/Orders/Abstract_Request.php';
+				}
+
 				if ( ! class_exists( API\Orders\Acknowledge\Request::class ) ) {
 					require_once __DIR__ . '/includes/API/Orders/Acknowledge/Request.php';
 				}

--- a/includes/API.php
+++ b/includes/API.php
@@ -179,6 +179,16 @@ class API extends Framework\SV_WC_API_Base {
 				delete_transient( 'wc_facebook_connection_invalid' );
 			}
 
+			// if the code indicates a retry and we've not hit the retry limit, perform the request again
+			if ( in_array( $code, $request->get_retry_codes(), false ) && $request->get_retry_count() < $request->get_retry_limit() ) {
+
+				$request->mark_retry();
+
+				$this->response = $this->perform_request( $request );
+
+				return;
+			}
+
 			throw new Framework\SV_WC_API_Exception( $message, $code );
 		}
 

--- a/includes/API/Orders/Abstract_Request.php
+++ b/includes/API/Orders/Abstract_Request.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\API\Orders;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\API;
+
+abstract class Abstract_Request extends API\Request {
+
+
+	/**
+	 * Abstract_Request constructor.
+	 *
+	 * @param string $path request path
+	 * @param string $method request method
+	 */
+	public function __construct( $path, $method ) {
+
+		parent::__construct( $path, $method );
+
+		/** @link https://developers.facebook.com/docs/commerce-platform/order-management/error-codes */
+		$this->retry_codes[] = 2361081;
+	}
+
+
+}

--- a/includes/API/Orders/Acknowledge/Request.php
+++ b/includes/API/Orders/Acknowledge/Request.php
@@ -19,7 +19,7 @@ use SkyVerge\WooCommerce\Facebook\API;
  *
  * @since 2.1.0-dev.1
  */
-class Request extends API\Request  {
+class Request extends API\Orders\Abstract_Request  {
 
 
 	use API\Traits\Idempotent_Request;

--- a/includes/API/Orders/Cancel/Request.php
+++ b/includes/API/Orders/Cancel/Request.php
@@ -19,7 +19,7 @@ use SkyVerge\WooCommerce\Facebook\API;
  *
  * @since 2.1.0-dev.1
  */
-class Request extends API\Request  {
+class Request extends API\Orders\Abstract_Request  {
 
 
 	use API\Traits\Idempotent_Request;

--- a/includes/API/Orders/Fulfillment/Request.php
+++ b/includes/API/Orders/Fulfillment/Request.php
@@ -19,7 +19,7 @@ use SkyVerge\WooCommerce\Facebook\API;
  *
  * @since 2.1.0-dev.1
  */
-class Request extends API\Request  {
+class Request extends API\Orders\Abstract_Request  {
 
 
 	use API\Traits\Idempotent_Request;

--- a/includes/API/Orders/Read/Request.php
+++ b/includes/API/Orders/Read/Request.php
@@ -19,7 +19,7 @@ use SkyVerge\WooCommerce\Facebook\API;
  *
  * @since 2.1.0-dev.1
  */
-class Request extends API\Request  {
+class Request extends API\Orders\Abstract_Request  {
 
 
 	/**

--- a/includes/API/Orders/Refund/Request.php
+++ b/includes/API/Orders/Refund/Request.php
@@ -19,7 +19,7 @@ use SkyVerge\WooCommerce\Facebook\API;
  *
  * @since 2.1.0-dev.1
  */
-class Request extends API\Request  {
+class Request extends API\Orders\Abstract_Request  {
 
 
 	use API\Traits\Idempotent_Request;

--- a/includes/API/Orders/Request.php
+++ b/includes/API/Orders/Request.php
@@ -12,14 +12,12 @@ namespace SkyVerge\WooCommerce\Facebook\API\Orders;
 
 defined( 'ABSPATH' ) or exit;
 
-use SkyVerge\WooCommerce\Facebook\API;
-
 /**
  * Orders API list request object.
  *
  * @since 2.1.0-dev.1
  */
-class Request extends API\Request  {
+class Request extends Abstract_Request  {
 
 
 	/**

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -101,7 +101,7 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 
 
 	/**
-	 * Gets the number of retries to attempt if told to do so by Facebook.
+	 * Gets the maximum number of retries to attempt if told to do so by Facebook.
 	 *
 	 * @since 2.1.0-dev.1
 	 *

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -25,6 +25,16 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 	use Traits\Rate_Limited_Request;
 
 
+	/** @var int number of retries to attempt if told to do so by Facebook */
+	protected $retry_limit = 5;
+
+	/** @var int number of times this request has been retried */
+	protected $retry_count = 0;
+
+	/** @var int[] the response codes that should trigger */
+	protected $retry_codes = [];
+
+
 	/**
 	 * API request constructor.
 	 *
@@ -63,6 +73,56 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 	public function set_data( $data ) {
 
 		$this->data = $data;
+	}
+
+
+	/**
+	 * Gets the number of times this request has been retried.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return int
+	 */
+	public function get_retry_count() {
+
+		return $this->retry_count;
+	}
+
+
+	/**
+	 * Marks the request as having been retried.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function mark_retry() {
+
+		$this->retry_count++;
+	}
+
+
+	/**
+	 * Gets the number of retries to attempt if told to do so by Facebook.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return int
+	 */
+	public function get_retry_limit() {
+
+		return $this->retry_limit;
+	}
+
+
+	/**
+	 * Response codes that should trigger a retry for this request.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return int[]
+	 */
+	public function get_retry_codes() {
+
+		return $this->retry_codes;
 	}
 
 

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -25,7 +25,7 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 	use Traits\Rate_Limited_Request;
 
 
-	/** @var int number of retries to attempt if told to do so by Facebook */
+	/** @var int maximum number of retries to attempt if told to do so by Facebook */
 	protected $retry_limit = 5;
 
 	/** @var int number of times this request has been retried */

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -109,7 +109,15 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 	 */
 	public function get_retry_limit() {
 
-		return $this->retry_limit;
+		/**
+		 * Filters the maximum number of retries allowed for the request.
+		 *
+		 * @since 2.1.0-dev.1
+		 *
+		 * @param int $retry_limit maximum number of retries
+		 * @param Request $request request object
+		 */
+		return (int) apply_filters( 'wc_facebook_api_request_retry_limit', $this->retry_limit, $this );
 	}
 
 

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -31,7 +31,7 @@ class Request extends Framework\SV_WC_API_JSON_Request {
 	/** @var int number of times this request has been retried */
 	protected $retry_count = 0;
 
-	/** @var int[] the response codes that should trigger */
+	/** @var int[] the response codes that should trigger a retry */
 	protected $retry_codes = [];
 
 

--- a/tests/integration/API/Orders/Abstract_Request_Test.php
+++ b/tests/integration/API/Orders/Abstract_Request_Test.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders;
+
+use SkyVerge\WooCommerce\Facebook\API\Orders\Abstract_Request;
+
+/**
+ * Tests the API\Orders\Order class.
+ */
+class Abstract_Request_Test extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Before each test.
+	 *
+	 * @throws \SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Exception
+	 */
+	public function _before() {
+
+		parent::_before();
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		// create an instance of the API and load all the request and response classes
+		facebook_for_woocommerce()->get_api();
+	}
+
+
+	/** @see Request::get_retry_codes() */
+	public function test_get_retry_codes() {
+
+		$request = new class( null, null ) extends Abstract_Request {};
+
+		$this->assertContains( 2361081, $request->get_retry_codes() );
+	}
+
+
+}

--- a/tests/integration/API/RequestTest.php
+++ b/tests/integration/API/RequestTest.php
@@ -112,6 +112,17 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Request::get_retry_limit() */
+	public function test_get_retry_limit_filtered() {
+
+		add_filter( 'wc_facebook_api_request_retry_limit', function() {
+			return 10;
+		} );
+
+		$this->assertSame( 10, ( new Request( null, null ) )->get_retry_limit() );
+	}
+
+
 	/** @see Request::get_retry_codes() */
 	public function test_get_retry_codes() {
 

--- a/tests/integration/API/RequestTest.php
+++ b/tests/integration/API/RequestTest.php
@@ -83,4 +83,43 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Request::get_retry_count() */
+	public function test_get_retry_count() {
+
+		$this->assertSame( 0, ( new Request( null, null ) )->get_retry_count() );
+	}
+
+
+	/** @see Request::mark_retry() */
+	public function test_mark_retry() {
+
+		$request = new Request( null, null );
+
+		$request->mark_retry();
+
+		$this->assertSame( 1, $request->get_retry_count() );
+
+		$request->mark_retry();
+
+		$this->assertSame( 2, $request->get_retry_count() );
+	}
+
+
+	/** @see Request::get_retry_limit() */
+	public function test_get_retry_limit() {
+
+		$this->assertSame( 5, ( new Request( null, null ) )->get_retry_limit() );
+	}
+
+
+	/** @see Request::get_retry_codes() */
+	public function test_get_retry_codes() {
+
+		$codes = ( new Request( null, null ) )->get_retry_codes();
+
+		$this->assertIsArray( $codes );
+		$this->assertEmpty( $codes );
+	}
+
+
 }

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -88,6 +88,7 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 			] ) ) ),
 		] );
 
+		// the request is expected to be retried 5 times using the Expected::exactly() call, then it lets this exception through
 		$this->expectException( Framework\SV_WC_API_Exception::class );
 
 		$api->perform_request( $request );

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -64,6 +64,36 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see API::perform_request() */
+	public function test_do_post_parse_response_validation_retry() {
+
+		$request = new class extends API\Request {
+
+			public function __construct() {
+
+				parent::__construct( null, null );
+
+				$this->retry_codes[] = 5678;
+			}
+		};
+
+		// mock the API to use fake data instead of making a real API call and return a valid response handler
+		$api = $this->make( facebook_for_woocommerce()->get_api(), [
+			'get_parsed_response'    => \Codeception\Stub\Expected::exactly( 6, new API\Response( json_encode( [
+				'error' => [
+					'message'          => 'Retry me!',
+					'type'             => 'OAuthException',
+					'code'             => 5678,
+				]
+			] ) ) ),
+		] );
+
+		$this->expectException( Framework\SV_WC_API_Exception::class );
+
+		$api->perform_request( $request );
+	}
+
+
 	/**
 	 * @see API::do_post_parse_response_validation()
 	 *


### PR DESCRIPTION
# Summary

This PR implements the retry handling for API requests.

Please do not merged until #1526 is merged.

### Story: [CH 63042](https://app.clubhouse.io/skyverge/story/63042)
### Release: #1477 

## Details

This updates `API\Request` with some retry helper methods. Each request can now have:
- A list of response error codes that indicate the request should be retried
- A limit on the number of retries (default 5) to prevent a loop
- The number of times the request has been retried

The API will retry a request with known codes until that limit has been reached, then it will throw an exception as it normally would on any non-retry error.

So far this only applies to a single error code for Orders API requests, but this will allow us to add more in the future as we find them.

## QA

- [ ] Integrations test pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version