### PR TITLE
Implement the connection handler method

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -188,8 +188,16 @@ class Connection {
 
 		$response = $this->get_plugin()->get_api()->get_installation_ids( $this->get_external_business_id() );
 
-		if ( $response->get_page_id() ) {
-			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $response->get_page_id() ) );
+		$page_id = sanitize_text_field( $response->get_page_id() );
+
+		if ( $page_id ) {
+
+			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, $page_id );
+
+			// get and store a current access token for the configured page
+			$page_access_token = $this->retrieve_page_access_token( $page_id );
+
+			$this->update_page_access_token( $page_access_token );
 		}
 
 		if ( $response->get_pixel_id() ) {

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -374,6 +374,37 @@ class Connection {
 
 
 	/**
+	 * Enables order management for the given commerce manager.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $commerce_manager_id commerce manager ID
+	 * @param string $page_access_token page access token
+	 * @throws SV_WC_API_Exception
+	 */
+	private function enable_order_management( $commerce_manager_id, $page_access_token ) {
+
+		facebook_for_woocommerce()->log( 'Enabling order management' );
+
+		$response = wp_remote_post( "https://graph.facebook.com/{$commerce_manager_id}/order_management_apps?access_token={$page_access_token}" );
+
+		$body = wp_remote_retrieve_body( $response );
+		$body = json_decode( $body, true );
+
+		if ( ! is_array( $body ) || empty( $body['success'] ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+
+			facebook_for_woocommerce()->log( print_r( $body, true ) );
+
+			throw new SV_WC_API_Exception( sprintf(
+				/* translators: Placeholders: %s - API error message */
+				__( 'Could not enable order management. %s', 'facebook for woocommerce' ),
+				wp_remote_retrieve_response_message( $response )
+			) );
+		}
+	}
+
+
+	/**
 	 * Gets the API access token.
 	 *
 	 * @since 2.0.0

--- a/tests/acceptance/ConnectionCest.php
+++ b/tests/acceptance/ConnectionCest.php
@@ -61,4 +61,168 @@ class ConnectionCest {
 	}
 
 
+	/** @see Connection::handle_connect_commerce() */
+	public function try_handle_connect_commerce_as_guest( AcceptanceTester $I ) {
+
+		$I->wantTo( 'Ensure nothing is stored by the callback for guests' );
+
+		$I->amOnUrl( add_query_arg( [
+			'wc-api'              => Connection::ACTION_CONNECT_COMMERCE,
+			'nonce'               => wp_create_nonce( Connection::ACTION_CONNECT_COMMERCE ),
+			'commerce_manager_id' => 'xyz',
+		], home_url( '/' ) ) );
+
+		$I->dontSeeOptionInDatabase( [
+			'option_name' => Connection::OPTION_COMMERCE_MANAGER_ID,
+		] );
+
+		$I->see( '-1' );
+	}
+
+
+	/** @see Connection::handle_connect_commerce() */
+	public function try_handle_connect_commerce_with_bad_nonce( AcceptanceTester $I ) {
+
+		$I->wantTo( 'Ensure nothing is stored with an invalid nonce' );
+
+		$I->loginAsAdmin();
+
+		$I->amOnUrl( add_query_arg( [
+			'wc-api'              => Connection::ACTION_CONNECT_COMMERCE,
+			'nonce'               => 'bad-nonce',
+			'commerce_manager_id' => 'xyz',
+		], home_url( '/' ) ) );
+
+		$I->dontSeeOptionInDatabase( [
+			'option_name' => Connection::OPTION_COMMERCE_MANAGER_ID,
+		] );
+	}
+
+
+	/** @see Connection::handle_connect_commerce() */
+	public function try_handle_connect_commerce_with_no_commerce_manager_id( AcceptanceTester $I ) {
+
+		$I->wantTo( 'Ensure nothing is stored if the commerce manager ID is missing' );
+
+		$I->loginAsAdmin();
+
+		$I->amOnUrl( add_query_arg( [
+			'wc-api'              => Connection::ACTION_CONNECT_COMMERCE,
+			'nonce'               => wp_create_nonce( Connection::ACTION_CONNECT_COMMERCE ),
+		], home_url( '/' ) ) );
+
+		$I->dontSeeOptionInDatabase( [
+			'option_name' => Connection::OPTION_COMMERCE_MANAGER_ID,
+		] );
+	}
+
+
+	/** @see Connection::handle_connect_commerce() */
+	public function try_handle_connect_commerce( AcceptanceTester $I ) {
+
+		$I->wantTo( 'Ensure the callback stores the commerce manager ID if everything passes security checks' );
+
+		$this->add_get_pages_success_response( $I );
+		$this->add_enable_order_management_success_response( $I );
+
+		$I->haveOptionInDatabase( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, 'PAGE_ID' );
+
+		$I->loginAsAdmin();
+
+		$I->amOnUrl( add_query_arg( [
+			'wc-api'              => Connection::ACTION_CONNECT_COMMERCE,
+			'nonce'               => wp_create_nonce( Connection::ACTION_CONNECT_COMMERCE ),
+			'commerce_manager_id' => 'xyz',
+		], home_url( '/' ) ) );
+
+		$I->haveOptionInDatabase( Connection::OPTION_PAGE_ACCESS_TOKEN, 'PAGE_ACCESS_TOKEN' );
+		$I->haveOptionInDatabase( Connection::OPTION_COMMERCE_MANAGER_ID, 'xyz' );
+	}
+
+
+	/**
+	 * Adds a MU plugin to filter the Facebook API response and simulate a successful GET of the page accounts.
+	 *
+	 * @param AcceptanceTester $I
+	 */
+	private function add_get_pages_success_response(  AcceptanceTester $I ) {
+
+		// simulate a successful configuration response
+		$code = <<<PHP
+add_filter( 'pre_http_request', function( \$response, \$args, \$url ) {
+
+	if ( false !== strpos( \$url, 'me/accounts' ) && 'GET' === \$args['method'] ) {
+
+		\$response = [
+			'headers' => [],
+			'body'    => json_encode(
+				[
+					'data' => [
+						[
+							'access_token' => 'PAGE_ACCESS_TOKEN',
+							'id'           => 'PAGE_ID',
+						],
+						[
+							'access_token' => 'OTHER_PAGE_ACCESS_TOKEN',
+							'id'           => 'OTHER_PAGE_ID',
+						],
+					],
+				]
+			),
+			'response'      => [
+				'code'    => 200,
+				'message' => 'Ok',
+			],
+			'cookies'       => [],
+			'http_response' => null,
+		];
+	}
+
+	return \$response;
+
+}, 10, 3 );
+PHP;
+
+		$I->haveMuPlugin( 'get-pages-response-filter.php', $code );
+	}
+
+
+	/**
+	 * Adds a MU plugin to filter the Facebook API response and simulate a successful GET of the page accounts.
+	 *
+	 * @param AcceptanceTester $I
+	 */
+	private function add_enable_order_management_success_response(  AcceptanceTester $I ) {
+
+		// simulate a successful configuration response
+		$code = <<<PHP
+add_filter( 'pre_http_request', function( \$response, \$args, \$url ) {
+
+	if ( false !== strpos( \$url, 'me/accounts' ) && 'GET' === \$args['method'] ) {
+
+		\$response = [
+			'headers' => [],
+			'body'    => json_encode(
+				[
+					'success' => true,
+				]
+			),
+			'response'      => [
+				'code'    => 200,
+				'message' => 'Ok',
+			],
+			'cookies'       => [],
+			'http_response' => null,
+		];
+	}
+
+	return \$response;
+
+}, 10, 3 );
+PHP;
+
+		$I->haveMuPlugin( 'get-order-management-response-filter.php', $code );
+	}
+
+
 }


### PR DESCRIPTION
# Summary

Implements the WC API callback handler for after the proxy app redirects back to the site.

### Story: [CH 63852](https://app.clubhouse.io/skyverge/story/63852)
### Release: #1477 

## Details

The only thing that is returned to the site is a nonce to validate and the commerce manager ID. We can validate those things, then finish the necessary connection setup, including:
1. Get and store the latest access token for the commerce page
1. Enable API order management for that commerce manager

As noted in the doc, I opted to keep the scope of this smaller by not creating API request & response objects for these one-off API operations. I did break them up into helper methods to keep the handler method a bit smaller.

## UI Changes

_N/A_

## QA

I added basic tests to make sure security is validated. Manual QA can be done once we've got the rest of the related stories in place.

- [x] `acceptance ConnectionCest:try_handle_connect_commerce` tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version