### PR TITLE
Add the Google Product Category field class

### DIFF
--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -27,8 +27,6 @@ class Google_Product_Category_Field {
 	/**
 	 * Instantiates the JS handler for the Google product category field.
 	 *
-	 * @internal
-	 *
 	 * @since 2.1.0-dev.1
 	 *
 	 * @param string $input_id element that should receive the latest concrete category ID value
@@ -40,8 +38,6 @@ class Google_Product_Category_Field {
 
 	/**
 	 * Gets the full categories list from Google and stores it.
-	 *
-	 * @internal
 	 *
 	 * @since 2.1.0-dev.1
 	 */

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -20,4 +20,8 @@ defined( 'ABSPATH' ) or exit;
 class Google_Product_Category_Field {
 
 
+	/** @var string the WordPress option name where the full categories list is stored */
+	const OPTION_GOOGLE_PRODUCT_CATEGORIES = 'wc_facebook_google_product_categories';
+
+
 }

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Admin;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * Google product category field.
+ *
+ * @since 2.1.0-dev.1
+ */
+class Google_Product_Category_Field {
+
+
+}

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -24,4 +24,30 @@ class Google_Product_Category_Field {
 	const OPTION_GOOGLE_PRODUCT_CATEGORIES = 'wc_facebook_google_product_categories';
 
 
+	/**
+	 * Instantiates the JS handler for the Google product category field.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $input_id element that should receive the latest concrete category ID value
+	 */
+	public function render( $input_id ) {
+
+	}
+
+
+	/**
+	 * Gets the full categories list from Google and stores it.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function get_categories() {
+
+	}
+
+
 }

--- a/tests/integration/Admin/GoogleProductCategoryFieldTest.php
+++ b/tests/integration/Admin/GoogleProductCategoryFieldTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Admin;
+
+/**
+ * Tests the Admin\Google_Product_Category_Field class.
+ */
+class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+		require_once 'includes/Admin/Google_Product_Category_Field.php';
+	}
+
+
+	/**
+	 * Runs after each test.
+	 */
+	protected function _after() {
+
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	// TODO: add test for render()
+
+	// TODO: add test for get_categories()
+
+
+}


### PR DESCRIPTION
# Summary

This PR adds the `Admin\Google_Product_Category_Field` class with its stub methods and a corresponding test class.

### Story: [CH 63579](https://app.clubhouse.io/skyverge/story/63579/add-the-google-product-category-field-class)
### Release: #1477 

## QA

- [x] Code review only

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version