### PR TITLE
Check for the commerce manager id when determining connection status

### DIFF
--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -112,7 +112,9 @@ class Commerce {
 	 */
 	public function is_connected() {
 
-		$connected = (bool) strlen( facebook_for_woocommerce()->get_connection_handler()->get_page_access_token() );
+		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
+
+		$connected = $connection_handler->has_commerce_manager_id() && (bool) strlen( $connection_handler->get_page_access_token() );
 
 		/**
 		 * Filters whether the site is connected.

--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -114,7 +114,7 @@ class Commerce {
 
 		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
 
-		$connected = $connection_handler->has_commerce_manager_id() && (bool) strlen( $connection_handler->get_page_access_token() );
+		$connected = (bool) strlen( $connection_handler->get_page_access_token() ) && ! empty( $connection_handler->get_commerce_manager_id() );
 
 		/**
 		 * Filters whether the site is connected.

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -983,6 +983,19 @@ class Connection {
 
 
 	/**
+	 * Determines whether the Commerce has a manager ID.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function has_commerce_manager_id() {
+
+		return ! empty( $this->get_commerce_manager_id() );
+	}
+
+
+	/**
 	 * Determines whether the site has previously connected to FBE 2.
 	 *
 	 * @since 2.0.0

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -983,19 +983,6 @@ class Connection {
 
 
 	/**
-	 * Determines whether the Commerce has a manager ID.
-	 *
-	 * @since 2.1.0-dev.1
-	 *
-	 * @return bool
-	 */
-	public function has_commerce_manager_id() {
-
-		return ! empty( $this->get_commerce_manager_id() );
-	}
-
-
-	/**
 	 * Determines whether the site has previously connected to FBE 2.
 	 *
 	 * @since 2.0.0

--- a/tests/integration/CommerceTest.php
+++ b/tests/integration/CommerceTest.php
@@ -125,9 +125,10 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @dataProvider provider_is_connected
 	 */
-	public function test_is_connected( $access_token, $is_connected ) {
+	public function test_is_connected( $access_token, $manager_id, $is_connected ) {
 
 		facebook_for_woocommerce()->get_connection_handler()->update_page_access_token( $access_token );
+		facebook_for_woocommerce()->get_connection_handler()->update_commerce_manager_id( $manager_id );
 
 		$this->assertSame( $is_connected, $this->get_commerce_handler()->is_connected() );
 	}
@@ -137,8 +138,10 @@ class CommerceTest extends \Codeception\TestCase\WPTestCase {
 	public function provider_is_connected() {
 
 		return [
-			[ '123456', true ],
-			[ '',       false ],
+			[ '123456', '1', true ],
+			[ '',       '',  false ],
+			[ '',       '1', false ],
+			[ '123456', '',  false ],
 		];
 	}
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -623,6 +623,7 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 		$connection = $this->get_connection();
 
 		$connection->update_access_token( 'access token' );
+		$connection->update_commerce_manager_id( 'manager id' );
 
 		$this->assertTrue( $connection->is_connected() );
 	}


### PR DESCRIPTION
# Summary

This PR will add another condition to determine whether the site is connected by also checking for a commerce manager ID.

### Story: [CH 63809](https://app.clubhouse.io/skyverge/story/63809/check-for-the-commerce-manager-id-when-determining-connection-status)
### Release: #1477

## Details

This PR comes from a fork for Facebook for WooCommerce: Instagram checkout - frontend by SkyVerge.

## QA

- [x] `tests/integration/CommerceTest.php` tests pass
- [x] `tests/integration/Handlers/ConnectionTest.php` tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version