### PR TITLE
Implement the admin product google product category render method

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -35,6 +35,35 @@
 	clear: both;
 }
 
+#woocommerce-product-data .wc_facebook_commerce_enabled_field label,
+#woocommerce-product-data .wc_facebook_commerce_fields label {
+	padding-right: 37px;
+	position: relative;
+	width: 113px;
+}
+#woocommerce-product-data .wc_facebook_commerce_enabled_field label .woocommerce-help-tip,
+#woocommerce-product-data .wc_facebook_commerce_fields label .woocommerce-help-tip {
+	margin: 0;
+	position: absolute;
+	top: 4px;
+	right: 12px;
+}
+
+#woocommerce-product-data #wc-facebook-google-product-category-fields {
+	width: 50%;
+}
+
+#woocommerce-product-data .wc-facebook-google-product-category-field select {
+	float: none;
+	width: 100%;
+	max-width: none;
+}
+
+#woocommerce-product-data #wc-facebook-google-product-category-fields .select2-container {
+	float: none;
+	width: 100% !important;
+}
+
 .notice .button.js-wc-plugin-framework-notice-dismiss {
 	margin-left: 10px;
 }

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -12,6 +12,8 @@ namespace SkyVerge\WooCommerce\Facebook\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Facebook\Products as Products_Handler;
+
 /**
  * General handler for product admin functionality.
  *
@@ -50,6 +52,24 @@ class Products {
 	 */
 	public static function render_google_product_category_fields( \WC_Product $product ) {
 
+		$field = new Google_Product_Category_Field();
+
+		$field->render( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID );
+
+		?>
+		<p class="form-field">
+			<label for="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>">
+				<?php esc_html_e( 'Google product category', 'facebook-for-woocommerce' ); ?>
+				<?php echo wc_help_tip( __( 'Choose the Google product category and (optionally) sub-categories associated with this product.', 'facebook-for-woocommerce' ) ); ?>
+			</label>
+			<input
+				id="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
+				type="hidden"
+				name="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
+				value="<?php echo esc_attr( Products_Handler::get_google_product_category_id( $product ) ); ?>"
+			/>
+		</p>
+		<?php
 	}
 
 
@@ -88,7 +108,7 @@ class Products {
 			<input type="checkbox" class="enable-if-sync-enabled"
 			       name="<?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>"
 			       id="<?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>" value="yes"
-			       checked="<?php echo \SkyVerge\WooCommerce\Facebook\Products::is_commerce_enabled_for_product( $product ) ? 'checked' : ''; ?>">
+			       checked="<?php echo Products_Handler::is_commerce_enabled_for_product( $product ) ? 'checked' : ''; ?>">
 		</p>
 
 		<div id="product-not-ready-notice" style="display:none;">


### PR DESCRIPTION
# Summary

Renders the Google Product Category fields for a product.

### Story: [CH 63720](https://app.clubhouse.io/skyverge/story/63720)
### Release: #1477 

## Details

Some extra styling was needed to ensure the select widths would match the existing select fields, and to ensure the new tooltips align.

## UI Changes

- The new fields: https://cloud.skyver.ge/geuznqW2

## QA

### Setup

1. Add `add_filter( 'wc_facebook_commerce_is_available', '__return_true' )`
1. Add `add_filter( 'wc_facebook_commerce_is_connected', '__return_true' )`

### Steps

1. Go to edit a product
1. Select the Facebook tab
    - [x] The Google fields are present
1. Select some categories
    - [x] The selects are added as expected
1. Add `_wc_facebook_google_product_category` meta to the product, value `5710`
1. Reload the edit product page
    - [x] The Google fields load pre-selected with `Arts & Entertainment -> Hobbies & Creative Arts` selected

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version