### PR TITLE
Add product-categories.js

### DIFF
--- a/assets/js/admin/product-categories.js
+++ b/assets/js/admin/product-categories.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+jQuery( document ).ready( ( $ ) => {
+
+} );

--- a/assets/js/admin/product-categories.min.js
+++ b/assets/js/admin/product-categories.min.js
@@ -1,0 +1,2 @@
+"use strict";jQuery(document).ready(function(e){});
+//# sourceMappingURL=product-categories.min.js.map

--- a/assets/js/admin/product-categories.min.js.map
+++ b/assets/js/admin/product-categories.min.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["../admin/product-categories.js"],"names":["jQuery","document","ready","$"],"mappings":"aASAA,OAAQC,UAAWC,MAAO,SAAEC","file":"product-categories.min.js"}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -113,6 +113,7 @@ class Admin {
 		$modal_screens = [
 			'product',
 			'edit-product',
+			'edit-product_cat',
 		];
 
 		if ( isset( $current_screen->id ) ) {

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -52,7 +52,16 @@ class Product_Categories {
 	 */
 	public function enqueue_assets() {
 
-		wp_enqueue_script( 'wc-facebook-product-categories', facebook_for_woocommerce()->get_plugin_url() . '/assets/js/admin/product-categories.min.js', [ 'jquery', 'wc-backbone-modal', 'jquery-blockui', 'jquery-tiptip', 'facebook-for-woocommerce-modal' ], \WC_Facebookcommerce::PLUGIN_VERSION );
+		if ( $this->is_categories_screen() ) {
+
+			wp_enqueue_script( 'wc-facebook-product-categories', facebook_for_woocommerce()->get_plugin_url() . '/assets/js/admin/product-categories.min.js', [
+					'jquery',
+					'wc-backbone-modal',
+					'jquery-blockui',
+					'jquery-tiptip',
+					'facebook-for-woocommerce-modal',
+			], \WC_Facebookcommerce::PLUGIN_VERSION );
+		}
 	}
 
 
@@ -192,6 +201,21 @@ class Product_Categories {
 				facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( $sync_product_ids );
 			}
 		}
+	}
+
+
+	/**
+	 * Determines whether or not the current screen is a categories screen.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function is_categories_screen() {
+
+		return Framework\SV_WC_Helper::is_current_screen( 'edit-product_cat' );
 	}
 
 

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -55,11 +55,11 @@ class Product_Categories {
 		if ( $this->is_categories_screen() ) {
 
 			wp_enqueue_script( 'wc-facebook-product-categories', facebook_for_woocommerce()->get_plugin_url() . '/assets/js/admin/product-categories.min.js', [
-					'jquery',
-					'wc-backbone-modal',
-					'jquery-blockui',
-					'jquery-tiptip',
-					'facebook-for-woocommerce-modal',
+				'jquery',
+				'wc-backbone-modal',
+				'jquery-blockui',
+				'jquery-tiptip',
+				'facebook-for-woocommerce-modal',
 			], \WC_Facebookcommerce::PLUGIN_VERSION );
 		}
 	}

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -52,6 +52,7 @@ class Product_Categories {
 	 */
 	public function enqueue_assets() {
 
+		wp_enqueue_script( 'wc-facebook-product-categories', facebook_for_woocommerce()->get_plugin_url() . '/assets/js/admin/product-categories.min.js', [ 'jquery', 'wc-backbone-modal', 'jquery-blockui', 'jquery-tiptip', 'facebook-for-woocommerce-modal' ], \WC_Facebookcommerce::PLUGIN_VERSION );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR adds the `product-categories.js` script and enqueues it and it's dependencies.

### Story: [CH 63673](https://app.clubhouse.io/skyverge/story/63673/add-product-categories-js)
### Release: #1477 

## QA

1. Open the page to list the product categories
1. Check the Sources
    - [x] The `product-categories.min.js` is loaded
1. Open the page to edit a product category
1. Check the Sources
    - [x] The `product-categories.min.js` is loaded
1. Open another admin page (for instance the Orders page)
1. Check the Sources
    - [x] The `product-categories.min.js` is **not** loaded

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version