### PR TITLE
Don't poll for new orders until commerce is connected

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -432,7 +432,7 @@ class Orders {
 	 */
 	public function schedule_local_orders_update() {
 
-		if ( false === as_next_scheduled_action( self::ACTION_FETCH_ORDERS, [], \WC_Facebookcommerce::PLUGIN_ID ) ) {
+		if ( facebook_for_woocommerce()->get_commerce_handler()->is_connected() && false === as_next_scheduled_action( self::ACTION_FETCH_ORDERS, [], \WC_Facebookcommerce::PLUGIN_ID ) ) {
 
 			$interval = $this->get_order_update_interval();
 

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -340,6 +340,11 @@ class Orders {
 	 */
 	public function update_local_orders() {
 
+		// sanity check for connection status
+		if ( ! facebook_for_woocommerce()->get_commerce_handler()->is_connected() ) {
+			return;
+		}
+
 		$page_id = facebook_for_woocommerce()->get_integration()->get_facebook_page_id();
 
 		try {


### PR DESCRIPTION
# Summary

Halts scheduling the recurring order poll if not yet connected.

### Story: [CH 64523](https://app.clubhouse.io/skyverge/story/64523)
### Release: #1477 

## UI Changes

N/A

## QA

### Setup

- Ensure you don't have an snippets to enable connection
- Enable plugin debug logging

### Steps

1. Go to Scheduled Actions
    - [x] The `wc_facebook_commerce_fetch_orders` action is **not** scheduled
1. Add these snippets:
    - `add_filter( 'wc_facebook_commerce_is_connected', '__return_true' );`
    - `add_filter( 'wc_facebook_commerce_is_available', '__return_true' );`
1. Go to Scheduled Actions
    - [x] The `wc_facebook_commerce_fetch_orders` action is scheduled
1. Manually run the action
    - [x] The API request is logged (an API failure is expected)

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version