### PR TITLE
Fix background job to hide virtual products

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Facebook for WooCommerce Changelog ***
 
 2020.nn.nn - version 2.0.3-dev.1
+ * Fix - Remove duplicate visibility meta entries from postmeta table
 
 2020.09.25 - version 2.0.2
  * Tweak - Allow simple and variable products with zero/empty price to sync to Facebook

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -11,6 +11,7 @@
 use SkyVerge\WooCommerce\Facebook\API;
 use SkyVerge\WooCommerce\Facebook\Lifecycle;
 use SkyVerge\WooCommerce\Facebook\Utilities\Background_Handle_Virtual_Products_Variations;
+use SkyVerge\WooCommerce\Facebook\Utilities\Background_Remove_Duplicate_Visibility_Meta;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
 if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
@@ -56,6 +57,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 		/** @var Background_Handle_Virtual_Products_Variations instance */
 		protected $background_handle_virtual_products_variations;
+
+		/** @var Background_Remove_Duplicate_Visibility_Meta job handler instance */
+		protected $background_remove_duplicate_visibility_meta;
 
 		/** @var \SkyVerge\WooCommerce\Facebook\Products\Sync products sync handler */
 		private $products_sync_handler;
@@ -133,6 +137,14 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/Utilities/Background_Handle_Virtual_Products_Variations.php';
 
 					$this->background_handle_virtual_products_variations = new Background_Handle_Virtual_Products_Variations();
+
+				}
+
+				if ( 'yes' !== get_option( 'wc_facebook_background_remove_duplicate_visibility_meta_complete', 'no' ) ) {
+
+					require_once __DIR__ . '/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php';
+
+					$this->background_remove_duplicate_visibility_meta = new Background_Remove_Duplicate_Visibility_Meta();
 				}
 
 				$this->connection_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\Connection( $this );
@@ -495,6 +507,19 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		public function get_background_handle_virtual_products_variations_instance() {
 
 			return $this->background_handle_virtual_products_variations;
+		}
+
+
+		/**
+		 * Gets the background remove duplicate visibility meta data handler instance.
+		 *
+		 * @since 2.0.2-dev.1
+		 *
+		 * @return Background_Remove_Duplicate_Visibility_Meta
+		 */
+		public function get_background_remove_duplicate_visibility_meta_instance() {
+
+			return $this->background_remove_duplicate_visibility_meta;
 		}
 
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -513,7 +513,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Gets the background remove duplicate visibility meta data handler instance.
 		 *
-		 * @since 2.0.2-dev.1
+		 * @since 2.0.3-dev.1
 		 *
 		 * @return Background_Remove_Duplicate_Visibility_Meta
 		 */

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -40,7 +40,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 			'1.10.1',
 			'1.11.0',
 			'2.0.0',
-			'2.0.2',
+			'2.0.3',
 		];
 	}
 
@@ -268,11 +268,11 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 
 
 	/**
-	 * Upgrades to version 2.0.2
+	 * Upgrades to version 2.0.3
 	 *
-	 * @since 2.0.2-dev.1
+	 * @since 2.0.3-dev.1
 	 */
-	protected function upgrade_to_2_0_2() {
+	protected function upgrade_to_2_0_3() {
 
 		// create a job to remove duplicate visibility meta data entries
 		if ( $handler = $this->get_plugin()->get_background_remove_duplicate_visibility_meta_instance() ) {

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -284,4 +284,29 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 	}
 
 
+	/**
+	 * Determines whether we need to run a background job to remove duplicate visibility meta.
+	 *
+	 * @since 2.0.3-dev.1
+	 *
+	 * @return bool
+	 */
+	private function should_create_remove_duplicate_visibility_meta_background_job() {
+
+		// we should try to remove duplicate meta if the virtual product variations job ran
+		if ( 'yes' === get_option( 'wc_facebook_background_handle_virtual_products_variations_complete', 'no' ) ) {
+			return true;
+		}
+
+		$handler = $this->get_plugin()->get_background_handle_virtual_products_variations_instance();
+
+		// the virtual product variations job is not marked as complete but there is at least one job in the database
+		if ( $handler && $handler->get_jobs() ) {
+			return true;
+		}
+
+		return false;
+	}
+
+
 }

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -40,6 +40,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 			'1.10.1',
 			'1.11.0',
 			'2.0.0',
+			'2.0.2',
 		];
 	}
 
@@ -263,6 +264,23 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 
 		// deletes an option that is not longer used to generate an admin notice
 		delete_option( 'fb_cart_url' );
+	}
+
+
+	/**
+	 * Upgrades to version 2.0.2
+	 *
+	 * @since 2.0.2-dev.1
+	 */
+	protected function upgrade_to_2_0_2() {
+
+		// create a job to remove duplicate visibility meta data entries
+		if ( $handler = $this->get_plugin()->get_background_remove_duplicate_visibility_meta_instance() ) {
+
+			// create_job() expects an non-empty array of attributes
+			$handler->create_job( [ 'created_at' => current_time( 'mysql' ) ] );
+			$handler->dispatch();
+		}
 	}
 
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -278,6 +278,11 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 			return;
 		}
 
+		// if an unfinished job is stuck, give the handler a chance to complete it
+		if ( $handler = $this->get_plugin()->get_background_handle_virtual_products_variations_instance() ) {
+			$handler->dispatch();
+		}
+
 		// create a job to remove duplicate visibility meta data entries
 		if ( $handler = $this->get_plugin()->get_background_remove_duplicate_visibility_meta_instance() ) {
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -274,6 +274,10 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 	 */
 	protected function upgrade_to_2_0_3() {
 
+		if ( ! $this->should_create_remove_duplicate_visibility_meta_background_job() ) {
+			return;
+		}
+
 		// create a job to remove duplicate visibility meta data entries
 		if ( $handler = $this->get_plugin()->get_background_remove_duplicate_visibility_meta_instance() ) {
 

--- a/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
+++ b/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
@@ -254,6 +254,39 @@ class Background_Handle_Virtual_Products_Variations extends Framework\SV_WP_Back
 
 
 	/**
+	 * Updates the value of the visibility meta for the given post IDs.
+	 *
+	 * @since 2.0.2-dev.1
+	 *
+	 * @param int[] $post_ids post IDs to update
+	 * @return int
+	 */
+	private function update_product_visibility_meta( $post_ids ) {
+		global $wpdb;
+
+		if ( empty( $post_ids ) ) {
+			return 0;
+		}
+
+		$sql = sprintf(
+			"UPDATE {$wpdb->postmeta} SET meta_value = 'no' WHERE meta_key = 'fb_visibility' AND post_id IN (%s)",
+			implode( ', ', array_map( 'intval', $post_ids ) )
+		);
+
+		$rows_updated = $wpdb->query( $sql );
+
+		if ( false === $rows_updated ) {
+
+			$message = sprintf( 'There was an error trying to update products and variations meta data. %s', $wpdb->last_error );
+
+			facebook_for_woocommerce()->log( $message );
+		}
+
+		return (int) $rows_updated;
+	}
+
+
+	/**
 	 * No-op
 	 *
 	 * @since 2.0.0

--- a/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
+++ b/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
@@ -214,6 +214,46 @@ class Background_Handle_Virtual_Products_Variations extends Framework\SV_WP_Back
 
 
 	/**
+	 * Adds new visibility meta set to 'no' for the given post IDs.
+	 *
+	 * @since 2.0.2-dev.1
+	 *
+	 * @param int[] $post_ids post IDs to update
+	 * @return int
+	 */
+	private function set_product_visibility_meta( $post_ids ) {
+		global $wpdb;
+
+		if ( empty( $post_ids ) ) {
+			return 0;
+		}
+
+		$values_str = '';
+
+		foreach ( $post_ids as $post_id ) {
+			$values_str .= "('{$post_id}', 'fb_visibility', 'no')";
+		}
+
+		// we need to explicitly insert the metadata and set it to no, because not having it means it is visible
+		$sql = "
+			INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value )
+				VALUES {$values_str}
+		";
+
+		$rows_inserted = $wpdb->query( $sql );
+
+		if ( false === $rows_inserted ) {
+
+			$message = sprintf( 'There was an error trying to set products and variations meta data. %s', $wpdb->last_error );
+
+			facebook_for_woocommerce()->log( $message );
+		}
+
+		return (int) $rows_inserted;
+	}
+
+
+	/**
 	 * No-op
 	 *
 	 * @since 2.0.0

--- a/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
+++ b/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
@@ -185,6 +185,35 @@ class Background_Handle_Virtual_Products_Variations extends Framework\SV_WP_Back
 
 
 	/**
+	 * Gets the ID and current visibility setting for virtual products that are enabled for sync.
+	 *
+	 * The method returns data for products that have visibility set to 'yes' or is not defined.
+	 * Products that have visibility set to 'no' are ignored.
+	 *
+	 * @since 2.0.2-dev.1
+	 *
+	 * @return array|null
+	 */
+	private function get_posts_to_update() {
+		global $wpdb;
+
+		$sql = "
+			SELECT DISTINCT posts.ID id, visibility_meta.meta_value as visibility
+			FROM {$wpdb->posts} AS posts
+			INNER JOIN {$wpdb->postmeta} AS virtual_meta ON ( posts.ID = virtual_meta.post_id AND virtual_meta.meta_key = '_virtual' AND virtual_meta.meta_value = 'yes' )
+			LEFT JOIN {$wpdb->postmeta} AS sync_meta ON ( posts.ID = sync_meta.post_id AND sync_meta.meta_key = '_wc_facebook_sync_enabled' )
+			LEFT JOIN {$wpdb->postmeta} AS visibility_meta ON ( posts.ID = visibility_meta.post_id AND visibility_meta.meta_key = 'fb_visibility' )
+			WHERE posts.post_type IN ( 'product', 'product_variation' )
+			AND ( sync_meta.meta_value IS NULL OR sync_meta.meta_value = 'yes' )
+			AND ( visibility_meta.meta_value IS NULL OR visibility_meta.meta_value = 'yes' )
+			LIMIT 1000
+		";
+
+		return $wpdb->get_results( $sql );
+	}
+
+
+	/**
 	 * No-op
 	 *
 	 * @since 2.0.0

--- a/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
+++ b/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
@@ -164,7 +164,7 @@ class Background_Handle_Virtual_Products_Variations extends Framework\SV_WP_Back
 	 * The method returns data for products that have visibility set to 'yes' or is not defined.
 	 * Products that have visibility set to 'no' are ignored.
 	 *
-	 * @since 2.0.2-dev.1
+	 * @since 2.0.3-dev.1
 	 *
 	 * @return array|null
 	 */
@@ -190,7 +190,7 @@ class Background_Handle_Virtual_Products_Variations extends Framework\SV_WP_Back
 	/**
 	 * Adds new visibility meta set to 'no' for the given post IDs.
 	 *
-	 * @since 2.0.2-dev.1
+	 * @since 2.0.3-dev.1
 	 *
 	 * @param int[] $post_ids post IDs to update
 	 * @return int
@@ -230,7 +230,7 @@ class Background_Handle_Virtual_Products_Variations extends Framework\SV_WP_Back
 	/**
 	 * Updates the value of the visibility meta for the given post IDs.
 	 *
-	 * @since 2.0.2-dev.1
+	 * @since 2.0.3-dev.1
 	 *
 	 * @param int[] $post_ids post IDs to update
 	 * @return int

--- a/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
+++ b/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Utilities;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+
+
+/**
+ * Background job handler to remove duplicate fb_visibility entries from the postmeta table.
+ *
+ * The background job handler to hide virtual products from the catalog had a bug that allowed it to create many entries for each product.
+ *
+ * @since 2.0.2-dev.1
+ */
+class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Background_Job_Handler {
+
+
+	/**
+	 * Background job constructor.
+	 *
+	 * @since 2.0.2-dev.1
+	 */
+	public function __construct() {
+
+		$this->prefix = 'wc_facebook';
+		$this->action = 'background_remove_duplicate_visibility_meta';
+
+		parent::__construct();
+	}
+
+
+	/**
+	 * No-op
+	 *
+	 * @since 2.0.2-dev.1
+	 */
+	protected function process_item( $item, $job ) {
+		// void
+	}
+
+
+}

--- a/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
+++ b/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
@@ -40,6 +40,146 @@ class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Backgr
 
 
 	/**
+	 * Processes job.
+	 *
+	 * This job continues to update products and product variations meta data until we run out of memory
+	 * or exceed the time limit. There is no list of items to loop over.
+	 *
+	 * @since 2.0.2-dev.1
+	 *
+	 * @param object $job
+	 * @param int $items_per_batch number of items to process in a single request. Defaults to unlimited.
+	 * @return object
+	 */
+	public function process_job( $job, $items_per_batch = null ) {
+
+		// don't do anything until the job used to hide virtual variations is done
+		if ( 'yes' !== get_option( 'wc_facebook_background_handle_virtual_products_variations_complete', 'no' ) ) {
+			return $job;
+		}
+
+		if ( ! isset( $job->total ) ) {
+			$job->total = $this->count_remaining_products();
+		}
+
+		if ( ! isset( $job->progress ) ) {
+			$job->progress = 0;
+		}
+
+		while ( $job->progress < $job->total ) {
+
+			$job->progress += $this->remove_duplicates();
+
+			// update job progress
+			$job = $this->update_job( $job );
+
+			if ( $this->time_exceeded() || $this->memory_exceeded() ) {
+				break;
+			}
+		}
+
+		// job complete! :)
+		if ( $this->count_remaining_products() === 0 ) {
+
+			update_option( 'wc_facebook_background_remove_duplicate_visibility_meta_complete', 'yes' );
+
+			$this->complete_job( $job );
+		}
+
+		return $job;
+	}
+
+
+	/**
+	 * Counts the number of virtual products or product variations with sync enabled and visible.
+	 *
+	 * @since 2.0.2-dev.1
+	 *
+	 * @return bool
+	 */
+	private function count_remaining_products() {
+		global $wpdb;
+
+		$sql = "
+			SELECT COUNT(post_id)
+			FROM (
+				SELECT post_id, COUNT(meta_key) entries
+				FROM {$wpdb->postmeta}
+				WHERE meta_key = 'fb_visibility'
+				GROUP BY post_id
+				HAVING entries > 1
+			) AS duplicate_entries
+		";
+
+		return (int) $wpdb->get_var( $sql );
+	}
+
+
+	/**
+	 * Removes duplicate visibility meta data entries for products.
+	 *
+	 * @since 2.0.2-dev.1
+	 *
+	 * @return int
+	 */
+	private function remove_duplicates() {
+		global $wpdb;
+
+		$results = $this->get_posts_to_update();
+
+		if ( empty( $results ) ) {
+			facebook_for_woocommerce()->log( 'There are no products or products variations with duplicate visibility meta data.' );
+			return 0;
+		}
+
+		$products_updated = 0;
+
+		foreach ( $results as $result ) {
+
+			$sql = "DELETE FROM wp_postmeta WHERE post_id = %d AND meta_key = 'fb_visibility' AND meta_id != %d";
+
+			if ( false === $wpdb->query( $wpdb->prepare( $sql, $result->post_id, $result->last_meta_id ) ) ) {
+
+				facebook_for_woocommerce()->log( sprintf(
+					'There was an error trying to set products and variations meta data. %s',
+					$wpdb->last_error
+				) );
+
+				continue;
+			}
+
+			$products_updated++;
+		}
+
+		return $products_updated;
+	}
+
+
+	/**
+	 * Gets the ID of products that duplicate visibility meta data.
+	 *
+	 * The method also returns the number of meta data entries and ID of the last meta data entry for each product.
+	 *
+	 * @since 2.0.2-dev.1
+	 *
+	 * @return array|null
+	 */
+	private function get_posts_to_update() {
+		global $wpdb;
+
+		$sql = "
+			SELECT post_id, COUNT(meta_key) entries, MAX(meta_id) last_meta_id
+			FROM {$wpdb->postmeta}
+			WHERE meta_key = 'fb_visibility'
+			GROUP BY post_id
+			HAVING entries > 1
+		";
+
+		return $wpdb->get_results( $sql );
+	}
+
+
+	/**
 	 * No-op
 	 *
 	 * @since 2.0.2-dev.1

--- a/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
+++ b/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
@@ -20,7 +20,7 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
  *
  * The background job handler to hide virtual products from the catalog had a bug that allowed it to create many entries for each product.
  *
- * @since 2.0.2-dev.1
+ * @since 2.0.3-dev.1
  */
 class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Background_Job_Handler {
 
@@ -28,7 +28,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Backgr
 	/**
 	 * Background job constructor.
 	 *
-	 * @since 2.0.2-dev.1
+	 * @since 2.0.3-dev.1
 	 */
 	public function __construct() {
 
@@ -45,7 +45,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Backgr
 	 * This job continues to update products and product variations meta data until we run out of memory
 	 * or exceed the time limit. There is no list of items to loop over.
 	 *
-	 * @since 2.0.2-dev.1
+	 * @since 2.0.3-dev.1
 	 *
 	 * @param object $job
 	 * @param int $items_per_batch number of items to process in a single request. Defaults to unlimited.
@@ -93,7 +93,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Backgr
 	/**
 	 * Counts the number of virtual products or product variations with sync enabled and visible.
 	 *
-	 * @since 2.0.2-dev.1
+	 * @since 2.0.3-dev.1
 	 *
 	 * @return bool
 	 */
@@ -118,7 +118,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Backgr
 	/**
 	 * Removes duplicate visibility meta data entries for products.
 	 *
-	 * @since 2.0.2-dev.1
+	 * @since 2.0.3-dev.1
 	 *
 	 * @return int
 	 */
@@ -160,7 +160,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Backgr
 	 *
 	 * The method also returns the number of meta data entries and ID of the last meta data entry for each product.
 	 *
-	 * @since 2.0.2-dev.1
+	 * @since 2.0.3-dev.1
 	 *
 	 * @return array|null
 	 */
@@ -182,7 +182,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Backgr
 	/**
 	 * No-op
 	 *
-	 * @since 2.0.2-dev.1
+	 * @since 2.0.3-dev.1
 	 */
 	protected function process_item( $item, $job ) {
 		// void

--- a/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
+++ b/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
@@ -54,7 +54,9 @@ class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Backgr
 	public function process_job( $job, $items_per_batch = null ) {
 
 		// don't do anything until the job used to hide virtual variations is done
-		if ( 'yes' !== get_option( 'wc_facebook_background_handle_virtual_products_variations_complete', 'no' ) ) {
+		$handler = facebook_for_woocommerce()->get_background_handle_virtual_products_variations_instance();
+
+		if ( $handler && $handler->get_jobs( [ 'status' => [ 'processing', 'queued' ] ] ) ) {
 			return $job;
 		}
 


### PR DESCRIPTION
# Summary

This PRs updates the background job handler used to hide virtual products to prevent it from creating duplicate meta data entries.

### Story: [CH 64549](https://app.clubhouse.io/skyverge/story/64549)
### Release: #1467 

## Details

The background job doesn't replace existing `fb_visibility` meta entries set to `yes` before or when adding the corresponding meta entries set to `no`. As a result, the number of items to processes never decreases and the job can continue to insert new records in the `postmeta` table indefinitely.

This PR updates the job to insert new rows for products that have no `fb_visibility` set and to update existing rows for products that have `fb_visibility` set to `yes`.

A new background job is also included to remove any duplicates created by the previous version. Whenever it finds a post with duplicate `fb_visibility` meta data, it removes all but the last entry. The last entry should have the most recent value for that meta because:

1. If the plugin hasn't updated visibility for that post, the last entry is the one added by the background job
1. If the plugin updated visibility for that post using `update_post_meta()` all entries would have been updated to have the most recent value
1. If the plugin updated visibility for that post using `$product->update_meta_data()` all duplicate rows would have been removed and the remaining entry would have the most recent value (and the post won't be picked up by the new background job anyway)

## UI Changes

N/A

## QA

### Setup

1. Install Facebook for WooCommerce 1.10.2

#### Simple Product

1. Create a Simple product
1. Define a price
1. Make the product virtual
1. Enable Facebook sync

#### Variable Product

1. Create a Variable Product
1. Add an attribute with two terms
1. Create a variation for each attribute
1. Define a price for each variation
1. Make one variation virtual
1. Enable Facebook sync for both variations

#### Set visibility

The next steps will ensure that `fb_visibility` is set to `yes` instead of `1`.

1. Go to the Products page
    1. Use the Hide button to hide the new products from the Catalog
    1. Use the Show button to show the new products again 

### Steps

#### Reproduce the bug

Create a snapshot of the database so that you can go back to this point to test the solution after you reproduce the bug.

1. Upgrade to Facebook for WooCommerce 2.0.1
1. Go to the Dashboard to trigger the lifecycle events
1. Run `SELECT COUNT(meta_id) FROM wp_postmeta WHERE meta_key = 'fb_visibility'` a couple of times against the website's database: 
    - [ ] The number of `fb_visibility` meta entries is constantly increasing

#### Solution

Once you upgrade to this branch, it may take several seconds or attempts to get the expected results if an old job is still running in the background. First the background job that handles virtual products needs to complete execution and then the background job that removes duplicates will start removing the additional rows.

1. Switch to this branch
1. Go to the Dashboard to trigger the lifecycle events
1. Run the SQL query again
    - [x] The number of `fb_visibility` meta entries stops increasing or suddenly decreases to a normal number
1. Run `SELECT post_id, COUNT(meta_key) entries, MAX(meta_id) last_meta_id FROM wp_postmeta WHERE meta_key = 'fb_visibility' GROUP BY post_id HAVING entries > 1` against the website's database:
    - [x] No results are returned - there are no posts with duplicate `fb_visibility` meta

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version