### PR TITLE
Implement the admin product attribute AJAX search

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -108,6 +108,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once $this->get_framework_path() . '/utilities/class-sv-wp-async-request.php';
 				require_once $this->get_framework_path() . '/utilities/class-sv-wp-background-job-handler.php';
 
+				require_once __DIR__ . '/includes/AJAX.php';
 				require_once __DIR__ . '/includes/Handlers/Connection.php';
 				require_once __DIR__ . '/includes/Integrations/Integrations.php';
 				require_once __DIR__ . '/includes/Product_Categories.php';
@@ -126,9 +127,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				$this->commerce_handler        = new \SkyVerge\WooCommerce\Facebook\Commerce();
 
 				if ( is_ajax() ) {
-
-					require_once __DIR__ . '/includes/AJAX.php';
-
 					$this->ajax = new \SkyVerge\WooCommerce\Facebook\AJAX();
 				}
 

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -22,6 +22,10 @@ defined( 'ABSPATH' ) or exit;
 class AJAX {
 
 
+	/** @var string the product attribute search AJAX action */
+	const ACTION_SEARCH_PRODUCT_ATTRIBUTES = 'wc_facebook_search_product_attributes';
+
+
 	/**
 	 * AJAX handler constructor.
 	 *

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -10,6 +10,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Admin;
 
+use SkyVerge\WooCommerce\Facebook\AJAX;
 use SkyVerge\WooCommerce\Facebook\Products as FacebookProducts;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
@@ -90,10 +91,11 @@ class Products {
 			'options'           => self::filter_available_product_attribute_names( $product, [ 'color', 'colour', __( 'color', 'facebook-for-woocommerce' ) ] ),
 			'value'             => FacebookProducts::get_product_color_attribute( $product ),
 			'custom_attributes' => [
-				'data-allow_clear' => true,
-				'data-placeholder' => __( 'Search attributes...', 'facebook-for-woocommerce' ),
-				'data-action'      => '', // TODO: define the value for the data-action and data-nonce attributes {WV 2020-09-18}
-				'data-nonce'       => wp_create_nonce( '' ),
+				'data-allow_clear'  => true,
+				'data-placeholder'  => __( 'Search attributes...', 'facebook-for-woocommerce' ),
+				'data-action'       => AJAX::ACTION_SEARCH_PRODUCT_ATTRIBUTES,
+				'data-nonce'        => wp_create_nonce( AJAX::ACTION_SEARCH_PRODUCT_ATTRIBUTES ),
+				'data-request_data' => $product->get_id(),
 			],
 		] );
 
@@ -107,10 +109,11 @@ class Products {
 			'options'           => self::filter_available_product_attribute_names( $product, [ 'size', __( 'size', 'facebook-for-woocommerce' ) ] ),
 			'value'             => FacebookProducts::get_product_size_attribute( $product ),
 			'custom_attributes' => [
-				'data-allow_clear' => true,
-				'data-placeholder' => __( 'Search attributes...', 'facebook-for-woocommerce' ),
-				'data-action'      => '', // TODO: define the value for the data-action and data-nonce attributes {WV 2020-09-18}
-				'data-nonce'       => wp_create_nonce( '' ),
+				'data-allow_clear'  => true,
+				'data-placeholder'  => __( 'Search attributes...', 'facebook-for-woocommerce' ),
+				'data-action'       => AJAX::ACTION_SEARCH_PRODUCT_ATTRIBUTES,
+				'data-nonce'        => wp_create_nonce( AJAX::ACTION_SEARCH_PRODUCT_ATTRIBUTES ),
+				'data-request_data' => $product->get_id(),
 			],
 		] );
 
@@ -124,10 +127,11 @@ class Products {
 			'options'           => self::filter_available_product_attribute_names( $product, [ 'pattern', __( 'pattern', 'facebook-for-woocommerce' ) ] ),
 			'value'             => FacebookProducts::get_product_pattern_attribute( $product ),
 			'custom_attributes' => [
-				'data-allow_clear' => true,
-				'data-placeholder' => __( 'Search attributes...', 'facebook-for-woocommerce' ),
-				'data-action'      => '', // TODO: define the value for the data-action and data-nonce attributes {WV 2020-09-18}
-				'data-nonce'       => wp_create_nonce( '' ),
+				'data-allow_clear'  => true,
+				'data-placeholder'  => __( 'Search attributes...', 'facebook-for-woocommerce' ),
+				'data-action'       => AJAX::ACTION_SEARCH_PRODUCT_ATTRIBUTES,
+				'data-nonce'        => wp_create_nonce( AJAX::ACTION_SEARCH_PRODUCT_ATTRIBUTES ),
+				'data-request_data' => $product->get_id(),
 			],
 		] );
 

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -174,7 +174,7 @@ class Products {
 	 * @param \WC_Product $product the product object
 	 * @return array
 	 */
-	private static function get_available_product_attribute_names( \WC_Product $product ) {
+	public static function get_available_product_attribute_names( \WC_Product $product ) {
 
 		return array_map(
 			function( $attribute ) use ( $product ) {


### PR DESCRIPTION
# Summary

Enables AJAX search for the product attribute selection fields.

### Story: [CH 63731](https://app.clubhouse.io/skyverge/story/63731)
### Release: #1477 

## UI Changes

_N/A_

## QA

Visibility, storage, and overall acceptance will be handled in later stories.

### Setup

- A product with more than one attribute

### Steps

1. Try searching for one of the attributes in each of the attribute settings fields
    - [x] Your expected attribute is returned based on the search term

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version