### PR TITLE
Implement the commerce settings method

### DIFF
--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -96,7 +96,12 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	 */
 	public function get_settings() {
 
-		return [];
+		return [
+			[
+				'id'   => \SkyVerge\WooCommerce\Facebook\Commerce::OPTION_GOOGLE_PRODUCT_CATEGORY_ID,
+				'type' => 'commerce_google_product_categories',
+			],
+		];
 	}
 
 

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -71,7 +71,6 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	 */
 	public function render_google_product_category_field() {
 
-		parent::render();
 	}
 
 


### PR DESCRIPTION
# Summary

Defines the custom setting for rendering the Google Product Category setting field.

### Story: [CH 63629](https://app.clubhouse.io/skyverge/story/63629)
### Release: #1477 

## Details

Nothing to QA here yet - the field's availability will be tested via acceptance tests once implemented.

## UI Changes

N/A

## QA

- [ ] Code review

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version