### PR TITLE
Implement the Commerce settings rendering

### DIFF
--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -59,7 +59,11 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	 */
 	public function render() {
 
-		parent::render();
+		// if not connected, fall back to standard display
+		if ( ! facebook_for_woocommerce()->get_connection_handler()->is_connected() ) {
+			parent::render();
+			return;
+		}
 	}
 
 

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -80,9 +80,10 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 					<th scope="row" class="titledesc"><?php esc_html_e( 'Sell on Instagram', 'facebook-for-woocommerce' ); ?></th>
 					<td class="forminp">
 						<?php if ( facebook_for_woocommerce()->get_commerce_handler()->is_connected() ) : ?>
-							<span class="dashicons dashicons-yes-alt" style="color:#4CB454"></span> <?php esc_html_e( 'Your store is connected to Instagram.', 'facebook-for-woocommerce' ); ?>
+							<p><span class="dashicons dashicons-yes-alt" style="color:#4CB454"></span> <?php esc_html_e( 'Your store is connected to Instagram.', 'facebook-for-woocommerce' ); ?></p>
 						<?php else: ?>
-							<span class="dashicons dashicons-dismiss" style="color:#dc3232"></span> <?php esc_html_e( 'Your store is not connected to Instagram.', 'facebook-for-woocommerce' ); ?>
+							<p><span class="dashicons dashicons-dismiss" style="color:#dc3232"></span> <?php esc_html_e( 'Your store is not connected to Instagram.', 'facebook-for-woocommerce' ); ?></p>
+
 						<?php endif; ?>
 					</td>
 				</tr>

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -64,6 +64,11 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 			parent::render();
 			return;
 		}
+
+		if ( ! facebook_for_woocommerce()->get_commerce_handler()->is_available() ) {
+			$this->render_us_only_limitation_notice();
+			return;
+		}
 	}
 
 

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -90,6 +90,8 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 		</table>
 
 		<?php
+
+		parent::render();
 	}
 
 

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -97,7 +97,9 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 
 		<?php
 
-		parent::render();
+        if ( $commerce_handler->is_connected() ) {
+			parent::render();
+		}
 	}
 
 

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -74,6 +74,21 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 
 		<h2><?php esc_html_e( 'Instagram Checkout', 'facebook-for-woocommerce' ); ?></h2>
 
+		<table class="form-table">
+			<tbody>
+				<tr valign="top" class="">
+					<th scope="row" class="titledesc"><?php esc_html_e( 'Sell on Instagram', 'facebook-for-woocommerce' ); ?></th>
+					<td class="forminp">
+						<?php if ( facebook_for_woocommerce()->get_commerce_handler()->is_connected() ) : ?>
+							<span class="dashicons dashicons-yes-alt" style="color:#4CB454"></span> <?php esc_html_e( 'Your store is connected to Instagram.', 'facebook-for-woocommerce' ); ?>
+						<?php else: ?>
+							<span class="dashicons dashicons-dismiss" style="color:#dc3232"></span> <?php esc_html_e( 'Your store is not connected to Instagram.', 'facebook-for-woocommerce' ); ?>
+						<?php endif; ?>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+
 		<?php
 	}
 

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -68,6 +68,21 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 
 
 	/**
+	 * Renders the notice about the US-only limitation for Instagram Checkout.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	private function render_us_only_limitation_notice() {
+
+		?>
+
+		<div class="notice notice-info"><p><?php esc_html_e( 'Instagram Checkout is only available to merchants located in the United States.', 'facebook-for-woocommerce' ); ?></p></div>
+
+		<?php
+	}
+
+
+	/**
 	 * Renders the Google category field markup.
 	 *
 	 * @internal

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -97,7 +97,7 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 
 		<?php
 
-        if ( $commerce_handler->is_connected() ) {
+		if ( $commerce_handler->is_connected() ) {
 			parent::render();
 		}
 	}

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -141,4 +141,21 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	}
 
 
+	/**
+	 * Gets the "disconnected" message.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_disconnected_message() {
+
+		return sprintf(
+			/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
+			__( 'Please %1$sconnect to Facebook%2$s to enable Instagram Checkout.', 'facebook-for-woocommerce' ),
+			'<a href="' . esc_url( facebook_for_woocommerce()->get_connection_handler()->get_connect_url() ) . '">', '</a>'
+		);
+	}
+
+
 }

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -65,7 +65,9 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 			return;
 		}
 
-		if ( ! facebook_for_woocommerce()->get_commerce_handler()->is_available() ) {
+		$commerce_handler = facebook_for_woocommerce()->get_commerce_handler();
+
+		if ( ! $commerce_handler->is_available() ) {
 			$this->render_us_only_limitation_notice();
 			return;
 		}
@@ -79,7 +81,7 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 				<tr valign="top" class="">
 					<th scope="row" class="titledesc"><?php esc_html_e( 'Sell on Instagram', 'facebook-for-woocommerce' ); ?></th>
 					<td class="forminp">
-						<?php if ( facebook_for_woocommerce()->get_commerce_handler()->is_connected() ) : ?>
+						<?php if ( $commerce_handler->is_connected() ) : ?>
 							<p><span class="dashicons dashicons-yes-alt" style="color:#4CB454"></span> <?php esc_html_e( 'Your store is connected to Instagram.', 'facebook-for-woocommerce' ); ?></p>
 						<?php else: ?>
 							<p><span class="dashicons dashicons-dismiss" style="color:#dc3232"></span> <?php esc_html_e( 'Your store is not connected to Instagram.', 'facebook-for-woocommerce' ); ?></p>

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -84,6 +84,9 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 						<?php else: ?>
 							<p><span class="dashicons dashicons-dismiss" style="color:#dc3232"></span> <?php esc_html_e( 'Your store is not connected to Instagram.', 'facebook-for-woocommerce' ); ?></p>
 
+							<p style="margin-top:24px">
+								<a class="button button-primary" href="<?php echo esc_url( $this->get_connect_url() ); ?>"><?php esc_html_e( 'Connect', 'facebook-for-woocommerce' ); ?></a>
+							</p>
 						<?php endif; ?>
 					</td>
 				</tr>

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -69,6 +69,12 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 			$this->render_us_only_limitation_notice();
 			return;
 		}
+
+		?>
+
+		<h2><?php esc_html_e( 'Instagram Checkout', 'facebook-for-woocommerce' ); ?></h2>
+
+		<?php
 	}
 
 

--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -189,9 +189,15 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 
 		return [
 			[
+				'type' => 'title',
+			],
+			[
 				'id'   => \SkyVerge\WooCommerce\Facebook\Commerce::OPTION_GOOGLE_PRODUCT_CATEGORY_ID,
 				'type' => 'commerce_google_product_categories',
 			],
+			[
+				'type' => 'sectionend',
+			]
 		];
 	}
 

--- a/tests/acceptance/Admin/Settings/CommerceCest.php
+++ b/tests/acceptance/Admin/Settings/CommerceCest.php
@@ -49,6 +49,25 @@ class InstagramCheckoutCest {
 
 
 	/**
+	 * Test that the Connect button is shown if the store is not connected.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 */
+	public function try_connect_button_is_present( AcceptanceTester $I ) {
+
+		$I->dontHaveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_PAGE_ACCESS_TOKEN );
+
+		$I->amOnAdminPage('admin.php?page=wc-facebook&tab=commerce' );
+
+		$I->wantTo( 'Test that the Connect button is shown if the store is not connected.' );
+
+		$I->see( 'Connect', 'a.button.button-primary' );
+
+		$I->dontSee( 'Save changes' );
+	}
+
+
+	/**
 	 * Test that the Facebook connection message is shown if the plugin is not connected.
 	 *
 	 * @param AcceptanceTester $I tester instance

--- a/tests/acceptance/Admin/Settings/CommerceCest.php
+++ b/tests/acceptance/Admin/Settings/CommerceCest.php
@@ -1,6 +1,6 @@
 <?php
 
-class InstagramCheckoutCest {
+class CommerceCest {
 
 
 	/**

--- a/tests/acceptance/Admin/Settings/CommerceCest.php
+++ b/tests/acceptance/Admin/Settings/CommerceCest.php
@@ -1,8 +1,5 @@
 <?php
 
-use Codeception\Exception\InjectionException;
-use Codeception\Exception\ConditionalAssertionFailed;
-
 class InstagramCheckoutCest {
 
 

--- a/tests/acceptance/Admin/Settings/InstagramCheckoutCest.php
+++ b/tests/acceptance/Admin/Settings/InstagramCheckoutCest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Codeception\Exception\InjectionException;
+use Codeception\Exception\ConditionalAssertionFailed;
+
+class InstagramCheckoutCest {
+
+
+	/**
+	 * Runs before each test.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 */
+	public function _before( AcceptanceTester $I ) {
+
+		$I->haveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_ACCESS_TOKEN, '1235' );
+		$I->haveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_PAGE_ACCESS_TOKEN, '1235' );
+
+		$I->loginAsAdmin();
+	}
+
+
+	/**
+	 * Test that the Instagram Checkout connection message is shown.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 */
+	public function try_store_connect_to_instagram_message( AcceptanceTester $I ) {
+
+		$I->amOnAdminPage('admin.php?page=wc-facebook&tab=commerce' );
+
+		$I->wantTo( 'Test that the Instagram Checkout connection message is shown' );
+
+		$I->see( 'Your store is connected to Instagram.', '.forminp' );
+	}
+
+	/**
+	 * Test that the Instagram Checkout connection message is shown if the store is not connected.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 */
+	public function try_store_not_connected_to_instagram_message( AcceptanceTester $I ) {
+
+		$I->dontHaveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_PAGE_ACCESS_TOKEN );
+
+		$I->amOnAdminPage('admin.php?page=wc-facebook&tab=commerce' );
+
+		$I->wantTo( 'Test that the Instagram Checkout connection message is shown when the store is not connected' );
+
+		$I->see( 'Your store is not connected to Instagram.', '.forminp' );
+	}
+
+
+	/**
+	 * Test that the Facebook connection message is shown if the plugin is not connected.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 */
+	public function try_connect_message( AcceptanceTester $I ) {
+
+		$I->dontHaveOptionInDatabase( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::OPTION_ACCESS_TOKEN );
+
+		$I->amOnAdminPage('admin.php?page=wc-facebook&tab=commerce' );
+
+		$I->see( 'Please connect to Facebook to enable Instagram Checkout', '.notice' );
+	}
+
+
+	/**
+	 * Test that the US-only limitation message is shown if the default country is not US.
+	 *
+	 * @param AcceptanceTester $I tester instance
+	 */
+	public function try_us_only_limitation_message( AcceptanceTester $I ) {
+
+		$I->haveOptionInDatabase( 'woocommerce_default_country', 'UK' );
+
+		$I->amOnAdminPage('admin.php?page=wc-facebook&tab=commerce' );
+
+		$I->see( 'Instagram Checkout is only available to merchants located in the United States.', '.notice' );
+	}
+
+
+}


### PR DESCRIPTION
# Summary

Renders the Commerce settings screen as described in the pitch.

### Story: [CH 63636](https://app.clubhouse.io/skyverge/story/63636)
### Release: #1477 

## UI Changes

- A notice is shown if the plugin is not connected: https://cloud.skyver.ge/YEuo9Q5p
- A notice is shown if Commerce is not available: https://cloud.skyver.ge/E0un19GE
- A message is shown to indicate whether the store is connected to Commerce: https://cloud.skyver.ge/bLuRngeB and https://cloud.skyver.ge/geuzN4ve
- A Connect button is shown if the store is not connected: https://cloud.skyver.ge/bLuRngeB

## QA

### Setup

### Steps

1. Add `add_filter( 'wc_facebook_connection_access_token', '__return_false' )` 
1. Go to WooCommerce > Facebook > Instagram Checkout 
    - [x] The plugin not connected message is shown
1. Remove the previous filter and add `add_filter( 'wc_facebook_commerce_is_available', '__return_false' )` 
1. Go to WooCommerce > Facebook > Instagram Checkout 
    - [x] A notice indicates that Commerce is not available
1. Remove the previous filter and add `add_filter( 'wc_facebook_commerce_is_connected', '__return_false' )`
1. Go to WooCommerce > Facebook > Instagram Checkout 
    - [x] A message indicates that the store is not connected
    - [x] A Connect button shows up
    - [x] No Save changes button is shown
1. Remove the previous filter and add `add_filter( 'wc_facebook_commerce_is_connected', '__return_true' )`
1. Go to WooCommerce > Facebook > Instagram Checkout 
    - [x] A message indicates that the store IS connected
    - [x] The Connect button does not show up
    - [x] The Save changes button is shown

### Tests

- [ ] `acceptance Admin/Settings/CommerceCest.php` tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version