### PR TITLE
Implement the base admin product fields render method

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1074,6 +1074,16 @@ class Admin {
 					'class'       => 'enable-if-sync-enabled',
 				] );
 
+				$commerce_handler = facebook_for_woocommerce()->get_commerce_handler();
+
+				if ( $commerce_handler->is_connected() && $commerce_handler->is_available() ) {
+
+					$product = wc_get_product( $post );
+
+					if ( $product instanceof \WC_Product ) {
+						\SkyVerge\WooCommerce\Facebook\Admin\Products::render_commerce_fields( $product );
+					}
+				}
 				?>
 			</div>
 		</div>

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -978,7 +978,7 @@ class Admin {
 		$tabs['fb_commerce_tab'] = [
 			'label'  => __( 'Facebook', 'facebook-for-woocommerce' ),
 			'target' => 'facebook_options',
-			'class'  => [ 'show_if_simple' ],
+			'class'  => [ 'show_if_simple', 'show_if_variable' ],
 		];
 
 		return $tabs;

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1013,7 +1013,7 @@ class Admin {
 		// 'id' attribute needs to match the 'target' parameter set above
 		?>
 		<div id='facebook_options' class='panel woocommerce_options_panel'>
-			<div class='options_group'>
+			<div class='options_group show_if_simple'>
 				<?php
 
 				woocommerce_wp_select( [
@@ -1073,6 +1073,12 @@ class Admin {
 					'value'       => $price,
 					'class'       => 'enable-if-sync-enabled',
 				] );
+
+				?>
+			</div>
+
+			<div class='options_group'>
+				<?php
 
 				$commerce_handler = facebook_for_woocommerce()->get_commerce_handler();
 

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -89,6 +89,22 @@ class Products {
 
 		?>
 
+		<div id="product-not-ready-notice" style="display:none;">
+			<p>
+				<?php esc_html_e( 'This product does not meet the requirements to sell on Instagram.', 'facebook-for-woocommerce' ); ?>
+				<a href="#" id="product-not-ready-notice-open-modal"><?php esc_html_e( 'Click here to learn more.', 'facebook-for-woocommerce' ); ?></a>
+			</p>
+		</div>
+
+		<div id="variable-product-not-ready-notice" style="display:none;">
+			<p><?php sprintf(
+				/* translators: Placeholders %1$s - strong opening tag, %2$s - strong closing tag */
+				__( 'To sell this product on Instagram, at least one variation must be synced to Facebook. You can control variation sync on the %1$sVariations%2$s tab with the %1$sFacebook Sync%2$s setting.', 'facebook-for-woocommerce' ),
+				'<strong>',
+				'</strong>'
+			);?></p>
+		</div>
+
 		<div class='wc_facebook_commerce_fields'>
 			<?php self::render_google_product_category_fields( $product ); ?>
 			<?php self::render_attribute_fields( $product ); ?>

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -78,16 +78,18 @@ class Products {
 	 */
 	public static function render_commerce_fields( \WC_Product $product ) {
 
-		woocommerce_wp_checkbox( [
-			'id'          => self::FIELD_COMMERCE_ENABLED,
-			'value'       => \SkyVerge\WooCommerce\Facebook\Products::is_commerce_enabled_for_product( $product ) ? 'yes' : 'no',
-			'label'       => __( 'Sell on Instagram', 'facebook-for-woocommerce' ),
-			'class'       => 'enable-if-sync-enabled',
-			'desc_tip'    => true,
-			'description' => __( 'Enable to sell this product on Instagram. Products that are hidden in the Facebook catalog can be synced, but won’t be available for purchase.', 'facebook-for-woocommerce' ),
-		] );
-
 		?>
+		<p class="form-field <?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>_field">
+			<label for="<?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>">
+				<?php echo esc_html_e( 'Sell on Instagram', 'facebook-for-woocommerce' ); ?>
+				<span class="woocommerce-help-tip"
+				      data-tip="<?php echo esc_attr_e( 'Enable to sell this product on Instagram. Products that are hidden in the Facebook catalog can be synced, but won’t be available for purchase.', 'facebook-for-woocommerce' ); ?>"></span>
+			</label>
+			<input type="checkbox" class="enable-if-sync-enabled"
+			       name="<?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>"
+			       id="<?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>" value="yes"
+			       checked="<?php echo \SkyVerge\WooCommerce\Facebook\Products::is_commerce_enabled_for_product( $product ) ? 'checked' : ''; ?>">
+		</p>
 
 		<div id="product-not-ready-notice" style="display:none;">
 			<p>

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -79,10 +79,12 @@ class Products {
 	public static function render_commerce_fields( \WC_Product $product ) {
 
 		woocommerce_wp_checkbox( [
-			'id'    => self::FIELD_COMMERCE_ENABLED,
-			'value' => \SkyVerge\WooCommerce\Facebook\Products::is_commerce_enabled_for_product( $product ) ? 'yes' : 'no',
-			'label' => __( 'Sell on Instagram', 'facebook-for-woocommerce' ),
-			'class' => 'enable-if-sync-enabled',
+			'id'          => self::FIELD_COMMERCE_ENABLED,
+			'value'       => \SkyVerge\WooCommerce\Facebook\Products::is_commerce_enabled_for_product( $product ) ? 'yes' : 'no',
+			'label'       => __( 'Sell on Instagram', 'facebook-for-woocommerce' ),
+			'class'       => 'enable-if-sync-enabled',
+			'desc_tip'    => true,
+			'description' => __( 'Enable to sell this product on Instagram. Products that are hidden in the Facebook catalog can be synced, but won’t be available for purchase.', 'facebook-for-woocommerce' ),
 		] );
 
 		?>

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -84,6 +84,15 @@ class Products {
 			'label' => __( 'Sell on Instagram', 'facebook-for-woocommerce' ),
 			'class' => 'enable-if-sync-enabled',
 		] );
+
+		?>
+
+		<div class='wc_facebook_commerce_fields'>
+			<?php self::render_google_product_category_fields( $product ); ?>
+			<?php self::render_attribute_fields( $product ); ?>
+		</div>
+
+		<?php
 	}
 
 

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -78,6 +78,12 @@ class Products {
 	 */
 	public static function render_commerce_fields( \WC_Product $product ) {
 
+		woocommerce_wp_checkbox( [
+			'id'    => self::FIELD_COMMERCE_ENABLED,
+			'value' => \SkyVerge\WooCommerce\Facebook\Products::is_commerce_enabled_for_product( $product ) ? 'yes' : 'no',
+			'label' => __( 'Sell on Instagram', 'facebook-for-woocommerce' ),
+			'class' => 'enable-if-sync-enabled',
+		] );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR implements the `Admin\Products::render_commerce_fields()` method.

### Story: [CH 63724](https://app.clubhouse.io/skyverge/story/63724/implement-the-base-admin-product-fields-render-method)
### Release: #1477 

## Details

As discussed on the [implementation doc](https://docs.google.com/document/d/11AG_ZVIYGKn96BvEn_Qwy91FOALeE7GmB5cpfN1D6LU/edit?disco=AAAAJ6ycYlw), I've added the notices for product/variable product not meeting the requirements with a `display:none;`. The visibility for these will be triggered by the JS, in [CH 63822](https://app.clubhouse.io/skyverge/story/63822/show-sell-product-on-instagram-message).

## QA

1. Open the page to edit a simple product
1. Navigate to the Facebook tab
    - [x] The "Sell on Instagram" checkbox is displayed after the sync fields (Facebook sync, Facebook Description, Facebook Product Image, Custom Image URL, and Facebook Price)
1. Switch the product type to "Variable product"
1. Navigate to the Facebook tab
    - [x] The "Sell on Instagram" checkbox is displayed and the sync fields (Facebook sync, Facebook Description, Facebook Product Image, Custom Image URL, and Facebook Price) are not displayed

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version