### PR TITLE
Implement the Commerce\Orders::is_order_pending() method

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -49,6 +49,20 @@ class Orders {
 
 
 	/**
+	 * Returns whether or not the order is a pending Commerce order.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Order $order order object
+	 * @return bool
+	 */
+	public static function is_order_pending( \WC_Order $order ) {
+
+		return self::is_commerce_order( $order ) && 'pending' === $order->get_status();
+	}
+
+
+	/**
 	 * Returns whether or not the order is a Commerce order.
 	 *
 	 * @since 2.1.0-dev.1

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -36,6 +36,42 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
+	 * @see Orders::is_order_pending()
+	 *
+	 * @param string $created_via created via value
+	 * @param string $status WC order status value
+	 * @param bool $expected expected result
+	 *
+	 * @dataProvider provider_is_order_pending
+	 *
+	 * @throws \WC_Data_Exception
+	 */
+	public function test_is_order_pending( $created_via, $status, $expected ) {
+
+		$order = new \WC_Order();
+		$order->set_created_via( $created_via );
+		$order->set_status( $status );
+		$order->save();
+
+		$this->assertEquals( $expected, Orders::is_order_pending( $order ) );
+	}
+
+
+	/** @see test_is_order_pending */
+	public function provider_is_order_pending() {
+
+		return [
+			[ 'checkout', 'pending', false ],
+			[ 'checkout', 'processing', false ],
+			[ 'instagram', 'pending', true ],
+			[ 'instagram', 'processing', false ],
+			[ 'facebook', 'pending', true ],
+			[ 'facebook', 'processing', false ],
+		];
+	}
+
+
+	/**
 	 * @see Orders::is_commerce_order()
 	 *
 	 * @param string $created_via created via value


### PR DESCRIPTION
# Summary

This PR implements the `Commerce\Orders::is_order_pending()` method.

### Story: [CH 63756](https://app.clubhouse.io/skyverge/story/63756/implement-the-commerce-orders-is-order-pending-method)
### Release: #1477 

## QA

- [x] `tests/integration/Commerce/OrdersTest.php` pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version