### PR TITLE
Implement the Commerce\Orders::is_commerce_order() method

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -49,6 +49,20 @@ class Orders {
 
 
 	/**
+	 * Returns whether or not the order is a Commerce order.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Order $order order object
+	 * @return bool
+	 */
+	public static function is_commerce_order( \WC_Order $order ) {
+
+		return in_array( $order->get_created_via(), [ 'instagram', 'facebook' ], true );
+	}
+
+
+	/**
 	 * Finds a local order based on the Commerce ID stored in REMOTE_ID_META_KEY.
 	 *
 	 * @since 2.1.0-dev.1

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -35,6 +35,37 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
+	/**
+	 * @see Orders::is_commerce_order()
+	 *
+	 * @param string $created_via created via value
+	 * @param bool $expected expected result
+	 *
+	 * @dataProvider provider_is_commerce_order
+	 *
+	 * @throws \WC_Data_Exception
+	 */
+	public function test_is_commerce_order( $created_via, $expected ) {
+
+		$order = new \WC_Order();
+		$order->set_created_via( $created_via );
+		$order->save();
+
+		$this->assertEquals( $expected, Orders::is_commerce_order( $order ) );
+	}
+
+
+	/** @see test_is_commerce_order */
+	public function provider_is_commerce_order() {
+
+		return [
+			[ 'checkout', false ],
+			[ 'instagram', true ],
+			[ 'facebook', true ],
+		];
+	}
+
+
 	/** @see Orders::find_local_order() */
 	public function test_find_local_order_found() {
 


### PR DESCRIPTION
# Summary

This PR implements the `Commerce\Orders::is_commerce_order()` method.

### Story: [CH 63754](https://app.clubhouse.io/skyverge/story/63754/implement-the-commerce-orders-is-commerce-order-method)
### Release: #1477 

## QA

- [ ] `tests/integration/Commerce/OrdersTest.php` tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version