### PR TITLE
Add the admin product handler class

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -57,6 +57,7 @@ class Admin {
 		}
 
 		require_once __DIR__ . '/Admin/Orders.php';
+		require_once __DIR__ . '/Admin/Products.php';
 		require_once __DIR__ . '/Admin/Product_Categories.php';
 
 		$this->orders = new Admin\Orders();

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -39,4 +39,60 @@ class Products {
 	const FIELD_PATTERN = 'wc_facebook_pattern';
 
 
+	/**
+	 * Renders the Google product category fields.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Product $product product object
+	 */
+	public static function render_google_product_category_fields( \WC_Product $product ) {
+
+	}
+
+
+	/**
+	 * Renders the attribute fields.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Product $product product object
+	 */
+	public static function render_attribute_fields( \WC_Product $product ) {
+
+	}
+
+
+	/**
+	 * Renders the Commerce settings fields.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Product $product product object
+	 */
+	public static function render_commerce_fields( \WC_Product $product ) {
+
+	}
+
+
+	/**
+	 * Saves the Commerce settings.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Product $product product object
+	 */
+	public static function save_commerce_fields( \WC_Product $product ) {
+
+	}
+
+
 }

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -20,4 +20,23 @@ defined( 'ABSPATH' ) or exit;
 class Products {
 
 
+	/** @var string Commerce enabled field */
+	const FIELD_COMMERCE_ENABLED = 'wc_facebook_commerce_enabled';
+
+	/** @var string Google Product category ID field */
+	const FIELD_GOOGLE_PRODUCT_CATEGORY_ID = 'wc_facebook_google_product_category_id';
+
+	/** @var string gender field */
+	const FIELD_GENDER = 'wc_facebook_gender';
+
+	/** @var string color field */
+	const FIELD_COLOR = 'wc_facebook_color';
+
+	/** @var string size field */
+	const FIELD_SIZE = 'wc_facebook_size';
+
+	/** @var string pattern field */
+	const FIELD_PATTERN = 'wc_facebook_pattern';
+
+
 }

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Admin;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * General handler for product admin functionality.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Products {
+
+
+}

--- a/tests/integration/Admin/ProductsTest.php
+++ b/tests/integration/Admin/ProductsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Admin;
+
+/**
+ * Tests the Admin\Products class.
+ */
+class ProductsTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+		require_once 'includes/Admin/Products.php';
+	}
+
+
+	/**
+	 * Runs after each test.
+	 */
+	protected function _after() {
+
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	// TODO: add test for render_google_product_category_fields()
+
+	// TODO: add test for render_attribute_fields()
+
+	// TODO: add test for render_commerce_fields()
+
+	// TODO: add test for save_commerce_fields()
+
+
+	/** Utility methods ***********************************************************************************************/
+
+
+	/**
+	 * Gets a products handler instance.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return Admin\Products
+	 */
+	private function get_products_handler() {
+
+		return new Admin\Products();
+	}
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `Admin\Products` class with its stub methods and a corresponding test class.

### Story: [CH 63716](https://app.clubhouse.io/skyverge/story/63716/add-the-admin-product-handler-class)
### Release: #1477 

## QA

- [x] Code review only

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version