### PR TITLE
Handle instagram orders bulk update

### DIFF
--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -113,26 +113,25 @@ class Orders {
 
 		$commerce_orders = get_transient( $this->bulk_order_update_transient );
 
-		if ( empty( $commerce_orders ) ) {
-			return;
-		}
+		if ( ! empty( $commerce_orders ) ) {
 
-		// if there were orders managed by Instagram updated in bulk, we need to warn the merchant that it wasn't updated
-		facebook_for_woocommerce()->get_message_handler()->add_error( sprintf(
-			_n(
+			// if there were orders managed by Instagram updated in bulk, we need to warn the merchant that it wasn't updated
+			facebook_for_woocommerce()->get_message_handler()->add_error(sprintf(
+				_n(
 				/* translators: %s - order ID */
-				'Heads up! Instagram order statuses can’t be updated in bulk. Please update Instagram order %s so you can provide order details required by Instagram.',
-				/* translators: %s - order IDs list */
-				'Heads up! Instagram order statuses can’t be updated in bulk. Please update Instagram orders %s individually so you can provide order details required by Instagram.',
-				count( $commerce_orders ),
-				'facebook-for-woocommerce'
-			),
-			implode( ', ', $commerce_orders )
-		) );
+					'Heads up! Instagram order statuses can’t be updated in bulk. Please update Instagram order %s so you can provide order details required by Instagram.',
+					/* translators: %s - order IDs list */
+					'Heads up! Instagram order statuses can’t be updated in bulk. Please update Instagram orders %s individually so you can provide order details required by Instagram.',
+					count($commerce_orders),
+					'facebook-for-woocommerce'
+				),
+				implode(', ', $commerce_orders)
+			));
 
-		delete_transient( $this->bulk_order_update_transient );
+			delete_transient($this->bulk_order_update_transient);
 
-		facebook_for_woocommerce()->get_message_handler()->show_messages();
+			facebook_for_woocommerce()->get_message_handler()->show_messages();
+		}
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -45,6 +45,8 @@ class Orders {
 
 		add_action( 'admin_notices', [ $this, 'add_notices' ] );
 
+		add_action( 'load-edit.php', [ $this, 'handle_bulk_update' ], 100 );
+
 		add_filter( 'wc_order_is_editable', [ $this, 'is_order_editable' ], 10, 2 );
 
 		add_action( 'admin_footer', [ $this, 'render_modal_templates' ] );

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -180,7 +180,8 @@ class Orders {
 
 		$action = $wp_list_table->current_action();
 
-		if ( ! $action ) {
+		// listen for order status change actions
+		if ( ! $action || ! Framework\SV_WC_Helper::str_starts_with( $action, 'mark_' ) ) {
 			return;
 		}
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -184,10 +184,6 @@ class Orders {
 	 */
 	public function handle_bulk_update() {
 
-		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			return;
-		}
-
 		$wp_list_table = _get_list_table( 'WC_Admin_List_Table_Orders' );
 
 		if ( ! $wp_list_table ) {

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -121,15 +121,14 @@ class Orders {
 		facebook_for_woocommerce()->get_message_handler()->add_error( sprintf(
 			_n(
 				/* translators: %s - order ID */
-			'Heads up! Instagram order statuses can’t be updated in bulk. Please update Instagram order %s so you can provide order details required by Instagram.',
+				'Heads up! Instagram order statuses can’t be updated in bulk. Please update Instagram order %s so you can provide order details required by Instagram.',
 				/* translators: %s - order IDs list */
-			'Heads up! Instagram order statuses can’t be updated in bulk. Please update Instagram orders %s individually so you can provide order details required by Instagram.',
+				'Heads up! Instagram order statuses can’t be updated in bulk. Please update Instagram orders %s individually so you can provide order details required by Instagram.',
 				count( $commerce_orders ),
-			'facebook-for-woocommerce'
+				'facebook-for-woocommerce'
 			),
 			implode( ', ', $commerce_orders )
-			)
-		);
+		) );
 
 		delete_transient( $this->bulk_order_update_transient );
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -23,6 +23,10 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 class Orders {
 
 
+	/** @var string key used for setting a transient in the event of bulk actions fired on Commerce orders */
+	private $bulk_order_update_transient = 'wc_facebook_bulk_order_update';
+
+
 	/**
 	 * Handler constructor.
 	 *
@@ -199,7 +203,7 @@ class Orders {
 
 			if ( Commerce\Orders::is_commerce_order( $order ) ) {
 
-				set_transient( 'wc_facebook_bulk_order_update', MINUTE_IN_SECONDS );
+				set_transient( $this->bulk_order_update_transient, MINUTE_IN_SECONDS );
 
 				$has_commerce_order = true;
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -118,7 +118,7 @@ class Orders {
 			// if there were orders managed by Instagram updated in bulk, we need to warn the merchant that it wasn't updated
 			facebook_for_woocommerce()->get_message_handler()->add_error(sprintf(
 				_n(
-				/* translators: %s - order ID */
+					/* translators: %s - order ID */
 					'Heads up! Instagram order statuses can’t be updated in bulk. Please update Instagram order %s so you can provide order details required by Instagram.',
 					/* translators: %s - order IDs list */
 					'Heads up! Instagram order statuses can’t be updated in bulk. Please update Instagram orders %s individually so you can provide order details required by Instagram.',

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -110,6 +110,18 @@ class Orders {
 	 */
 	public function add_notices() {
 
+		if ( ! get_transient( $this->bulk_order_update_transient ) ) {
+			return;
+		}
+
+		facebook_for_woocommerce()->get_message_handler()->add_error( sprintf(
+			/* translators: %1$s - <strong> HTML tag, %2$s </strong> HTML tag */
+			esc_html__( '%1$sHeads up!%2$s Instagram order statuses can’t be updated in bulk. Please update Instagram orders individually so you can provide order details required by Instagram.', 'facebook-for-woocommerce' ),
+			'<strong>',
+			'</strong>'
+		) );
+
+		delete_transient( $this->bulk_order_update_transient );
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -184,7 +184,7 @@ class Orders {
 	 */
 	public function handle_bulk_update() {
 
-		if ( current_user_can( 'manage_woocommerce' ) ) {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
# Summary

This PR implements the `render_refund_reason_field()`

### Story: [CH 63774](https://app.clubhouse.io/skyverge/story/63774/update-the-admin-orders-add-notices-method-to-add-the-pending-order-notice)
### Release: #1477 (release PR)

## UI Changes

If the merchant attempts to bulk update orders that are created via Instagram/Facebook, the order won't be updated and an error message will be raised:

![image](https://user-images.githubusercontent.com/1227930/93873086-b4e72d80-fd03-11ea-8fbf-2346dba34498.png)

## Additional details

I took the liberty to tweak the notice content to list the affected orders, in this way the merchant will have a clue which ones haven't been processed.

The total list of orders that have been processed will be reflected in WooCommerce/WordPress main update message.

## QA

### Setup

You need to have one or more orders that have `set_created_via( 'instagram' );`. And regular orders too.

### Steps

1. Go to WooCommerce > Orders
1. Run a bulk actino to change the status of your orders (including the IG ones)
    - [x] A notice is produced listing the orders that couldn't be updated
    - [x] The listed orders have been effectively skipped from bulk action processing
    - [x] There is no `wc_facebook_bulk_order_update` transient in `$wpdb`

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version