### PR TITLE
Implement the admin orders is order editable

### DIFF
--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -308,9 +308,13 @@ class Orders {
 	 */
 	public function is_order_editable( $maybe_editable, $order ) {
 
-		$maybe_editable = $maybe_editable && ! Commerce\Orders::is_order_pending( $order );
+		// checks if the order is an instance of WC_Order
+		$is_wc_order = isset( $order ) && $order instanceof \WC_Order;
 
-		return $maybe_editable;
+		// if the order is a WC_Order, determines whether it is pending or not
+		$is_order_pending = $is_wc_order && Commerce\Orders::is_order_pending( $order );
+
+		return $maybe_editable && ! $is_order_pending;
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -306,7 +306,7 @@ class Orders {
 	 * @param \WC_Order $order order object
 	 * @return bool
 	 */
-	public function is_order_editable( $maybe_editable, \WC_Order $order ) {
+	public function is_order_editable( $maybe_editable, $order ) {
 
 		$maybe_editable = $maybe_editable && ! Commerce\Orders::is_order_pending( $order );
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -308,6 +308,8 @@ class Orders {
 	 */
 	public function is_order_editable( $maybe_editable, \WC_Order $order ) {
 
+		$maybe_editable = $maybe_editable && ! Commerce\Orders::is_order_pending( $order );
+
 		return $maybe_editable;
 	}
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -308,11 +308,8 @@ class Orders {
 	 */
 	public function is_order_editable( $maybe_editable, $order ) {
 
-		// checks if the order is an instance of WC_Order
-		$is_wc_order = isset( $order ) && $order instanceof \WC_Order;
-
 		// if the order is a WC_Order, determines whether it is pending or not
-		$is_order_pending = $is_wc_order && Commerce\Orders::is_order_pending( $order );
+		$is_order_pending = $order instanceof \WC_Order && Commerce\Orders::is_order_pending( $order );
 
 		return $maybe_editable && ! $is_order_pending;
 	}

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -126,7 +126,41 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	// TODO: add test for is_order_editable()
+	/**
+	 * @see Admin\Orders::is_order_editable()
+	 *
+	 * @param bool $maybe_editable
+	 * @param string $created_via
+	 * @param string $status
+	 * @param bool $expected
+	 *
+	 * @dataProvider provider_is_order_editable
+	 *
+ 	 * @throws WC_Data_Exception
+	 */
+	public function test_is_order_editable( $maybe_editable, $created_via, $status, $expected ) {
+
+		$order = new \WC_Order();
+		$order->set_created_via( $created_via );
+		$order->set_status( $status );
+		$order->save();
+
+		$this->assertEquals( $expected, $this->get_orders_handler()->is_order_editable( $maybe_editable, $order ) );
+	}
+
+
+	/** @see test_is_order_editable */
+	public function provider_is_order_editable() {
+
+		return [
+			[ false, 'checkout',  'pending',    false ],
+			[ true,  'checkout',  'pending',    true ],
+			[ true,  'instagram', 'pending',    false ],
+			[ true,  'instagram', 'processing', true ],
+			[ true,  'facebook',  'pending',    false ],
+			[ true,  'facebook',  'processing', true ],
+		];
+	}
 
 
 	/** Utility methods ***********************************************************************************************/


### PR DESCRIPTION
# Summary

This PR will add an implementation to the callback for order editability.

### Story: [CH 63766](https://app.clubhouse.io/skyverge/story/63766/implement-the-admin-orders-is-order-editable-callback-method)
### Release: #1477 (release PR)

## QA

- [x] `tests/integration/Admin/OrdersTest.php` tests pass
 * _Although this is a very simple PR, my test environment is not working properly, so it's important to run the test above to QA._ 

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version