### PR TITLE
Implement the methods in Admin\Orders to check the current screen

### DIFF
--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -12,6 +12,8 @@ namespace SkyVerge\WooCommerce\Facebook\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+
 /**
  * General handler for order admin functionality.
  *
@@ -189,7 +191,8 @@ class Orders {
 	 */
 	public function is_orders_screen() {
 
-		return true;
+		return Framework\SV_WC_Helper::is_current_screen( 'edit-shop_order' ) ||
+		       Framework\SV_WC_Helper::is_current_screen( 'shop_order' );
 	}
 
 
@@ -204,7 +207,7 @@ class Orders {
 	 */
 	public function is_edit_order_screen() {
 
-		return true;
+		return Framework\SV_WC_Helper::is_current_screen( 'shop_order' );
 	}
 
 

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -50,10 +50,6 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 	// TODO: add test for is_order_editable()
 
-	// TODO: add test for is_orders_screen()
-
-	// TODO: add test for is_edit_order_screen()
-
 
 	/** Utility methods ***********************************************************************************************/
 


### PR DESCRIPTION
# Summary

This PR implements the `Admin\Orders::is_orders_screen()` and `Admin\Orders::is_edit_order_screen()` methods.

### Story: [CH 63768](https://app.clubhouse.io/skyverge/story/63768/implement-the-methods-in-admin-orders-to-check-the-current-screen)
### Release: #1477 

## QA

- [x] Code review only

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version