### PR TITLE
Implement the email blocking for Admin Orders

### DIFF
--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -174,11 +174,12 @@ class Orders {
 			 * Filters the flag used to determine whether the email is enabled.
 			 *
 			 * @param bool $is_enabled whether the email is enabled
+			 * @param \WC_Order $order order object
 			 * @param Orders $this admin orders instance
 			 * @since 2.1.0-dev.1
 			 *
 			 */
-			$is_enabled = (bool) apply_filters( 'wc_facebook_commerce_send_woocommerce_emails', $is_enabled, $this );
+			$is_enabled = (bool) apply_filters( 'wc_facebook_commerce_send_woocommerce_emails', $is_enabled, $order, $this );
 		}
 
 		return $is_enabled;

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -159,6 +159,8 @@ class Orders {
 	 */
 	public function maybe_stop_order_email( $is_enabled, $order ) {
 
+		$is_enabled = $is_enabled && ! ( $order instanceof \WC_Order && \SkyVerge\WooCommerce\Facebook\Commerce\Orders::is_commerce_order( $order ) );
+
 		return $is_enabled;
 	}
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -161,6 +161,16 @@ class Orders {
 
 		$is_enabled = $is_enabled && ! ( $order instanceof \WC_Order && \SkyVerge\WooCommerce\Facebook\Commerce\Orders::is_commerce_order( $order ) );
 
+		/**
+		 * Filters the flag used to determine whether the email is enabled.
+		 *
+		 * @since 2.1.0-dev.1
+		 *
+		 * @param bool $is_enabled whether the email is enabled
+		 * @param Orders $this admin orders instance
+		 */
+		$is_enabled = (bool) apply_filters( 'wc_facebook_commerce_send_woocommerce_emails', $is_enabled, $this );
+
 		return $is_enabled;
 	}
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -159,17 +159,27 @@ class Orders {
 	 */
 	public function maybe_stop_order_email( $is_enabled, $order ) {
 
-		$is_enabled = $is_enabled && ! ( $order instanceof \WC_Order && \SkyVerge\WooCommerce\Facebook\Commerce\Orders::is_commerce_order( $order ) );
+		// will decide whether to allow $is_enabled to be filtered
+		$is_previously_enabled = $is_enabled;
 
-		/**
-		 * Filters the flag used to determine whether the email is enabled.
-		 *
-		 * @since 2.1.0-dev.1
-		 *
-		 * @param bool $is_enabled whether the email is enabled
-		 * @param Orders $this admin orders instance
-		 */
-		$is_enabled = (bool) apply_filters( 'wc_facebook_commerce_send_woocommerce_emails', $is_enabled, $this );
+		// checks whether or not the order is a Commerce order
+		$is_commerce_order = $order instanceof \WC_Order && \SkyVerge\WooCommerce\Facebook\Commerce\Orders::is_commerce_order( $order );
+
+		// decides whether to disable or to keep emails enabled
+		$is_enabled = $is_enabled && ! $is_commerce_order;
+
+		if ( $is_previously_enabled && $is_commerce_order ) {
+
+			/**
+			 * Filters the flag used to determine whether the email is enabled.
+			 *
+			 * @param bool $is_enabled whether the email is enabled
+			 * @param Orders $this admin orders instance
+			 * @since 2.1.0-dev.1
+			 *
+			 */
+			$is_enabled = (bool) apply_filters( 'wc_facebook_commerce_send_woocommerce_emails', $is_enabled, $this );
+		}
 
 		return $is_enabled;
 	}

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -90,10 +90,11 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @param bool $is_enabled
 	 * @param bool $expected
+	 * @param \WC_Order|string|null $order
 	 *
 	 * @dataProvider provider_maybe_stop_order_email_filter
 	 */
-	public function test_maybe_stop_order_email_filter( $is_enabled, $expected ) {
+	public function test_maybe_stop_order_email_filter( $is_enabled, $order, $expected ) {
 
 		add_filter( 'wc_facebook_commerce_send_woocommerce_emails', function( $is_enabled ) {
 
@@ -102,16 +103,22 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 		$orders_handler = $this->get_orders_handler();
 
-		$this->assertEquals( $expected, $orders_handler->maybe_stop_order_email( $is_enabled, null ) );
+		$this->assertEquals( $expected, $orders_handler->maybe_stop_order_email( $is_enabled, $order ) );
 	}
 
 
 	/** @see test_maybe_stop_order_email_filter */
 	public function provider_maybe_stop_order_email_filter() {
 
+		$commerce_order = new \WC_Order();
+		$commerce_order->set_created_via( 'instagram' );
+
 		return [
-			[ false, true ],
-			[ true,  false ],
+			[ false, null,                     false ],
+			[ true,  null,                     true ],
+			[ true,  'a non \WC_Order object', true ],
+			[ true,  new \WC_Order(),          true ],
+			[ true,  $commerce_order,          true ],
 		];
 	}
 

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -18,6 +18,7 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	protected function _before() {
 
 		require_once 'includes/Admin/Orders.php';
+		require_once 'includes/Commerce/Orders.php';
 	}
 
 
@@ -46,7 +47,29 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 	// TODO: add test for handle_bulk_update()
 
-	// TODO: add test for maybe_stop_order_email()
+
+	/**
+	 * @see Admin\Orders::maybe_stop_order_email()
+	 *
+	 * @throws WC_Data_Exception
+	 */
+	public function test_maybe_stop_order_email() {
+
+		$orders_handler = $this->get_orders_handler();
+
+		$this->assertFalse( $orders_handler->maybe_stop_order_email( false, null ) );
+		$this->assertTrue( $orders_handler->maybe_stop_order_email( true, null ) );
+		$this->assertTrue( $orders_handler->maybe_stop_order_email( true, 'a non \WC_Order object' ) );
+
+		$order = new \WC_Order();
+
+		$this->assertTrue( $orders_handler->maybe_stop_order_email( true, $order ) );
+
+		$order->set_created_via( 'instagram' );
+
+		$this->assertFalse( $orders_handler->maybe_stop_order_email( true, $order ) );
+	}
+
 
 	// TODO: add test for is_order_editable()
 

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -117,8 +117,11 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 			[ false, null,                     false ],
 			[ true,  null,                     true ],
 			[ true,  'a non \WC_Order object', true ],
+			[ false, 'a non \WC_Order object', false ],
 			[ true,  new \WC_Order(),          true ],
+			[ false, new \WC_Order(),          false ],
 			[ true,  $commerce_order,          true ],
+			[ false, $commerce_order,          false ],
 		];
 	}
 

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -71,6 +71,21 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Admin\Orders::maybe_stop_order_email() */
+	public function test_maybe_stop_order_email_filter() {
+
+		add_filter( 'wc_facebook_commerce_send_woocommerce_emails', function( $is_enabled ) {
+
+			return ! $is_enabled;
+		} );
+
+		$orders_handler = $this->get_orders_handler();
+
+		$this->assertTrue( $orders_handler->maybe_stop_order_email( false, null ) );
+		$this->assertFalse( $orders_handler->maybe_stop_order_email( true, null ) );
+	}
+
+
 	// TODO: add test for is_order_editable()
 
 


### PR DESCRIPTION
# Summary

This PR will provide an implementation to the `Orders:maybe_stop_order_email` method.

### Story: [CH 63866](https://app.clubhouse.io/skyverge/story/63866/admin-orders-implement-the-email-blocking)
### Release: #1477

## Details

This PR comes from a fork for Facebook for WooCommerce: Instagram checkout - frontend by SkyVerge.

## QA

- [x] `tests/integration/Admin/OrdersTest.php` tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version