### PR TITLE
Add the Commerce settings screen class

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -151,6 +151,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/Admin/Settings_Screens/Connection.php';
 					require_once __DIR__ . '/includes/Admin/Settings_Screens/Product_Sync.php';
 					require_once __DIR__ . '/includes/Admin/Settings_Screens/Messenger.php';
+					require_once __DIR__ . '/includes/Admin/Settings_Screens/Commerce.php.php';
 
 					$this->admin_settings = new \SkyVerge\WooCommerce\Facebook\Admin\Settings();
 				}

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/Admin/Settings_Screens/Connection.php';
 					require_once __DIR__ . '/includes/Admin/Settings_Screens/Product_Sync.php';
 					require_once __DIR__ . '/includes/Admin/Settings_Screens/Messenger.php';
-					require_once __DIR__ . '/includes/Admin/Settings_Screens/Commerce.php.php';
+					require_once __DIR__ . '/includes/Admin/Settings_Screens/Commerce.php';
 
 					$this->admin_settings = new \SkyVerge\WooCommerce\Facebook\Admin\Settings();
 				}

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -42,6 +42,7 @@ class Settings {
 			Settings_Screens\Connection::ID => new Settings_Screens\Connection(),
 			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 			Settings_Screens\Messenger::ID => new Settings_Screens\Messenger(),
+			Settings_Screens\Commerce::ID => new Settings_Screens\Commerce(),
 		];
 
 		add_action( 'admin_menu', [ $this, 'add_menu_item' ] );

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -24,4 +24,79 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	const ID = 'commerce';
 
 
+	/**
+	 * Connection constructor.
+	 */
+	public function __construct() {
+
+		$this->id    = self::ID;
+		$this->label = __( 'Instagram Checkout', 'facebook-for-woocommerce' );
+		$this->title = __( 'Instagram Checkout', 'facebook-for-woocommerce' );
+
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+
+		add_action( 'woocommerce_admin_field_commerce_google_product_categories', [ $this, 'render_google_product_category_field' ] );
+	}
+
+
+	/**
+	 * Enqueues the assets.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function enqueue_assets() {
+
+	}
+
+
+	/**
+	 * Renders the screen.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function render() {
+
+		parent::render();
+	}
+
+
+	/**
+	 * Renders the Google category field markup.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function render_google_product_category_field() {
+
+		parent::render();
+	}
+
+
+	/**
+	 * Builds the connect URL.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_connect_url() {
+
+		return '';
+	}
+
+
+	/**
+	 * Gets the screen settings.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_settings() {
+
+		return [];
+	}
+
+
 }

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Admin\Settings_Screens;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\Admin;
+
+/**
+ * The Commerce settings screen object.
+ */
+class Commerce extends Admin\Abstract_Settings_Screen {
+
+}

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -19,4 +19,9 @@ use SkyVerge\WooCommerce\Facebook\Admin;
  */
 class Commerce extends Admin\Abstract_Settings_Screen {
 
+
+	/** @var string screen ID */
+	const ID = 'commerce';
+
+
 }

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -65,6 +65,8 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	/**
 	 * Renders the Google category field markup.
 	 *
+	 * @internal
+
 	 * @since 2.1.0-dev.1
 	 */
 	public function render_google_product_category_field() {

--- a/tests/integration/Admin/SettingsTest.php
+++ b/tests/integration/Admin/SettingsTest.php
@@ -70,6 +70,9 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayHasKey( 'messenger', $screens );
 		$this->assertInstanceOf( Admin\Settings_Screens\Messenger::class, $screens['messenger'] );
+
+		$this->assertArrayHasKey( 'commerce', $screens );
+		$this->assertInstanceOf( Admin\Settings_Screens\Commerce::class, $screens['commerce'] );
 	}
 
 
@@ -117,6 +120,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayHasKey( 'product_sync', $tabs );
 		$this->assertArrayHasKey( 'messenger', $tabs );
+		$this->assertArrayHasKey( 'commerce', $tabs );
 	}
 
 

--- a/tests/integration/Admin/SettingsTest.php
+++ b/tests/integration/Admin/SettingsTest.php
@@ -22,6 +22,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		require_once 'includes/Admin/Settings_Screens/Connection.php';
 		require_once 'includes/Admin/Settings_Screens/Product_Sync.php';
 		require_once 'includes/Admin/Settings_Screens/Messenger.php';
+		require_once 'includes/Admin/Settings_Screens/Commerce.php';
 	}
 
 


### PR DESCRIPTION
# Summary

This PR adds the `Admin\Settings_Screens\Commerce` class.

### Story: [CH 63618](https://app.clubhouse.io/skyverge/story/63618/add-the-commerce-settings-screen-class)
### Release: #1477 

## QA

### Automated tests

- [x] `tests/integration/Admin/SettingsTest.php` tests pass

### Setup

- The plugin is installed and configured

### Steps

1. Navigate to WooCommerce > Facebook
    - [x] There is an "Instagram Checkout" tab

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version