### PR TITLE
Implement the Google Product Category field getter

### DIFF
--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -63,7 +63,7 @@ class Google_Product_Category_Field {
 		if ( empty( $categories ) ) {
 
 			// get the categories from the saved option
-			$categories = get_option( self::OPTION_GOOGLE_PRODUCT_CATEGORIES );
+			$categories = get_option( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, [] );
 		}
 
 		return $categories;

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -145,7 +145,7 @@ class Google_Product_Category_Field {
 
 		return array_filter( array_map( function ( $category ) use ( $category_id ) {
 
-			return $category['parent'] === $category_id ? $category : false;
+			return $category['parent'] === $category_id ? $category['label'] : false;
 		}, $categories ) );
 	}
 

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -78,7 +78,7 @@ class Google_Product_Category_Field {
 	 * @param array|\WP_Error $categories_response categories response from Google
 	 * @return array
 	 */
-	private function parse_categories_response( $categories_response ) {
+	protected function parse_categories_response( $categories_response ) {
 
 		$categories = [];
 

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -99,7 +99,7 @@ class Google_Product_Category_Field {
 
 				list( $category_id, $category_tree ) = explode( ' - ', $category_line );
 
-				$category_id    = trim( $category_id );
+				$category_id    = (string) trim( $category_id );
 				$category_tree  = explode( ' > ', $category_tree );
 				$category_label = end( $category_tree );
 
@@ -121,10 +121,10 @@ class Google_Product_Category_Field {
 						return $item['label'];
 					}, $categories ) );
 
-					$category['parent'] = $parent_category;
+					$category['parent'] = (string) $parent_category;
 				}
 
-				$categories[ $category_id ] = $category;
+				$categories[ (string) $category_id ] = $category;
 
 				if ( count( $categories ) > 10 ) {
 					break;

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -136,4 +136,22 @@ class Google_Product_Category_Field {
 	}
 
 
+	/**
+	 * Gets the category options (children) for a given category.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $category_id category ID
+	 * @param array $categories full category list
+	 * @return array
+	 */
+	public function get_category_options( $category_id, $categories ) {
+
+		return array_filter( array_map( function ( $category ) use ( $category_id ) {
+
+			return $category['parent'] === $category_id ? $category : false;
+		}, $categories ) );
+	}
+
+
 }

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -125,10 +125,6 @@ class Google_Product_Category_Field {
 				}
 
 				$categories[ (string) $category_id ] = $category;
-
-				if ( count( $categories ) > 10 ) {
-					break;
-				}
 			}
 		}
 

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -126,6 +126,12 @@ class Google_Product_Category_Field {
 
 				$categories[ (string) $category_id ] = $category;
 			}
+
+			// add the options to the list
+			foreach ( $categories as $key => $category ) {
+
+				$categories[ $key ]['options'] = $this->get_category_options( $key, $categories );
+			}
 		}
 
 		return $categories;

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -43,6 +43,32 @@ class Google_Product_Category_Field {
 	 */
 	public function get_categories() {
 
+		// only fetch again if not fetched less than one hour ago
+		$categories = get_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES );
+
+		if ( empty ( $categories ) ) {
+
+			// fetch from the URL
+			$categories_response = wp_remote_get( 'https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt', [ 'timeout' => 1 ] );
+
+			if ( is_array( $categories_response ) && isset( $categories_response['body'] ) ) {
+
+				$categories = $categories_response['body'];
+
+				// TODO: parse categories
+
+				set_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, $categories, HOUR_IN_SECONDS );
+				update_option( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, $categories );
+			}
+		}
+
+		if ( empty( $categories ) ) {
+
+			// get the categories from the saved option
+			$categories = get_option( self::OPTION_GOOGLE_PRODUCT_CATEGORIES );
+		}
+
+		return $categories;
 	}
 
 

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -130,7 +130,7 @@ class Google_Product_Category_Field {
 			// add the options to the list
 			foreach ( $categories as $key => $category ) {
 
-				$categories[ $key ]['options'] = $this->get_category_options( $key, $categories );
+				$categories[ $key ]['options'] = $this->get_category_options( (string) $key, $categories );
 			}
 		}
 

--- a/tests/integration/Admin/GoogleProductCategoryFieldTest.php
+++ b/tests/integration/Admin/GoogleProductCategoryFieldTest.php
@@ -101,20 +101,13 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 	/** @see \SkyVerge\WooCommerce\Facebook\Admin\Google_Product_Category_Field::get_categories() */
 	public function test_get_categories_success() {
 
-		$field = new Admin\Google_Product_Category_Field();
+		$field     = new Admin\Google_Product_Category_Field();
+		$test_body = $this->get_test_categories_response_body();
 
-		add_filter( 'pre_http_request', static function () {
+		add_filter( 'pre_http_request', static function () use ( $test_body ) {
 
 			return [
-				'body' => '# Google_Product_Taxonomy_Version: 2019-07-10
-1 - Animals & Pet Supplies
-3237 - Animals & Pet Supplies > Live Animals
-2 - Animals & Pet Supplies > Pet Supplies
-3 - Animals & Pet Supplies > Pet Supplies > Bird Supplies
-7385 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories
-499954 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories > Bird Cage Bird Baths
-7386 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories > Bird Cage Food & Water Dishes
-4989 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cages & Stands',
+				'body' => $test_body,
 			];
 		} );
 
@@ -151,15 +144,7 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 			'response with empty body' => [ [ 'body' => '' ], [] ],
 			'response with valid body' => [
 				[
-					'body' => '# Google_Product_Taxonomy_Version: 2019-07-10
-1 - Animals & Pet Supplies
-3237 - Animals & Pet Supplies > Live Animals
-2 - Animals & Pet Supplies > Pet Supplies
-3 - Animals & Pet Supplies > Pet Supplies > Bird Supplies
-7385 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories
-499954 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories > Bird Cage Bird Baths
-7386 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories > Bird Cage Food & Water Dishes
-4989 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cages & Stands',
+					'body' => $this->get_test_categories_response_body(),
 				],
 				$this->get_test_category_list(),
 			],
@@ -231,6 +216,25 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/** Helper methods **************************************************************************************************/
+
+
+	/**
+	 * Gets a test categories response body.
+	 *
+	 * @return string
+	 */
+	private function get_test_categories_response_body() {
+
+		return '# Google_Product_Taxonomy_Version: 2019-07-10
+1 - Animals & Pet Supplies
+3237 - Animals & Pet Supplies > Live Animals
+2 - Animals & Pet Supplies > Pet Supplies
+3 - Animals & Pet Supplies > Pet Supplies > Bird Supplies
+7385 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories
+499954 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories > Bird Cage Bird Baths
+7386 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories > Bird Cage Food & Water Dishes
+4989 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cages & Stands';
+	}
 
 
 	/**

--- a/tests/integration/Admin/GoogleProductCategoryFieldTest.php
+++ b/tests/integration/Admin/GoogleProductCategoryFieldTest.php
@@ -151,34 +151,53 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 			'1'      => [
 				'label'  => 'Animals & Pet Supplies',
 				'parent' => '',
+				'options' => [
+					'3237'   => 'Live Animals',
+					'2'      => 'Pet Supplies',
+				]
 			],
 			'3237'   => [
 				'label'  => 'Live Animals',
 				'parent' => '1',
+				'options' => [],
 			],
 			'2'      => [
 				'label'  => 'Pet Supplies',
 				'parent' => '1',
+				'options' => [
+					'3'      => 'Bird Supplies',
+				],
 			],
 			'3'      => [
 				'label'  => 'Bird Supplies',
 				'parent' => '2',
+				'options' => [
+					'7385'   => 'Bird Cage Accessories',
+					'4989'   => 'Bird Cages & Stands',
+				]
 			],
 			'7385'   => [
 				'label'  => 'Bird Cage Accessories',
 				'parent' => '3',
+				'options' => [
+					'499954' => 'Bird Cage Bird Baths',
+					'7386'   => 'Bird Cage Food & Water Dishes',
+				],
 			],
 			'499954' => [
 				'label'  => 'Bird Cage Bird Baths',
 				'parent' => '7385',
+				'options' => [],
 			],
 			'7386'   => [
 				'label'  => 'Bird Cage Food & Water Dishes',
 				'parent' => '7385',
+				'options' => [],
 			],
 			'4989'   => [
 				'label'  => 'Bird Cages & Stands',
 				'parent' => '3',
+				'options' => [],
 			],
 		];
 	}

--- a/tests/integration/Admin/GoogleProductCategoryFieldTest.php
+++ b/tests/integration/Admin/GoogleProductCategoryFieldTest.php
@@ -104,49 +104,28 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 			'top level category' => [
 				$this->get_test_category_list(),
 				'1', [
-					'3237'   => [
-						'label'  => 'Live Animals',
-						'parent' => '1',
-					],
-					'2'      => [
-						'label'  => 'Pet Supplies',
-						'parent' => '1',
-					],
+					'3237'   => 'Live Animals',
+					'2'      => 'Pet Supplies',
 				],
 			],
 			'2nd level category' => [
 				$this->get_test_category_list(),
 				'2', [
-					'3'      => [
-						'label'  => 'Bird Supplies',
-						'parent' => '2',
-					],
+					'3'      => 'Bird Supplies',
 				],
 			],
 			'3rd level category' => [
 				$this->get_test_category_list(),
 				'3', [
-					'7385'   => [
-						'label'  => 'Bird Cage Accessories',
-						'parent' => '3',
-					],
-					'4989'   => [
-						'label'  => 'Bird Cages & Stands',
-						'parent' => '3',
-					],
+					'7385'   => 'Bird Cage Accessories',
+					'4989'   => 'Bird Cages & Stands',
 				],
 			],
 			'4th level category' => [
 				$this->get_test_category_list(),
 				'7385', [
-					'499954' => [
-						'label'  => 'Bird Cage Bird Baths',
-						'parent' => '7385',
-					],
-					'7386'   => [
-						'label'  => 'Bird Cage Food & Water Dishes',
-						'parent' => '7385',
-					],
+					'499954' => 'Bird Cage Bird Baths',
+					'7386'   => 'Bird Cage Food & Water Dishes',
 				],
 			],
 			'5th level category' => [

--- a/tests/integration/Admin/GoogleProductCategoryFieldTest.php
+++ b/tests/integration/Admin/GoogleProductCategoryFieldTest.php
@@ -103,34 +103,39 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 
 			'top level category' => [
 				$this->get_test_category_list(),
-				'1', [
-					'3237'   => 'Live Animals',
-					'2'      => 'Pet Supplies',
+				'1',
+				[
+					'3237' => 'Live Animals',
+					'2'    => 'Pet Supplies',
 				],
 			],
 			'2nd level category' => [
 				$this->get_test_category_list(),
-				'2', [
-					'3'      => 'Bird Supplies',
+				'2',
+				[
+					'3' => 'Bird Supplies',
 				],
 			],
 			'3rd level category' => [
 				$this->get_test_category_list(),
-				'3', [
-					'7385'   => 'Bird Cage Accessories',
-					'4989'   => 'Bird Cages & Stands',
+				'3',
+				[
+					'7385' => 'Bird Cage Accessories',
+					'4989' => 'Bird Cages & Stands',
 				],
 			],
 			'4th level category' => [
 				$this->get_test_category_list(),
-				'7385', [
+				'7385',
+				[
 					'499954' => 'Bird Cage Bird Baths',
 					'7386'   => 'Bird Cage Food & Water Dishes',
 				],
 			],
 			'5th level category' => [
 				$this->get_test_category_list(),
-				'499954', [],
+				'499954',
+				[],
 			],
 		];
 	}
@@ -149,54 +154,54 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 
 		return [
 			'1'      => [
-				'label'  => 'Animals & Pet Supplies',
-				'parent' => '',
+				'label'   => 'Animals & Pet Supplies',
+				'parent'  => '',
 				'options' => [
-					'3237'   => 'Live Animals',
-					'2'      => 'Pet Supplies',
-				]
+					'3237' => 'Live Animals',
+					'2'    => 'Pet Supplies',
+				],
 			],
 			'3237'   => [
-				'label'  => 'Live Animals',
-				'parent' => '1',
+				'label'   => 'Live Animals',
+				'parent'  => '1',
 				'options' => [],
 			],
 			'2'      => [
-				'label'  => 'Pet Supplies',
-				'parent' => '1',
+				'label'   => 'Pet Supplies',
+				'parent'  => '1',
 				'options' => [
-					'3'      => 'Bird Supplies',
+					'3' => 'Bird Supplies',
 				],
 			],
 			'3'      => [
-				'label'  => 'Bird Supplies',
-				'parent' => '2',
+				'label'   => 'Bird Supplies',
+				'parent'  => '2',
 				'options' => [
-					'7385'   => 'Bird Cage Accessories',
-					'4989'   => 'Bird Cages & Stands',
-				]
+					'7385' => 'Bird Cage Accessories',
+					'4989' => 'Bird Cages & Stands',
+				],
 			],
 			'7385'   => [
-				'label'  => 'Bird Cage Accessories',
-				'parent' => '3',
+				'label'   => 'Bird Cage Accessories',
+				'parent'  => '3',
 				'options' => [
 					'499954' => 'Bird Cage Bird Baths',
 					'7386'   => 'Bird Cage Food & Water Dishes',
 				],
 			],
 			'499954' => [
-				'label'  => 'Bird Cage Bird Baths',
-				'parent' => '7385',
+				'label'   => 'Bird Cage Bird Baths',
+				'parent'  => '7385',
 				'options' => [],
 			],
 			'7386'   => [
-				'label'  => 'Bird Cage Food & Water Dishes',
-				'parent' => '7385',
+				'label'   => 'Bird Cage Food & Water Dishes',
+				'parent'  => '7385',
 				'options' => [],
 			],
 			'4989'   => [
-				'label'  => 'Bird Cages & Stands',
-				'parent' => '3',
+				'label'   => 'Bird Cages & Stands',
+				'parent'  => '3',
 				'options' => [],
 			],
 		];

--- a/tests/integration/Admin/GoogleProductCategoryFieldTest.php
+++ b/tests/integration/Admin/GoogleProductCategoryFieldTest.php
@@ -50,7 +50,9 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 
 		$field = new Admin\Google_Product_Category_Field();
 
-		$this->assertNotEmpty( $field->get_categories() );
+		$parse_categories_response = IntegrationTester::getMethod( Admin\Google_Product_Category_Field::class, 'parse_categories_response' );
+
+		$this->assertEquals( $expected, $parse_categories_response->invokeArgs( $field, [ $response ] ) );
 	}
 
 
@@ -92,7 +94,7 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 
 		$field = new Admin\Google_Product_Category_Field();
 
-		$this->assertNotEmpty( $field->get_categories() );
+		$this->assertEquals( $expected, $field->get_category_options( $category_id, $categories ) );
 	}
 
 

--- a/tests/integration/Admin/GoogleProductCategoryFieldTest.php
+++ b/tests/integration/Admin/GoogleProductCategoryFieldTest.php
@@ -34,7 +34,175 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 
 	// TODO: add test for render()
 
+
 	// TODO: add test for get_categories()
+
+
+	/**
+	 * @see \SkyVerge\WooCommerce\Facebook\Admin\Google_Product_Category_Field::parse_categories_response()
+	 *
+	 * @param array $response test response
+	 * @param array $expected expected categories
+	 *
+	 * @dataProvider provider_parse_categories_response
+	 */
+	public function test_parse_categories_response( $response, $expected ) {
+
+		$field = new Admin\Google_Product_Category_Field();
+
+		$this->assertNotEmpty( $field->get_categories() );
+	}
+
+
+	/** @see test_parse_categories_response */
+	public function provider_parse_categories_response() {
+
+		return [
+			'error response'           => [ new WP_Error(), [] ],
+			'response without body'    => [ [], [] ],
+			'response with empty body' => [ [ 'body' => '' ], [] ],
+			'response with valid body' => [
+				[
+					'body' => '# Google_Product_Taxonomy_Version: 2019-07-10
+1 - Animals & Pet Supplies
+3237 - Animals & Pet Supplies > Live Animals
+2 - Animals & Pet Supplies > Pet Supplies
+3 - Animals & Pet Supplies > Pet Supplies > Bird Supplies
+7385 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories
+499954 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories > Bird Cage Bird Baths
+7386 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories > Bird Cage Food & Water Dishes
+4989 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cages & Stands',
+				],
+				$this->get_test_category_list(),
+			],
+		];
+	}
+
+
+	/**
+	 * @see \SkyVerge\WooCommerce\Facebook\Admin\Google_Product_Category_Field::get_category_options()
+	 *
+	 * @param array $categories full category list
+	 * @param string $category_id category ID
+	 * @param array $expected expected options
+	 *
+	 * @dataProvider provider_get_category_options
+	 */
+	public function test_get_category_options( $categories, $category_id, $expected ) {
+
+		$field = new Admin\Google_Product_Category_Field();
+
+		$this->assertNotEmpty( $field->get_categories() );
+	}
+
+
+	/** @see test_get_category_options */
+	public function provider_get_category_options() {
+
+		return [
+
+			'top level category' => [
+				$this->get_test_category_list(),
+				'1', [
+					'3237'   => [
+						'label'  => 'Live Animals',
+						'parent' => '1',
+					],
+					'2'      => [
+						'label'  => 'Pet Supplies',
+						'parent' => '1',
+					],
+				],
+			],
+			'2nd level category' => [
+				$this->get_test_category_list(),
+				'2', [
+					'3'      => [
+						'label'  => 'Bird Supplies',
+						'parent' => '2',
+					],
+				],
+			],
+			'3rd level category' => [
+				$this->get_test_category_list(),
+				'3', [
+					'7385'   => [
+						'label'  => 'Bird Cage Accessories',
+						'parent' => '3',
+					],
+					'4989'   => [
+						'label'  => 'Bird Cages & Stands',
+						'parent' => '3',
+					],
+				],
+			],
+			'4th level category' => [
+				$this->get_test_category_list(),
+				'7385', [
+					'499954' => [
+						'label'  => 'Bird Cage Bird Baths',
+						'parent' => '7385',
+					],
+					'7386'   => [
+						'label'  => 'Bird Cage Food & Water Dishes',
+						'parent' => '7385',
+					],
+				],
+			],
+			'5th level category' => [
+				$this->get_test_category_list(),
+				'499954', [],
+			],
+		];
+	}
+
+
+
+	/** Helper methods **************************************************************************************************/
+
+
+	/**
+	 * Gets a test category list.
+	 *
+	 * @return array
+	 */
+	private function get_test_category_list() {
+
+		return [
+			'1'      => [
+				'label'  => 'Animals & Pet Supplies',
+				'parent' => '',
+			],
+			'3237'   => [
+				'label'  => 'Live Animals',
+				'parent' => '1',
+			],
+			'2'      => [
+				'label'  => 'Pet Supplies',
+				'parent' => '1',
+			],
+			'3'      => [
+				'label'  => 'Bird Supplies',
+				'parent' => '2',
+			],
+			'7385'   => [
+				'label'  => 'Bird Cage Accessories',
+				'parent' => '3',
+			],
+			'499954' => [
+				'label'  => 'Bird Cage Bird Baths',
+				'parent' => '7385',
+			],
+			'7386'   => [
+				'label'  => 'Bird Cage Food & Water Dishes',
+				'parent' => '7385',
+			],
+			'4989'   => [
+				'label'  => 'Bird Cages & Stands',
+				'parent' => '3',
+			],
+		];
+	}
 
 
 }

--- a/tests/integration/Admin/GoogleProductCategoryFieldTest.php
+++ b/tests/integration/Admin/GoogleProductCategoryFieldTest.php
@@ -35,7 +35,93 @@ class GoogleProductCategoryFieldTest extends \Codeception\TestCase\WPTestCase {
 	// TODO: add test for render()
 
 
-	// TODO: add test for get_categories()
+	/** @see \SkyVerge\WooCommerce\Facebook\Admin\Google_Product_Category_Field::get_categories() */
+	public function test_get_categories_transient() {
+
+		$transient_value = [
+			'1' => [
+				'label'   => 'Animals & Pet Supplies',
+				'parent'  => '',
+				'options' => [
+					'3237' => 'Live Animals',
+					'2'    => 'Pet Supplies',
+				],
+			],
+		];
+
+		set_transient( Admin\Google_Product_Category_Field::OPTION_GOOGLE_PRODUCT_CATEGORIES, $transient_value, HOUR_IN_SECONDS );
+
+		$field = new Admin\Google_Product_Category_Field();
+
+		$this->assertEquals( $transient_value, $field->get_categories() );
+	}
+
+
+	/** @see \SkyVerge\WooCommerce\Facebook\Admin\Google_Product_Category_Field::get_categories() */
+	public function test_get_categories_error() {
+
+		$field = new Admin\Google_Product_Category_Field();
+
+		add_filter( 'pre_http_request', static function() {
+
+			return new WP_Error();
+		} );
+
+		$this->assertEquals( [], $field->get_categories() );
+	}
+
+
+	/** @see \SkyVerge\WooCommerce\Facebook\Admin\Google_Product_Category_Field::get_categories() */
+	public function test_get_categories_error_option_set() {
+
+		$option_value = [
+			'1' => [
+				'label'   => 'Animals & Pet Supplies',
+				'parent'  => '',
+				'options' => [
+					'3237' => 'Live Animals',
+					'2'    => 'Pet Supplies',
+				],
+			],
+		];
+
+		update_option( Admin\Google_Product_Category_Field::OPTION_GOOGLE_PRODUCT_CATEGORIES, $option_value );
+
+		$field = new Admin\Google_Product_Category_Field();
+
+		add_filter( 'pre_http_request', static function() {
+
+			return new WP_Error();
+		} );
+
+		$this->assertEquals( $option_value, $field->get_categories() );
+	}
+
+
+	/** @see \SkyVerge\WooCommerce\Facebook\Admin\Google_Product_Category_Field::get_categories() */
+	public function test_get_categories_success() {
+
+		$field = new Admin\Google_Product_Category_Field();
+
+		add_filter( 'pre_http_request', static function () {
+
+			return [
+				'body' => '# Google_Product_Taxonomy_Version: 2019-07-10
+1 - Animals & Pet Supplies
+3237 - Animals & Pet Supplies > Live Animals
+2 - Animals & Pet Supplies > Pet Supplies
+3 - Animals & Pet Supplies > Pet Supplies > Bird Supplies
+7385 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories
+499954 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories > Bird Cage Bird Baths
+7386 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories > Bird Cage Food & Water Dishes
+4989 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cages & Stands',
+			];
+		} );
+
+		$this->assertEquals( $this->get_test_category_list(), $field->get_categories() );
+		$this->assertEquals( $this->get_test_category_list(), get_option( Admin\Google_Product_Category_Field::OPTION_GOOGLE_PRODUCT_CATEGORIES ) );
+		$this->assertEquals( $this->get_test_category_list(), get_transient( Admin\Google_Product_Category_Field::OPTION_GOOGLE_PRODUCT_CATEGORIES ) );
+	}
 
 
 	/**


### PR DESCRIPTION
# Summary

This PR implements the `Google_Product_Category_Field::get_categories()` method.

### Story: [CH 63583](https://app.clubhouse.io/skyverge/story/63583/implement-the-google-product-category-field-getter)
### Release: #1477 

## Details

I've added a couple of auxiliar methods, just so this one wasn't larger than life.

I've also refactored the categories' structure as [discussed on the implementation doc](https://docs.google.com/document/d/11AG_ZVIYGKn96BvEn_Qwy91FOALeE7GmB5cpfN1D6LU/edit?disco=AAAAJ4F5PxA), to be a single level array of categories, indexed by their IDs, with their:
- label
- parent
- options (key-value array with the options' labels, to avoid the JS having to lookup the label for each option)

The JS will be able to retrieve the options (IDs and labels) for any category by looking for the category ID on the array keys and grabbing its `options` value.

## QA

- [x] `tests/integration/Admin/GoogleProductCategoryFieldTest.php` tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version