### PR TITLE
Implement the Commerce Google Product Category settings field

### DIFF
--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -68,9 +68,25 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	 * @internal
 
 	 * @since 2.1.0-dev.1
+	 *
+	 * @param array $field field data
 	 */
-	public function render_google_product_category_field() {
+	public function render_google_product_category_field( $field ) {
 
+		$category_field = new Admin\Google_Product_Category_Field();
+
+		?>
+		<tr valign="top">
+			<th scope="row" class="titledesc">
+				<label for="<?php echo esc_attr( $field['id'] ); ?>"><?php echo esc_html( $field['title'] ); ?>
+					<span class="woocommerce-help-tip" data-tip="<?php echo esc_attr( $field['desc_tip'] ); ?>"></span>
+				</label>
+			</th>
+			<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $field['type'] ) ); ?>">
+				<?php $category_field->render( $field['id'] ); ?>
+			</td>
+		</tr>
+		<?php
 	}
 
 
@@ -98,8 +114,10 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 
 		return [
 			[
-				'id'   => \SkyVerge\WooCommerce\Facebook\Commerce::OPTION_GOOGLE_PRODUCT_CATEGORY_ID,
-				'type' => 'commerce_google_product_categories',
+				'id'       => \SkyVerge\WooCommerce\Facebook\Commerce::OPTION_GOOGLE_PRODUCT_CATEGORY_ID,
+				'type'     => 'commerce_google_product_categories',
+				'title'    => __( 'Default Google product category', 'facebook-for-woocommerce' ),
+				'desc_tip' => __( 'Choose a default Google product category for your products. Defaults can also be set for product categories. Products need at least two category levels defined to sell via Instagram.', 'facebook-for-woocommerce' ),
 			],
 		];
 	}


### PR DESCRIPTION
# Summary

This PR implements the `Settings_Screens\Commerce::render_google_product_category_field()` method.

### Story: [CH 63632](https://app.clubhouse.io/skyverge/story/63632/implement-the-commerce-google-product-category-settings-field)
### Release: #1477 

## QA

### Setup

- The plugin is active and connected

### Steps

1. Navigate to the WooCommerce > Facebook page
1. Navigate to the Instagram Checkout tab
    - [x] The label for the product category field is displayed ("Default Google product category")
    - [x] The tooltip icon is displayed (it does not work because the JS is not enqueued yet, though)

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version