### PR TITLE
Admin\Product_Categories - Implement the field rendering methods

### DIFF
--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -80,7 +80,12 @@ class Product_Categories {
 
 		?>
 			<tr class="form-field term-<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>-wrap">
-				<th scope="row"><label for="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"></label></th>
+				<th scope="row">
+					<label for="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>">
+						<?php echo esc_html( $this->get_google_product_category_field_title() ); ?>
+						<?php $this->render_google_product_category_tooltip(); ?>
+					</label>
+				</th>
 				<td>
 					<input type="hidden" id="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
 					       name="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"/>

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -80,7 +80,8 @@ class Product_Categories {
 			<tr class="form-field term-<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>-wrap">
 				<th scope="row"><label for="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"></label></th>
 				<td>
-
+					<input type="hidden" id="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
+					       name="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"/>
 				</td>
 			</tr>
 		<?php

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -57,7 +57,8 @@ class Product_Categories {
 
 		?>
 			<div class="form-field term-<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>-wrap">
-
+				<input type="hidden" id="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
+				       name="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"/>
 			</div>
 		<?php
 	}

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -76,12 +76,15 @@ class Product_Categories {
 	 */
 	public function render_edit_google_product_category_field() {
 
+		$category_field = new Google_Product_Category_Field();
+
 		?>
 			<tr class="form-field term-<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>-wrap">
 				<th scope="row"><label for="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"></label></th>
 				<td>
 					<input type="hidden" id="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
 					       name="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"/>
+					<?php $category_field->render( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>
 				</td>
 			</tr>
 		<?php

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -93,6 +93,7 @@ class Product_Categories {
 	 */
 	public function get_google_product_category_field_title() {
 
+		return __( 'Default Google product category', 'facebook-for-woocommerce' );
 	}
 
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -79,6 +79,11 @@ class Product_Categories {
 	 */
 	public function render_google_product_category_tooltip() {
 
+		$tooltip_text = __( 'Choose a default Google product category for products in this category. Products need at least two category levels defined to be sold on Instagram.', 'facebook-for-woocommerce' );
+
+		?>
+			<span class="woocommerce-help-tip" data-tip="<?php echo esc_attr( $tooltip_text ); ?>"></span>
+		<?php
 	}
 
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -76,6 +76,14 @@ class Product_Categories {
 	 */
 	public function render_edit_google_product_category_field() {
 
+		?>
+			<tr class="form-field term-<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>-wrap">
+				<th scope="row"><label for="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"></label></th>
+				<td>
+
+				</td>
+			</tr>
+		<?php
 	}
 
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -59,6 +59,10 @@ class Product_Categories {
 
 		?>
 			<div class="form-field term-<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>-wrap">
+				<label for="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>">
+					<?php echo esc_html( $this->get_google_product_category_field_title() ); ?>
+					<?php $this->render_google_product_category_tooltip(); ?>
+				</label>
 				<input type="hidden" id="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
 				       name="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"/>
 				<?php $category_field->render( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -31,6 +31,10 @@ class Product_Categories {
 	 */
 	public function __construct() {
 
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+
+		add_action( 'product_cat_add_form_fields', [ $this, 'render_add_google_product_category_field' ] );
+		add_action( 'product_cat_edit_form_fields', [ $this, 'render_edit_google_product_category_field' ] );
 	}
 
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -55,6 +55,11 @@ class Product_Categories {
 	 */
 	public function render_add_google_product_category_field() {
 
+		?>
+			<div class="form-field term-<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>-wrap">
+
+			</div>
+		<?php
 	}
 
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -55,10 +55,13 @@ class Product_Categories {
 	 */
 	public function render_add_google_product_category_field() {
 
+		$category_field = new Google_Product_Category_Field();
+
 		?>
 			<div class="form-field term-<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>-wrap">
 				<input type="hidden" id="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
 				       name="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"/>
+				<?php $category_field->render( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>
 			</div>
 		<?php
 	}

--- a/tests/integration/Admin/ProductCategoriesTest.php
+++ b/tests/integration/Admin/ProductCategoriesTest.php
@@ -40,7 +40,13 @@ class ProductCategoriesTest extends \Codeception\TestCase\WPTestCase {
 
 	// TODO: add test for render_google_product_category_tooltip()
 
-	// TODO: add test for get_google_product_category_field_title()
+
+	/** @see Product_Categories::get_google_product_category_field_title() */
+	public function test_get_google_product_category_field_title() {
+
+		$this->assertEquals( 'Default Google product category', $this->get_product_categories_handler()->get_google_product_category_field_title() );
+	}
+
 
 	// TODO: add test for save_google_product_category()
 
@@ -49,7 +55,7 @@ class ProductCategoriesTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
-	 * Gets an orders handler instance.
+	 * Gets a handler instance.
 	 *
 	 * @since 2.1.0-dev.1
 	 *

--- a/tests/integration/Admin/ProductCategoriesTest.php
+++ b/tests/integration/Admin/ProductCategoriesTest.php
@@ -38,7 +38,16 @@ class ProductCategoriesTest extends \Codeception\TestCase\WPTestCase {
 
 	// TODO: add test for render_edit_google_product_category_field()
 
-	// TODO: add test for render_google_product_category_tooltip()
+
+	/** @see Product_Categories::render_google_product_category_tooltip() */
+	public function test_render_google_product_category_tooltip() {
+
+		ob_start();
+		$this->get_product_categories_handler()->render_google_product_category_tooltip();
+		$html = trim( ob_get_clean() );
+
+		$this->assertEquals( '<span class="woocommerce-help-tip" data-tip="Choose a default Google product category for products in this category. Products need at least two category levels defined to be sold on Instagram."></span>', $html );
+	}
 
 
 	/** @see Product_Categories::get_google_product_category_field_title() */

--- a/tests/integration/Admin/ProductCategoriesTest.php
+++ b/tests/integration/Admin/ProductCategoriesTest.php
@@ -35,8 +35,6 @@ class ProductCategoriesTest extends \Codeception\TestCase\WPTestCase {
 
 	// TODO: add test for enqueue_assets()
 
-	// TODO: add test for render_add_google_product_category_field()
-
 
 	/** @see Product_Categories::render_add_google_product_category_field() */
 	public function test_render_add_google_product_category_field() {
@@ -48,6 +46,8 @@ class ProductCategoriesTest extends \Codeception\TestCase\WPTestCase {
 		$html = trim( ob_get_clean() );
 
 		$this->assertStringContainsString( '<div class="form-field term-wc_facebook_google_product_category_id-wrap">', $html );
+		$this->assertStringContainsString( '<label for="wc_facebook_google_product_category_id">', $html );
+		$this->assertStringContainsString( '<span class="woocommerce-help-tip"', $html );
 		$this->assertStringContainsString( '<input type="hidden" id="wc_facebook_google_product_category_id"
 				       name="wc_facebook_google_product_category_id"/>', $html );
 
@@ -55,7 +55,23 @@ class ProductCategoriesTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	// TODO: add test for render_edit_google_product_category_field()
+	/** @see Product_Categories::render_edit_google_product_category_field() */
+	public function test_render_edit_google_product_category_field() {
+
+		global $wc_queued_js;
+
+		ob_start();
+		$this->get_product_categories_handler()->render_edit_google_product_category_field();
+		$html = trim( ob_get_clean() );
+
+		$this->assertStringContainsString( '<tr class="form-field term-wc_facebook_google_product_category_id-wrap">', $html );
+		$this->assertStringContainsString( '<label for="wc_facebook_google_product_category_id">', $html );
+		$this->assertStringContainsString( '<span class="woocommerce-help-tip"', $html );
+		$this->assertStringContainsString( '<input type="hidden" id="wc_facebook_google_product_category_id"
+					       name="wc_facebook_google_product_category_id"/>', $html );
+
+		$this->assertStringContainsString( 'new WC_Facebook_Google_Product_Category_Fields', $wc_queued_js );
+	}
 
 
 	/** @see Product_Categories::render_google_product_category_tooltip() */

--- a/tests/integration/Admin/ProductCategoriesTest.php
+++ b/tests/integration/Admin/ProductCategoriesTest.php
@@ -18,6 +18,7 @@ class ProductCategoriesTest extends \Codeception\TestCase\WPTestCase {
 	protected function _before() {
 
 		require_once 'includes/Admin/Product_Categories.php';
+		require_once 'includes/Admin/Google_Product_Category_Field.php';
 	}
 
 
@@ -35,6 +36,24 @@ class ProductCategoriesTest extends \Codeception\TestCase\WPTestCase {
 	// TODO: add test for enqueue_assets()
 
 	// TODO: add test for render_add_google_product_category_field()
+
+
+	/** @see Product_Categories::render_add_google_product_category_field() */
+	public function test_render_add_google_product_category_field() {
+
+		global $wc_queued_js;
+
+		ob_start();
+		$this->get_product_categories_handler()->render_add_google_product_category_field();
+		$html = trim( ob_get_clean() );
+
+		$this->assertStringContainsString( '<div class="form-field term-wc_facebook_google_product_category_id-wrap">', $html );
+		$this->assertStringContainsString( '<input type="hidden" id="wc_facebook_google_product_category_id"
+				       name="wc_facebook_google_product_category_id"/>', $html );
+
+		$this->assertStringContainsString( 'new WC_Facebook_Google_Product_Category_Fields', $wc_queued_js );
+	}
+
 
 	// TODO: add test for render_edit_google_product_category_field()
 


### PR DESCRIPTION
# Summary

This PR implements the `Admin\Product_Categories::get_google_product_category_field_title()`, `Admin\Product_Categories::render_google_product_category_tooltip()`, `Admin\Product_Categories::render_add_google_product_category_field()`, and `Admin\Product_Categories::render_edit_google_product_category_field()` methods.

### Story: [CH 63657](https://app.clubhouse.io/skyverge/story/63657/admin-product-categories-implement-the-field-rendering-methods)
### Release: #1477 

## QA

- [x] `tests/integration/Admin/ProductCategoriesTest.php` pass

### Setup

- The plugin is active and connected

### Steps

1. Navigate to Products > Categories
    - [x] The add form displays the field label "Default Google product category"
       - [x] The field label displays the tooltip icon
          - [x] The tooltip displays the text "Choose a default Google product category for products in this category. Products need at least two category levels defined to be sold on Instagram."
1. Click to edit a category
    - [x] The edit form displays the field label "Default Google product category"
       - [x] The field label displays the tooltip icon
          - [x] The tooltip displays the text "Choose a default Google product category for products in this category. Products need at least two category levels defined to be sold on Instagram."

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version