### PR TITLE
Implement the admin product attributes render method

### DIFF
--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -77,6 +77,7 @@ class Products {
 				'female' => __( 'Female', 'facebook-for-woocommerce' ),
 				'male'   => __( 'Male', 'facebook-for-woocommerce' ),
 			],
+			'value'       => FacebookProducts::get_product_gender( $product ),
 		] );
 
 		woocommerce_wp_select( [

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -11,6 +11,7 @@
 namespace SkyVerge\WooCommerce\Facebook\Admin;
 
 use SkyVerge\WooCommerce\Facebook\Products as FacebookProducts;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -66,6 +67,33 @@ class Products {
 	 */
 	public static function render_attribute_fields( \WC_Product $product ) {
 
+	}
+
+
+	/**
+	 * Gets a list of attribute names and labels that match any of the given words.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Product $product the product object
+	 * @param string $words a list of words used to filter attributes
+	 * @return array
+	 */
+	private static function filter_available_product_attribute_names( \WC_Product $product, $words ) {
+
+		$attributes = [];
+
+		foreach ( self::get_available_product_attribute_names( $product ) as $name => $label ) {
+
+			foreach ( $words as $word ) {
+
+				if ( Framework\SV_WC_Helper::str_exists( wc_strtolower( $label ), $word ) || Framework\SV_WC_Helper::str_exists( wc_strtolower( $name ), $word ) ) {
+					$attributes[ $name ] = $label;
+				}
+			}
+		}
+
+		return $attributes;
 	}
 
 

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -10,6 +10,8 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Admin;
 
+use SkyVerge\WooCommerce\Facebook\Products as FacebookProducts;
+
 defined( 'ABSPATH' ) or exit;
 
 /**
@@ -64,6 +66,25 @@ class Products {
 	 */
 	public static function render_attribute_fields( \WC_Product $product ) {
 
+	}
+
+
+	/**
+	 * Gets a indexed list of available product attributes with the name of the attribute as key and the label as the value.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param \WC_Product $product the product object
+	 * @return array
+	 */
+	private static function get_available_product_attribute_names( \WC_Product $product ) {
+
+		return array_map(
+			function( $attribute ) use ( $product ) {
+				return wc_attribute_label( $attribute->get_name(), $product );
+			},
+			FacebookProducts::get_available_product_attributes( $product )
+		);
 	}
 
 

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -129,6 +129,8 @@ class Products {
 				'data-nonce'       => wp_create_nonce( '' ),
 			],
 		] );
+
+		Framework\SV_WC_Helper::render_select2_ajax();
 	}
 
 

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -67,6 +67,17 @@ class Products {
 	 */
 	public static function render_attribute_fields( \WC_Product $product ) {
 
+		woocommerce_wp_select( [
+			'id'          => self::FIELD_GENDER,
+			'label'       => __( 'Gender', 'facebook-for-woocommerce' ),
+			'description' => __( "Select the product's gender for sizing.", 'facebook-for-woocommerce' ),
+			'desc_tip'    => true,
+			'options'     => [
+				'unisex' => __( 'Unisex', 'facebook-for-woocommerce' ),
+				'female' => __( 'Female', 'facebook-for-woocommerce' ),
+				'male'   => __( 'Male', 'facebook-for-woocommerce' ),
+			],
+		] );
 	}
 
 

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -78,6 +78,57 @@ class Products {
 				'male'   => __( 'Male', 'facebook-for-woocommerce' ),
 			],
 		] );
+
+		woocommerce_wp_select( [
+			'id'                => self::FIELD_COLOR,
+			'label'             => __( 'Color attribute', 'facebook-for-woocommerce' ),
+			'description'       => __( "Optionally select the attribute associated with the product's colors.", 'facebook-for-woocommerce' ),
+			'desc_tip'          => true,
+			'class'             => 'sv-wc-enhanced-search select short',
+			'style'             => 'width: 50%',
+			'options'           => self::filter_available_product_attribute_names( $product, [ 'color', 'colour', __( 'color', 'facebook-for-woocommerce' ) ] ),
+			'value'             => FacebookProducts::get_product_color_attribute( $product ),
+			'custom_attributes' => [
+				'data-allow_clear' => true,
+				'data-placeholder' => __( 'Search attributes...', 'facebook-for-woocommerce' ),
+				'data-action'      => '', // TODO: define the value for the data-action and data-nonce attributes {WV 2020-09-18}
+				'data-nonce'       => wp_create_nonce( '' ),
+			],
+		] );
+
+		woocommerce_wp_select( [
+			'id'                => self::FIELD_SIZE,
+			'label'             => __( 'Size attribute', 'facebook-for-woocommerce' ),
+			'description'       => __( "Optionally select the attribute associated with the product's sizes.", 'facebook-for-woocommerce' ),
+			'desc_tip'          => true,
+			'class'             => 'sv-wc-enhanced-search select short',
+			'style'             => 'width: 50%',
+			'options'           => self::filter_available_product_attribute_names( $product, [ 'size', __( 'size', 'facebook-for-woocommerce' ) ] ),
+			'value'             => FacebookProducts::get_product_size_attribute( $product ),
+			'custom_attributes' => [
+				'data-allow_clear' => true,
+				'data-placeholder' => __( 'Search attributes...', 'facebook-for-woocommerce' ),
+				'data-action'      => '', // TODO: define the value for the data-action and data-nonce attributes {WV 2020-09-18}
+				'data-nonce'       => wp_create_nonce( '' ),
+			],
+		] );
+
+		woocommerce_wp_select( [
+			'id'                => self::FIELD_PATTERN,
+			'label'             => __( 'Pattern attribute', 'facebook-for-woocommerce' ),
+			'description'       => __( "Optionally select the attribute associated with the product's patterns.", 'facebook-for-woocommerce' ),
+			'desc_tip'          => true,
+			'class'             => 'sv-wc-enhanced-search select short',
+			'style'             => 'width: 50%',
+			'options'           => self::filter_available_product_attribute_names( $product, [ 'pattern', __( 'pattern', 'facebook-for-woocommerce' ) ] ),
+			'value'             => FacebookProducts::get_product_pattern_attribute( $product ),
+			'custom_attributes' => [
+				'data-allow_clear' => true,
+				'data-placeholder' => __( 'Search attributes...', 'facebook-for-woocommerce' ),
+				'data-action'      => '', // TODO: define the value for the data-action and data-nonce attributes {WV 2020-09-18}
+				'data-nonce'       => wp_create_nonce( '' ),
+			],
+		] );
 	}
 
 

--- a/tests/integration/Admin/ProductsTest.php
+++ b/tests/integration/Admin/ProductsTest.php
@@ -17,6 +17,8 @@ class ProductsTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	protected function _before() {
 
+		require_once WC()->plugin_path() . '/includes/admin/wc-meta-box-functions.php';
+
 		require_once 'includes/Admin/Products.php';
 	}
 

--- a/tests/integration/Admin/ProductsTest.php
+++ b/tests/integration/Admin/ProductsTest.php
@@ -41,6 +41,8 @@ class ProductsTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @see Products::render_attribute_fields()
 	 *
+	 * TODO: add an acceptance test that checks the behavior of the attribute fields {WV 2020-09-18}
+	 *
 	 * @param string $constant_name the name of the input field
 	 * @dataProvider provider_render_attribute_fields
 	 */

--- a/tests/integration/Admin/ProductsTest.php
+++ b/tests/integration/Admin/ProductsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use SkyVerge\WooCommerce\Facebook\Admin;
+use SkyVerge\WooCommerce\Facebook\Admin\Products;
 
 /**
  * Tests the Admin\Products class.
@@ -36,7 +37,44 @@ class ProductsTest extends \Codeception\TestCase\WPTestCase {
 
 	// TODO: add test for render_google_product_category_fields()
 
-	// TODO: add test for render_attribute_fields()
+
+	/**
+	 * @see Products::render_attribute_fields()
+	 *
+	 * @param string $constant_name the name of the input field
+	 * @dataProvider provider_render_attribute_fields
+	 */
+	public function test_render_attribute_fields( $constant_name ) {
+		global $post;
+
+		$product = $this->tester->get_product();
+		$post    = get_post( $product->get_id() );
+
+		ob_start();
+
+		Products::render_attribute_fields( $product );
+
+		$output = ob_get_clean();
+
+		$this->tester->assertStringContainsString( constant( Products::class . '::' . $constant_name ), $output );
+	}
+
+
+	/**
+	 * This method cannot use Product's constants because the class is not loaded by the time the method is executed.
+	 *
+	 * @see test_render_attribute_fields()
+	 */
+	public function provider_render_attribute_fields() {
+
+		return [
+			[ 'FIELD_GENDER' ],
+			[ 'FIELD_COLOR' ],
+			[ 'FIELD_SIZE' ],
+			[ 'FIELD_PATTERN' ],
+		];
+	}
+
 
 	// TODO: add test for render_commerce_fields()
 


### PR DESCRIPTION
# Summary

This PR implements the method used to render the attribute fields in the Facebook tab for Products.

### Story: [CH 63728](https://app.clubhouse.io/skyverge/story/63728)
### Release: #1477 

## Details

I added a couple of helpers to turn the return value of `Products::get_available_product_attributes()` into an array of attribute names (like `pa_color`) and labels (like `Color`), and use that as the default options of the different select fields.

However, I noticed that select2 doesn't show any options when it's configured to load results using Ajax. It seems that all we can do is provide a default selected value.

I kept the helpers because perhaps we can move them and use them in the handler for the Ajax action, but it seems we should populate the options of the select with the already selected value, if any, and leave them empty to show the placeholder text in other cases.

Finally, I added a simple test to check that the name of the field appears in the output. I think it would be better to cover this section with an acceptance test once we implement the changes to save and hide the fields.

## UI Changes

None yet.

## QA

- [x] Code review
- [x] `run integration Admin/ProductsTest.php` pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version