### PR TITLE
Add the Admin\Product_Categories class

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -32,6 +32,10 @@ class Admin {
 	const SYNC_MODE_SYNC_DISABLED = 'sync_disabled';
 
 
+	/** @var \Admin\Product_Categories the product category admin handler */
+	protected $product_categories;
+
+
 	/**
 	 * Admin constructor.
 	 *
@@ -48,6 +52,10 @@ class Admin {
 		if ( ! $plugin->get_connection_handler()->is_connected() || ! $plugin->get_integration()->get_product_catalog_id() ) {
 			return;
 		}
+
+		require_once __DIR__ . '/Admin/Product_Categories.php';
+
+		$this->product_categories = new Admin\Product_Categories();
 
 		// add a modal in admin product pages
 		add_action( 'admin_footer', [ $this, 'render_modal_template' ] );
@@ -129,6 +137,19 @@ class Admin {
 				wp_enqueue_script( 'wc-enhanced-select' );
 			}
 		}
+	}
+
+
+	/**
+	 * Gets the product category admin handler instance.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return \SkyVerge\WooCommerce\Facebook\Admin\Product_Categories
+	 */
+	public function get_product_categories_handler() {
+
+		return $this->product_categories;
 	}
 
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -20,4 +20,8 @@ defined( 'ABSPATH' ) or exit;
 class Product_Categories {
 
 
+	/** @var string ID for the HTML field */
+	const FIELD_GOOGLE_PRODUCT_CATEGORY_ID = 'wc_facebook_google_product_category_id';
+
+
 }

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Admin;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * General handler for the product category admin functionality.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Product_Categories {
+
+
+}

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -35,7 +35,7 @@ class Product_Categories {
 
 
 	/**
-	 * Enqueue the assets.
+	 * Enqueues the assets.
 	 *
 	 * @internal
 	 *

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -24,4 +24,90 @@ class Product_Categories {
 	const FIELD_GOOGLE_PRODUCT_CATEGORY_ID = 'wc_facebook_google_product_category_id';
 
 
+	/**
+	 * Handler constructor.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function __construct() {
+
+	}
+
+
+	/**
+	 * Enqueue the assets.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function enqueue_assets() {
+
+	}
+
+
+	/**
+	 * Renders the Google product category field markup for the add form.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function render_add_google_product_category_field() {
+
+	}
+
+
+	/**
+	 * Renders the Google product category field markup for the edit form.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function render_edit_google_product_category_field() {
+
+	}
+
+
+	/**
+	 * Renders the common tooltip markup.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function render_google_product_category_tooltip() {
+
+	}
+
+
+	/**
+	 * Gets the common field title.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_google_product_category_field_title() {
+
+	}
+
+
+	/**
+	 * Saves the POSTed Google product category ID and triggers a sync for the affected products.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function save_google_product_category() {
+
+	}
+
+
 }

--- a/tests/integration/Admin/ProductCategoriesTest.php
+++ b/tests/integration/Admin/ProductCategoriesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Admin;
+
+/**
+ * Tests the Admin\Product_Categories class.
+ */
+class ProductCategoriesTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+		require_once 'includes/Admin/Product_Categories.php';
+	}
+
+
+	/**
+	 * Runs after each test.
+	 */
+	protected function _after() {
+
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	// TODO: add test for enqueue_assets()
+
+	// TODO: add test for render_add_google_product_category_field()
+
+	// TODO: add test for render_edit_google_product_category_field()
+
+	// TODO: add test for render_google_product_category_tooltip()
+
+	// TODO: add test for get_google_product_category_field_title()
+
+	// TODO: add test for save_google_product_category()
+
+
+	/** Utility methods ***********************************************************************************************/
+
+
+	/**
+	 * Gets an orders handler instance.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return Admin\Product_Categories
+	 */
+	private function get_product_categories_handler() {
+
+		return new Admin\Product_Categories();
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `Admin\Product_Categories` class with its stub methods and a corresponding test class.

### Story: [CH 63651](https://app.clubhouse.io/skyverge/story/63651/add-the-admin-product-categories-class)
### Release: #1477 

## QA

- [ ] Code review only

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version