### PR TITLE
Implement the commerce settings connect URL method

### DIFF
--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -104,7 +104,8 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 		], home_url( '/' ) );
 
 		// build the proxy app URL where the user will land after onboarding, to be redirected to the site URL
-		$redirect_url = add_query_arg( 'site_url', $site_url, facebook_for_woocommerce()->get_connection_handler()->get_proxy_url() );
+		$redirect_url = add_query_arg( 'site_url', urlencode( $site_url ), facebook_for_woocommerce()->get_connection_handler()->get_proxy_url() );
+```
 
 		// build the final connect URL, direct to Facebook
 		$connect_url = add_query_arg( [

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -99,8 +99,8 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 
 		// build the site URL to which the user will ultimately return
 		$site_url = add_query_arg( [
-			'wc-api'               => Connection_Handler::ACTION_CONNECT_COMMERCE,
-			'nonce'                => wp_create_nonce( Connection_Handler::ACTION_CONNECT_COMMERCE ),
+			'wc-api' => Connection_Handler::ACTION_CONNECT_COMMERCE,
+			'nonce'  => wp_create_nonce( Connection_Handler::ACTION_CONNECT_COMMERCE ),
 		], home_url( '/' ) );
 
 		// build the proxy app URL where the user will land after onboarding, to be redirected to the site URL

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -13,6 +13,7 @@ namespace SkyVerge\WooCommerce\Facebook\Admin\Settings_Screens;
 defined( 'ABSPATH' ) or exit;
 
 use SkyVerge\WooCommerce\Facebook\Admin;
+use SkyVerge\WooCommerce\Facebook\Handlers\Connection as Connection_Handler;
 
 /**
  * The Commerce settings screen object.
@@ -83,7 +84,29 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	 */
 	public function get_connect_url() {
 
-		return '';
+		// build the site URL to which the user will ultimately return
+		$site_url = add_query_arg( [
+			'wc-api'               => Connection_Handler::ACTION_CONNECT_COMMERCE,
+			'nonce'                => wp_create_nonce( Connection_Handler::ACTION_CONNECT_COMMERCE ),
+		], home_url( '/' ) );
+
+		// build the proxy app URL where the user will land after onboarding, to be redirected to the site URL
+		$redirect_url = add_query_arg( 'site_url', $site_url, facebook_for_woocommerce()->get_connection_handler()->get_proxy_url() );
+
+		// build the final connect URL, direct to Facebook
+		$connect_url = add_query_arg( [
+			'app_id'       => facebook_for_woocommerce()->get_connection_handler()->get_client_id(), // this endpoint calls the client ID "app ID"
+			'redirect_url' => urlencode( $redirect_url ),
+		], 'https://www.facebook.com/commerce_manager/onboarding/' );
+
+		/**
+		 * Filters the URL used to connect to Facebook Commerce.
+		 *
+		 * @since 2.1.0-dev.1
+		 *
+		 * @param string $connect_url connect URL
+		 */
+		return apply_filters( 'wc_facebook_commerce_connect_url', $connect_url );
 	}
 
 

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -78,6 +78,19 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	/**
 	 * Builds the connect URL.
 	 *
+	 * The base URL is https://www.facebook.com/commerce_manager/onboarding with two query variables:
+	 * - app_id - the developer app ID
+	 * - redirect_url - the URL where the user will land after onboarding is complete
+	 *
+	 * The redirect URL must be an approved domain, so it must be the connect.woocommerce.com proxy app. In that URL, we
+	 * include the final site URL, which is where the merchant will redirect to with the data that needs to be stored.
+	 * So the final URL looks like this without encoding:
+	 *
+	 * https://www.facebook.com/commerce_manager/onboarding/?app_id={id}&redirect_url=https://connect.woocommerce.com/auth/facebook/?site_url=https://example.com/?wc-api=wc_facebook_connect_commerce&nonce=1234
+	 *
+	 * If testing only, &is_test_mode=true can be appended to the URL using the wc_facebook_commerce_connect_url filter
+	 * to trigger the test account flow, where fake US-based business details can be used.
+	 *
 	 * @since 2.1.0-dev.1
 	 *
 	 * @return string

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -105,7 +105,6 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 
 		// build the proxy app URL where the user will land after onboarding, to be redirected to the site URL
 		$redirect_url = add_query_arg( 'site_url', urlencode( $site_url ), facebook_for_woocommerce()->get_connection_handler()->get_proxy_url() );
-```
 
 		// build the final connect URL, direct to Facebook
 		$connect_url = add_query_arg( [

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -871,7 +871,7 @@ class Connection {
 	 *
 	 * @return string
 	 */
-	private function get_client_id() {
+	public function get_client_id() {
 
 		/**
 		 * Filters the client ID.

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -37,6 +37,9 @@ class Connection {
 	/** @var string the action callback for the disconnection */
 	const ACTION_DISCONNECT = 'wc_facebook_disconnect';
 
+	/** @var string the action callback for the connection */
+	const ACTION_CONNECT_COMMERCE = 'wc_facebook_connect_commerce';
+
 	/** @var string the WordPress option name where the external business ID is stored */
 	const OPTION_EXTERNAL_BUSINESS_ID = 'wc_facebook_external_business_id';
 

--- a/tests/integration/Admin/Settings_Screens/CommerceTest.php
+++ b/tests/integration/Admin/Settings_Screens/CommerceTest.php
@@ -43,7 +43,7 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertStringContainsString( 'https://www.facebook.com/commerce_manager/onboarding/?app_id=', $connect_url );
 		$this->assertStringContainsString( 'redirect_url=https%3A%2F%2Fconnect.woocommerce.com%2Fauth%2Ffacebook%2F%3Fsite_url%3D', $connect_url );
-		$this->assertStringContainsString( 'wc-api%3D' . \SkyVerge\WooCommerce\Facebook\Handlers\Connection::ACTION_CONNECT_COMMERCE . '%26nonce%3D', $connect_url );
+		$this->assertStringContainsString( 'wc-api%253D' . \SkyVerge\WooCommerce\Facebook\Handlers\Connection::ACTION_CONNECT_COMMERCE . '%2526nonce%253D', $connect_url );
 	}
 
 

--- a/tests/integration/Admin/Settings_Screens/CommerceTest.php
+++ b/tests/integration/Admin/Settings_Screens/CommerceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook\Tests\Admin\Settings_Screens;
+
+use SkyVerge\WooCommerce\Facebook\Admin\Settings_Screens;
+
+/**
+ * Tests the Admin\Settings class.
+ */
+class CommerceTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/**
+	 * Runs before each test.
+	 */
+	protected function _before() {
+
+		require_once 'includes/Admin/Abstract_Settings_Screen.php';
+		require_once 'includes/Admin/Settings_Screens/Commerce.php';
+	}
+
+
+	/**
+	 * Runs after each test.
+	 */
+	protected function _after() {
+
+	}
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	/** @see Settings_Screens\Commerce::get_connect_url() */
+	public function test_get_connect_url() {
+
+		$screen = new Settings_Screens\Commerce();
+		$connect_url = $screen->get_connect_url();
+
+		$this->assertStringContainsString( 'https://www.facebook.com/commerce_manager/onboarding/?app_id=', $connect_url );
+		$this->assertStringContainsString( 'redirect_url=https%3A%2F%2Fconnect.woocommerce.com%2Fauth%2Ffacebook%2F%3Fsite_url%3D', $connect_url );
+		$this->assertStringContainsString( 'wc-api%3D' . \SkyVerge\WooCommerce\Facebook\Handlers\Connection::ACTION_CONNECT_COMMERCE . '%26nonce%3D', $connect_url );
+	}
+
+
+}

--- a/tests/integration/Admin/Settings_Screens/CommerceTest.php
+++ b/tests/integration/Admin/Settings_Screens/CommerceTest.php
@@ -5,7 +5,7 @@ namespace SkyVerge\WooCommerce\Facebook\Tests\Admin\Settings_Screens;
 use SkyVerge\WooCommerce\Facebook\Admin\Settings_Screens;
 
 /**
- * Tests the Admin\Settings class.
+ * Tests the Settings_Screens\Commerce class.
  */
 class CommerceTest extends \Codeception\TestCase\WPTestCase {
 


### PR DESCRIPTION
# Summary

Builds the Commerce connect URL.

### Story: [CH 63623](https://app.clubhouse.io/skyverge/story/63623)
### Release: #1477 

## UI Changes

_N/A_

## QA

- `integration Admin/Settings_Screens` tests pass

We will confirm further with acceptance tests once the settings screen has been implemented.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version