### PR TITLE
Fix undefined index PHP Notices thrown by WC_Facebook_Product_Feed::prepare_product_for_feed()

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -766,10 +766,10 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 			) . ',' .
 			'new' . ',' .
 			$product_data['visibility'] . ',' .
-			$product_data['gender'] . ',' .
-			$product_data['color'] . ',' .
-			$product_data['size'] . ',' .
-			$product_data['pattern'] . ',' .
+			static::get_value_from_product_data( $product_data, 'gender' ) . ',' .
+			static::get_value_from_product_data( $product_data, 'color' ) . ',' .
+			static::get_value_from_product_data( $product_data, 'size' ) . ',' .
+			static::get_value_from_product_data( $product_data, 'pattern' ) . ',' .
 			$google_product_category . ',' .
 			$product_data['default_product'] . ',' .
 			$product_data['variant'] . PHP_EOL;

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -742,37 +742,37 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 			$google_product_category = isset( $product_data['google_product_category'] ) ? $product_data['google_product_category'] : '';
 
 			return $product_data['retailer_id'] . ',' .
-			static::format_string_for_feed( $product_data['name'] ) . ',' .
-			static::format_string_for_feed( $product_data['description'] ) . ',' .
-			$product_data['image_url'] . ',' .
-			$product_data['url'] . ',' .
-			static::format_string_for_feed( $product_data['category'] ) . ',' .
-			static::format_string_for_feed( $product_data['brand'] ) . ',' .
+			static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'name' ) ) . ',' .
+			static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'description' ) ) . ',' .
+			static::get_value_from_product_data( $product_data, 'image_url' ) . ',' .
+			static::get_value_from_product_data( $product_data, 'url' ) . ',' .
+			static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'category' ) ) . ',' .
+			static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'brand' ) ) . ',' .
 			static::format_price_for_feed(
 				$product_data['price'],
 				$product_data['currency']
 			) . ',' .
-			$product_data['availability'] . ',' .
+			static::get_value_from_product_data( $product_data, 'availability' ) . ',' .
 			$item_group_id . ',' .
-			$product_data['checkout_url'] . ',' .
+			static::get_value_from_product_data( $product_data, 'checkout_url' ) . ',' .
 			static::format_additional_image_url(
 				$product_data['additional_image_urls']
 			) . ',' .
-			$product_data['sale_price_start_date'] . '/' .
-			$product_data['sale_price_end_date'] . ',' .
+			static::get_value_from_product_data( $product_data, 'sale_price_start_date' ) . '/' .
+			static::get_value_from_product_data( $product_data, 'sale_price_end_date' ) . ',' .
 			static::format_price_for_feed(
 				$product_data['sale_price'],
 				$product_data['currency']
 			) . ',' .
 			'new' . ',' .
-			$product_data['visibility'] . ',' .
+			static::get_value_from_product_data( $product_data, 'visibility' ) . ',' .
 			static::get_value_from_product_data( $product_data, 'gender' ) . ',' .
 			static::get_value_from_product_data( $product_data, 'color' ) . ',' .
 			static::get_value_from_product_data( $product_data, 'size' ) . ',' .
 			static::get_value_from_product_data( $product_data, 'pattern' ) . ',' .
 			$google_product_category . ',' .
-			$product_data['default_product'] . ',' .
-			$product_data['variant'] . PHP_EOL;
+			static::get_value_from_product_data( $product_data, 'default_product' ) . ',' .
+			static::get_value_from_product_data( $product_data, 'variant' ) . PHP_EOL;
 		}
 
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -860,11 +860,12 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 		 *
 		 * @param array $product_data the product data retrieved from a Woo product passed by reference
 		 * @param string $index the data index
+		 * @param mixed $return_if_not_set the value to be returned if product data has no index (default to '')
 		 * @return mixed|string the data value or an empty string
 		 */
-		private static function get_value_from_product_data( &$product_data, $index ) {
+		private static function get_value_from_product_data( &$product_data, $index, $return_if_not_set = '' ) {
 
-			return isset( $product_data[ $index ] ) ? $product_data[ $index ] : '';
+			return isset( $product_data[ $index ] ) ? $product_data[ $index ] : $return_if_not_set;
 		}
 
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -739,8 +739,6 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 				$product_data['default_product'] = '';
 			}
 
-			$google_product_category = isset( $product_data['google_product_category'] ) ? $product_data['google_product_category'] : '';
-
 			return $product_data['retailer_id'] . ',' .
 			static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'name' ) ) . ',' .
 			static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'description' ) ) . ',' .
@@ -770,7 +768,7 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 			static::get_value_from_product_data( $product_data, 'color' ) . ',' .
 			static::get_value_from_product_data( $product_data, 'size' ) . ',' .
 			static::get_value_from_product_data( $product_data, 'pattern' ) . ',' .
-			$google_product_category . ',' .
+			static::get_value_from_product_data( $product_data, 'google_product_category' ) . ',' .
 			static::get_value_from_product_data( $product_data, 'default_product' ) . ',' .
 			static::get_value_from_product_data( $product_data, 'variant' ) . PHP_EOL;
 		}

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -747,20 +747,18 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 			static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'category' ) ) . ',' .
 			static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'brand' ) ) . ',' .
 			static::format_price_for_feed(
-				$product_data['price'],
-				$product_data['currency']
+				static::get_value_from_product_data( $product_data, 'price', 0 ),
+				static::get_value_from_product_data( $product_data, 'currency' )
 			) . ',' .
 			static::get_value_from_product_data( $product_data, 'availability' ) . ',' .
 			$item_group_id . ',' .
 			static::get_value_from_product_data( $product_data, 'checkout_url' ) . ',' .
-			static::format_additional_image_url(
-				$product_data['additional_image_urls']
-			) . ',' .
+			static::format_additional_image_url( static::get_value_from_product_data( $product_data, 'additional_image_urls' ) ) . ',' .
 			static::get_value_from_product_data( $product_data, 'sale_price_start_date' ) . '/' .
 			static::get_value_from_product_data( $product_data, 'sale_price_end_date' ) . ',' .
 			static::format_price_for_feed(
-				$product_data['sale_price'],
-				$product_data['currency']
+				static::get_value_from_product_data( $product_data, 'sale_price', 0 ),
+				static::get_value_from_product_data( $product_data, 'currency' )
 			) . ',' .
 			'new' . ',' .
 			static::get_value_from_product_data( $product_data, 'visibility' ) . ',' .

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -854,6 +854,23 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 
 
 		/**
+		 * Gets the value from the product data.
+		 *
+		 * This method is used to avoid PHP undefined index notices.
+		 *
+		 * @since 2.1.0-dev.1
+		 *
+		 * @param array $product_data the product data retrieved from a Woo product passed by reference
+		 * @param string $index the data index
+		 * @return mixed|string the data value or an empty string
+		 */
+		private static function get_value_from_product_data( &$product_data, $index ) {
+
+			return isset( $product_data[ $index ] ) ? $product_data[ $index ] : '';
+		}
+
+
+		/**
 		 * Gets the status of the configured feed upload.
 		 *
 		 * The status indicator is one of 'in progress', 'complete', or 'error'.


### PR DESCRIPTION
# Summary

PHP Notices were being printed to the product catalog CSV file when `$product_data` was missing indexes like `gender`, `color`, `size` and `pattern`.

Besides the solution for those fields, this PR also covers the prevention for the other fields as well.

### Story: [CH 64484](https://app.clubhouse.io/skyverge/story/64484/undefined-index-php-notices-thrown-by-wc-facebook-product-feed-prepare-product-for-feed)
### Release: #1477 (release PR)

## QA

In order to reproduce the error, checkout `epic/instagram-checkout` and run the same QA steps.

### Setup

1. Make sure you have a few products in your store
2. Make sure your PHP is set to display errors and notices
3. Make sure your WP instance is saving entries to the `debug.log` file

### Steps

1. Checkout branch `epic/instagram-checkout`
2. Go to WooCommerce > Facebook
3. Open your browser's console and run `copy(facebookAdsToolboxConfig.feedPrepared.feedUrl)`
4. Append `&regenerate=1` to the Feed URL
5. Go to the resulting URL
 - [x] The .csv file contains PHP Notices
 - [x] The `debug.log` has a few PHP Notices
6. Checkout branch `ch64484/undefined-index-php-notices-thrown-by-wc`
7. Run the same steps
 - [x] The .csv file is generated
 - [x] The `debug.log` has no PHP Notices

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version