### PR TITLE
Add the Admin\Orders class

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -32,6 +32,10 @@ class Admin {
 	const SYNC_MODE_SYNC_DISABLED = 'sync_disabled';
 
 
+	/** @var \Admin\Orders the orders admin handler */
+	protected $orders;
+
+
 	/**
 	 * Admin constructor.
 	 *
@@ -48,6 +52,10 @@ class Admin {
 		if ( ! $plugin->get_connection_handler()->is_connected() || ! $plugin->get_integration()->get_product_catalog_id() ) {
 			return;
 		}
+
+		require_once __DIR__ . '/Admin/Orders.php';
+
+		$this->orders = new Admin\Orders();
 
 		// add a modal in admin product pages
 		add_action( 'admin_footer', [ $this, 'render_modal_template' ] );
@@ -129,6 +137,19 @@ class Admin {
 				wp_enqueue_script( 'wc-enhanced-select' );
 			}
 		}
+	}
+
+
+	/**
+	 * Gets the orders admin handler instance.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return \SkyVerge\WooCommerce\Facebook\Admin\Orders
+	 */
+	public function get_orders_handler() {
+
+		return $this->orders;
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -38,6 +38,23 @@ class Orders {
 	 */
 	public function add_hooks() {
 
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+
+		add_action( 'admin_notices', [ $this, 'add_notices' ] );
+
+		add_filter( 'wc_order_is_editable', [ $this, 'is_order_editable' ], 10, 2 );
+
+		add_action( 'admin_footer', [ $this, 'render_modal_templates' ] );
+
+		add_action( 'admin_footer', [ $this, 'render_refund_reason_field' ] );
+
+		add_action( 'woocommerce_refund_created', [ $this, 'handle_refund' ] );
+
+		add_action( 'woocommerce_email_enabled_customer_completed_order', [ $this, 'maybe_stop_order_email' ], 10, 2 );
+		add_action( 'woocommerce_email_enabled_customer_processing_order', [ $this, 'maybe_stop_order_email' ], 10, 2 );
+		add_action( 'woocommerce_email_enabled_customer_refunded_order', [ $this, 'maybe_stop_order_email' ], 10, 2 );
+
+		add_action( 'admin_menu', [ $this, 'maybe_remove_order_metaboxes' ] );
 	}
 
 
@@ -107,8 +124,10 @@ class Orders {
 	 * @internal
 	 *
 	 * @since 2.1.0-dev.1
+	 *
+	 * @param int $refund_id refund ID
 	 */
-	public function handle_refund() {
+	public function handle_refund( $refund_id ) {
 
 	}
 
@@ -132,11 +151,13 @@ class Orders {
 	 *
 	 * @since 2.1.0-dev.1
 	 *
+	 * @param bool $is_enabled whether the email is enabled in the first place
+	 * @param \WC_Order $order order object
 	 * @return bool
 	 */
-	public function maybe_stop_order_email() {
+	public function maybe_stop_order_email( $is_enabled, \WC_Order $order ) {
 
-		return true;
+		return $is_enabled;
 	}
 
 
@@ -147,11 +168,13 @@ class Orders {
 	 *
 	 * @since 2.1.0-dev.1
 	 *
+	 * @param bool $maybe_editable whether the order is editable in the first place
+	 * @param \WC_Order $order order object
 	 * @return bool
 	 */
-	public function is_order_editable() {
+	public function is_order_editable( $maybe_editable, \WC_Order $order ) {
 
-		return true;
+		return $maybe_editable;
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Admin;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * General handler for order admin functionality.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Orders {
+
+
+}

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -83,7 +83,7 @@ class Orders {
 
 
 	/**
-	 * Remove order metaboxes if the order is a Commerce pending order.
+	 * Removes order metaboxes if the order is a Commerce pending order.
 	 *
 	 * @internal
 	 *

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -162,7 +162,7 @@ class Orders {
 
 
 	/**
-	 * Returns whether or not the order is editable.
+	 * Determines whether or not the order is editable.
 	 *
 	 * @internal
 	 *
@@ -179,7 +179,7 @@ class Orders {
 
 
 	/**
-	 * Returns whether or not the current screen is an orders screen.
+	 * Determines whether or not the current screen is an orders screen.
 	 *
 	 * @internal
 	 *
@@ -194,7 +194,7 @@ class Orders {
 
 
 	/**
-	 * Returns whether or not the current screen is an order edit screen.
+	 * Determines whether or not the current screen is an order edit screen.
 	 *
 	 * @internal
 	 *

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -20,4 +20,169 @@ defined( 'ABSPATH' ) or exit;
 class Orders {
 
 
+	/**
+	 * Handler constructor.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function __construct() {
+
+		$this->add_hooks();
+	}
+
+
+	/**
+	 * Adds the necessary action & filter hooks.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function add_hooks() {
+
+	}
+
+
+	/**
+	 * Enqueue the assets.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function enqueue_assets() {
+
+	}
+
+
+	/**
+	 * Adds admin notices.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function add_notices() {
+
+	}
+
+
+	/**
+	 * Remove order metaboxes if the order is a Commerce pending order.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function maybe_remove_order_metaboxes() {
+
+	}
+
+
+	/**
+	 * Renders the Complete, Refund, & Cancel modals templates markup.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function render_modal_templates() {
+
+	}
+
+
+	/**
+	 * Renders the refund reason field.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function render_refund_reason_field() {
+
+	}
+
+
+	/**
+	 * Sends a refund request to the Commerce API when a WC refund is created.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function handle_refund() {
+
+	}
+
+
+	/**
+	 * Sets a transient to display a notice regarding bulk updates for Commerce orders' statuses.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function handle_bulk_update() {
+
+	}
+
+
+	/**
+	 * Prevents sending emails for Commerce orders.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function maybe_stop_order_email() {
+
+		return true;
+	}
+
+
+	/**
+	 * Returns whether or not the order is editable.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function is_order_editable() {
+
+		return true;
+	}
+
+
+	/**
+	 * Returns whether or not the current screen is an orders screen.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function is_orders_screen() {
+
+		return true;
+	}
+
+
+	/**
+	 * Returns whether or not the current screen is an order edit screen.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function is_edit_order_screen() {
+
+		return true;
+	}
+
+
 }

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Admin;
+
+/**
+ * Tests the Admin\Orders class.
+ */
+class OrdersTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+		require_once 'includes/Admin/Orders.php';
+	}
+
+
+	/**
+	 * Runs after each test.
+	 */
+	protected function _after() {
+
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	// TODO: add test for enqueue_assets()
+
+	// TODO: add test for add_notices()
+
+	// TODO: add test for maybe_remove_order_metaboxes()
+
+	// TODO: add test for render_modal_templates()
+
+	// TODO: add test for render_refund_reason_field()
+
+	// TODO: add test for handle_refund()
+
+	// TODO: add test for handle_bulk_update()
+
+	// TODO: add test for maybe_stop_order_email()
+
+	// TODO: add test for is_order_editable()
+
+	// TODO: add test for is_orders_screen()
+
+	// TODO: add test for is_edit_order_screen()
+
+
+	/** Utility methods ***********************************************************************************************/
+
+
+	/**
+	 * Gets an orders handler instance.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return Admin\Orders
+	 */
+	private function get_orders_handler() {
+
+		return new Admin\Orders();
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `Admin\Orders` class with its stub methods and a corresponding test class.

### Story: [CH 63749](https://app.clubhouse.io/skyverge/story/63749/add-the-admin-orders-class)
### Release: #1477 

## QA

- [ ] Code review only

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version