### PR TITLE
Admin\Product_Categories - Implement the field saving method

### DIFF
--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -165,7 +165,6 @@ class Product_Categories {
 			// get the products in the category being saved
 			$products = wc_get_products(
 				[
-					'type'     => ['simple', 'variable'],
 					'category' => [ $term->slug ],
 				]
 			);

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -158,19 +158,22 @@ class Product_Categories {
 
 		\SkyVerge\WooCommerce\Facebook\Product_Categories::update_google_product_category_id( $term_id, $google_product_category_id );
 
-		$term = get_term( $term_id, $taxonomy, ARRAY_A );
+		$term = get_term( $term_id, $taxonomy );
 
-		// get the products in the category being saved
-		$product_ids = wc_get_products(
-			[
-				'return'   => 'ids',
-				'category' => [ $term['slug'] ],
-			]
-		);
+		if ( $term instanceof \WP_Term ) {
 
-		if ( ! empty( $product_ids ) ) {
+			// get the products in the category being saved
+			$product_ids = wc_get_products(
+				[
+					'return'   => 'ids',
+					'category' => [ $term->slug ],
+				]
+			);
 
-			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( $product_ids );
+			if ( ! empty( $product_ids ) ) {
+
+				facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( $product_ids );
+			}
 		}
 	}
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -163,11 +163,9 @@ class Product_Categories {
 		if ( $term instanceof \WP_Term ) {
 
 			// get the products in the category being saved
-			$products = wc_get_products(
-				[
-					'category' => [ $term->slug ],
-				]
-			);
+			$products = wc_get_products( [
+				'category' => [ $term->slug ],
+			] );
 
 			if ( ! empty( $products ) ) {
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -151,7 +151,6 @@ class Product_Categories {
 	 * @param int $term_id term ID
 	 * @param int $tt_id term taxonomy ID
 	 * @param string $taxonomy Taxonomy slug
-	 * @return string
 	 */
 	public function save_google_product_category( $term_id, $tt_id, $taxonomy ) {
 
@@ -168,6 +167,11 @@ class Product_Categories {
 				'category' => [ $term['slug'] ],
 			]
 		);
+
+		if ( ! empty( $product_ids ) ) {
+
+			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( $product_ids );
+		}
 	}
 
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -35,6 +35,9 @@ class Product_Categories {
 
 		add_action( 'product_cat_add_form_fields', [ $this, 'render_add_google_product_category_field' ] );
 		add_action( 'product_cat_edit_form_fields', [ $this, 'render_edit_google_product_category_field' ] );
+
+		add_action( 'created_term', [ $this, 'save_google_product_category' ], 10, 3 );
+		add_action( 'edit_term', [ $this, 'save_google_product_category' ], 10, 3 );
 	}
 
 
@@ -143,9 +146,12 @@ class Product_Categories {
 	 *
 	 * @since 2.1.0-dev.1
 	 *
+	 * @param int $term_id term ID
+	 * @param int $tt_id term taxonomy ID
+	 * @param string $taxonomy Taxonomy slug
 	 * @return string
 	 */
-	public function save_google_product_category() {
+	public function save_google_product_category( $term_id, $tt_id, $taxonomy ) {
 
 	}
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -154,7 +154,7 @@ class Product_Categories {
 	 */
 	public function save_google_product_category( $term_id, $tt_id, $taxonomy ) {
 
-		$google_product_category_id = Framework\SV_WC_Helper::get_posted_value( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID );
+		$google_product_category_id = wc_clean( Framework\SV_WC_Helper::get_posted_value( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ) );
 
 		\SkyVerge\WooCommerce\Facebook\Product_Categories::update_google_product_category_id( $term_id, $google_product_category_id );
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -158,6 +158,16 @@ class Product_Categories {
 		$google_product_category_id = Framework\SV_WC_Helper::get_posted_value( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID );
 
 		\SkyVerge\WooCommerce\Facebook\Product_Categories::update_google_product_category_id( $term_id, $google_product_category_id );
+
+		$term = get_term( $term_id, $taxonomy, ARRAY_A );
+
+		// get the products in the category being saved
+		$product_ids = wc_get_products(
+			[
+				'return'   => 'ids',
+				'category' => [ $term['slug'] ],
+			]
+		);
 	}
 
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -12,6 +12,8 @@ namespace SkyVerge\WooCommerce\Facebook\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+
 /**
  * General handler for the product category admin functionality.
  *
@@ -153,6 +155,9 @@ class Product_Categories {
 	 */
 	public function save_google_product_category( $term_id, $tt_id, $taxonomy ) {
 
+		$google_product_category_id = Framework\SV_WC_Helper::get_posted_value( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID );
+
+		\SkyVerge\WooCommerce\Facebook\Product_Categories::update_google_product_category_id( $term_id, $google_product_category_id );
 	}
 
 

--- a/tests/integration/Admin/ProductCategoriesTest.php
+++ b/tests/integration/Admin/ProductCategoriesTest.php
@@ -101,18 +101,24 @@ class ProductCategoriesTest extends \Codeception\TestCase\WPTestCase {
 		$category_term_id          = $category['term_id'];
 		$category_term_taxonomy_id = $category['term_taxonomy_id'];
 
-		$product = $this->tester->get_product();
-		$product->set_category_ids( [ $category_term_id ] );
-		$product->save();
+		$simple_product = $this->tester->get_product();
+		$simple_product->set_category_ids( [ $category_term_id ] );
+		$simple_product->save();
+
+		$variable_product = $this->tester->get_variable_product();
+		$variable_product->set_category_ids( [ $category_term_id ] );
+		$variable_product->save();
 
 		$sync = $this
 			->getMockBuilder( Sync::class )
 			->onlyMethods( [ 'create_or_update_products' ] )
 			->getMock();
 
+		$expected_sync_ids = array_merge( [ $simple_product->get_id() ], $variable_product->get_children() );
+
 		// test will fail if the method is not called with the correct param
 		$sync->method( 'create_or_update_products' )
-		     ->willReturn( \Codeception\Stub\Expected::once( [ $product->get_id() ] ) );
+		     ->willReturn( \Codeception\Stub\Expected::once( $expected_sync_ids ) );
 
 		// replace the sync handler property
 		$property = new ReflectionProperty( \WC_Facebookcommerce::class, 'products_sync_handler' );


### PR DESCRIPTION
# Summary

This PR implements the `Admin\Product_Categories:: save_google_product_category()` method.

### Story: [CH 63664](https://app.clubhouse.io/skyverge/story/63664/admin-product-categories-implement-the-field-saving-method)
### Release: #1477 

## Details

This PR was branched off `ch63657/products-categories-field-render`, please merge #1549 first.

## QA

- [x] `tests/integration/Admin/ProductCategoriesTest.php` pass

Manual QA is not possible yet because the JS to create the selects is not implemented.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version