### PR TITLE
Add an order note to created orders on update_local_order()

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -313,6 +313,12 @@ class Orders {
 		// update order status
 		if ( Order::STATUS_CREATED === $remote_order->get_status() ) {
 			$local_order->set_status( 'processing' );
+
+			/* translators: Placeholders: %1$s - order remote id, %2$s - order created by */
+			$local_order->add_order_note( sprintf( __( 'Order %1$s paid in %2$s', 'facebook-for-woocommerce' ),
+				$remote_order->get_id(),
+				$remote_order->get_channel()
+			) );
 		}
 
 		// set remote ID

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -217,6 +217,8 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $response_data['id'], $updated_local_order->get_meta( Orders::REMOTE_ID_META_KEY ) );
 
 		$this->assertEquals( 'processing', $updated_local_order->get_status() );
+
+		$this->assertTrue( $this->order_has_note( $updated_local_order, sprintf( 'Order %s paid in %s', $response_data['id'], $response_data['channel'] ) ) );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR will add an order note when the order status has `STATUS_CREATED` in the `update_local_order()` method.

### Story: [CH 63760](https://app.clubhouse.io/skyverge/story/63760/update-the-commerce-orders-update-local-order-method-to-add-order-note)
### Release: #1477

## Details

This PR comes from a fork for Facebook for WooCommerce: Instagram checkout - frontend by SkyVerge.

## QA

- [x] `/tests/integration/Commerce/OrdersTest.php` tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version