### PR TITLE
Add the commerce manager ID methods

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -573,6 +573,19 @@ class Connection {
 
 
 	/**
+	 * Gets the Commerce manager ID value.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_commerce_manager_id() {
+
+		return get_option( self::OPTION_COMMERCE_MANAGER_ID, '' );
+	}
+
+
+	/**
 	 * Gets the proxy URL.
 	 *
 	 * @since 2.0.0

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -767,6 +767,19 @@ class Connection {
 
 
 	/**
+	 * Stores the given Commerce manager ID.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $id the ID
+	 */
+	public function update_commerce_manager_id( $id ) {
+
+		update_option( self::OPTION_COMMERCE_MANAGER_ID, $id );
+	}
+
+
+	/**
 	 * Stores the given token value.
 	 *
 	 * @since 2.0.0

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -58,6 +58,9 @@ class Connection {
 	/** @var string the page access token option name */
 	const OPTION_PAGE_ACCESS_TOKEN = 'wc_facebook_page_access_token';
 
+	/** @var string the Commerce manager ID option name */
+	const OPTION_COMMERCE_MANAGER_ID = 'wc_facebook_commerce_manager_id';
+
 	/** @var string|null the generated external merchant settings ID */
 	private $external_business_id;
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -280,6 +280,16 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_commerce_manager_id() */
+	public function test_get_commerce_manager_id() {
+
+		$commerce_manager_id = 'commerce manager id';
+		update_option( Connection::OPTION_COMMERCE_MANAGER_ID, $commerce_manager_id );
+
+		$this->assertSame( $commerce_manager_id, $this->get_connection()->get_commerce_manager_id() );
+	}
+
+
 	/** @see Connection::get_proxy_url() */
 	public function test_get_proxy_url() {
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -563,6 +563,16 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::update_commerce_manager_id() */
+	public function test_update_commerce_manager_id() {
+
+		$commerce_manager_id = 'commerce manager id';
+		$this->get_connection()->update_commerce_manager_id( $commerce_manager_id );
+
+		$this->assertSame( $commerce_manager_id, get_option( Connection::OPTION_COMMERCE_MANAGER_ID ) );
+	}
+
+
 	/** @see Connection::update_access_token() */
 	public function test_update_access_token() {
 


### PR DESCRIPTION
# Summary

This PR adds the commerce manager ID methods to the `Handlers\Connection` class.

### Story: [CH 63647](https://app.clubhouse.io/skyverge/story/63647/add-the-commerce-manager-id-methods)
### Release: #1477 

## QA

- [x] `tests/integration/Handlers/ConnectionTest.php` tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version