### PR TITLE
Implement the Admin\Orders modal messages/button methods

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -120,6 +120,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/facebook-commerce-messenger-chat.php';
 				require_once __DIR__ . '/includes/Events/Event.php';
 				require_once __DIR__ . '/includes/Commerce.php';
+				require_once __DIR__ . '/includes/Utilities/Shipment.php';
 
 				$this->product_feed            = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
 				$this->products_sync_handler   = new \SkyVerge\WooCommerce\Facebook\Products\Sync();

--- a/includes/API/Orders/Cancel/Request.php
+++ b/includes/API/Orders/Cancel/Request.php
@@ -25,22 +25,6 @@ class Request extends API\Orders\Abstract_Request  {
 	use API\Traits\Idempotent_Request;
 
 
-	/** @var string customer requested cancellation */
-	const REASON_CUSTOMER_REQUESTED = 'CUSTOMER_REQUESTED';
-
-	/** @var string out of stock cancellation */
-	const REASON_OUT_OF_STOCK = 'OUT_OF_STOCK';
-
-	/** @var string invalid address cancellation */
-	const REASON_INVALID_ADDRESS = 'INVALID_ADDRESS';
-
-	/** @var string suspicious order cancellation */
-	const REASON_SUSPICIOUS_ORDER = 'SUSPICIOUS_ORDER';
-
-	/** @var string other reason cancellation */
-	const REASON_OTHER = 'CANCEL_REASON_OTHER';
-
-
 	/**
 	 * API request constructor.
 	 *

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -291,6 +291,20 @@ class Orders {
 	 */
 	private function get_cancel_modal_buttons() {
 
+		ob_start();
+
+		?>
+		<button
+			id="btn-ok"
+			class="button button-large button-primary"
+		><?php esc_html_e( 'Submit cancellation', 'facebook-for-woocommerce' ); ?></button>
+		<button
+			class="button button-large"
+			onclick="jQuery( '.modal-close' ).trigger( 'click' )"
+		><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
+		<?php
+
+		return ob_get_clean();
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -215,6 +215,20 @@ class Orders {
 	 */
 	private function get_complete_modal_buttons() {
 
+		ob_start();
+
+		?>
+		<button
+			id="btn-ok"
+			class="button button-large button-primary"
+		><?php esc_html_e( 'Submit order', 'facebook-for-woocommerce' ); ?></button>
+		<button
+			class="button button-large"
+			onclick="jQuery( '.modal-close' ).trigger( 'click' )"
+		><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
+		<?php
+
+		return ob_get_clean();
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -13,6 +13,7 @@ namespace SkyVerge\WooCommerce\Facebook\Admin;
 defined( 'ABSPATH' ) or exit;
 
 use SkyVerge\WooCommerce\Facebook\Commerce;
+use SkyVerge\WooCommerce\Facebook\Utilities\Shipment;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 use function Crontrol\Event\get_list_table;
 
@@ -182,6 +183,26 @@ class Orders {
 	 */
 	private function get_complete_modal_message() {
 
+		ob_start();
+
+		?>
+		<p><?php esc_html_e( 'Select the carrier and tracking number for this order:', 'facebook-for-woocommerce' ); ?></p>
+		<?php
+
+		$shipment_utilities = new Shipment();
+
+		woocommerce_wp_select( [
+			'id'      => 'wc-facebook-carrier',
+			'label'   => __( 'Carrier', 'facebook-for-woocommerce' ),
+			'options' => $shipment_utilities->get_carrier_options(),
+		] );
+
+		woocommerce_wp_text_input( [
+			'id'    => 'wc-facebook-tracking-number',
+			'label' => __( 'Tracking number', 'facebook-for-woocommerce' ),
+		] );
+
+		return ob_get_clean();
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -263,6 +263,20 @@ class Orders {
 	 */
 	private function get_refund_modal_buttons() {
 
+		ob_start();
+
+		?>
+		<button
+			id="btn-ok"
+			class="button button-large button-primary"
+		><?php esc_html_e( 'Submit refund', 'facebook-for-woocommerce' ); ?></button>
+		<button
+			class="button button-large"
+			onclick="jQuery( '.modal-close' ).trigger( 'click' )"
+		><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
+		<?php
+
+		return ob_get_clean();
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -176,6 +176,33 @@ class Orders {
 
 
 	/**
+	 * Gets the markup for the buttons used in a modal.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $submit_label label for the submit button
+	 * @return string
+	 */
+	private function get_modal_buttons( $submit_label ) {
+
+		ob_start();
+
+		?>
+		<button
+			id="btn-ok"
+			class="button button-large button-primary"
+		><?php esc_html( $submit_label ); ?></button>
+		<button
+			class="button button-large"
+			onclick="jQuery( '.modal-close' ).trigger( 'click' )"
+		><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
+		<?php
+
+		return ob_get_clean();
+	}
+
+
+	/**
 	 * Gets the markup for the message used in the Complete modal.
 	 *
 	 * @since 2.1.0-dev.1
@@ -216,20 +243,7 @@ class Orders {
 	 */
 	private function get_complete_modal_buttons() {
 
-		ob_start();
-
-		?>
-		<button
-			id="btn-ok"
-			class="button button-large button-primary"
-		><?php esc_html_e( 'Submit order', 'facebook-for-woocommerce' ); ?></button>
-		<button
-			class="button button-large"
-			onclick="jQuery( '.modal-close' ).trigger( 'click' )"
-		><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
-		<?php
-
-		return ob_get_clean();
+		return $this->get_modal_buttons( __( 'Submit order', 'facebook-for-woocommerce' ) );
 	}
 
 
@@ -263,20 +277,7 @@ class Orders {
 	 */
 	private function get_refund_modal_buttons() {
 
-		ob_start();
-
-		?>
-		<button
-			id="btn-ok"
-			class="button button-large button-primary"
-		><?php esc_html_e( 'Submit refund', 'facebook-for-woocommerce' ); ?></button>
-		<button
-			class="button button-large"
-			onclick="jQuery( '.modal-close' ).trigger( 'click' )"
-		><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
-		<?php
-
-		return ob_get_clean();
+		return $this->get_modal_buttons( __( 'Submit refund', 'facebook-for-woocommerce' ) );
 	}
 
 
@@ -314,20 +315,7 @@ class Orders {
 	 */
 	private function get_cancel_modal_buttons() {
 
-		ob_start();
-
-		?>
-		<button
-			id="btn-ok"
-			class="button button-large button-primary"
-		><?php esc_html_e( 'Submit cancellation', 'facebook-for-woocommerce' ); ?></button>
-		<button
-			class="button button-large"
-			onclick="jQuery( '.modal-close' ).trigger( 'click' )"
-		><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
-		<?php
-
-		return ob_get_clean();
+		return $this->get_modal_buttons( __( 'Submit cancellation', 'facebook-for-woocommerce' ) );
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -12,7 +12,6 @@ namespace SkyVerge\WooCommerce\Facebook\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
-use SkyVerge\WooCommerce\Facebook\API;
 use SkyVerge\WooCommerce\Facebook\Commerce;
 use SkyVerge\WooCommerce\Facebook\Utilities\Shipment;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -242,6 +242,15 @@ class Orders {
 	 */
 	private function get_refund_modal_message() {
 
+		ob_start();
+
+		?>
+		<p><?php esc_html_e( 'Select a reason for refunding this order:', 'facebook-for-woocommerce' ); ?></p>
+		<?php
+
+		$this->render_refund_reason_field();
+
+		return ob_get_clean();
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -54,8 +54,6 @@ class Orders {
 
 		add_filter( 'wc_order_is_editable', [ $this, 'is_order_editable' ], 10, 2 );
 
-		add_action( 'admin_footer', [ $this, 'render_modal_templates' ] );
-
 		add_action( 'admin_footer', [ $this, 'render_refund_reason_field' ] );
 
 		add_action( 'woocommerce_refund_created', [ $this, 'handle_refund' ] );
@@ -165,18 +163,6 @@ class Orders {
 	 * @since 2.1.0-dev.1
 	 */
 	public function maybe_remove_order_metaboxes() {
-
-	}
-
-
-	/**
-	 * Renders the Complete, Refund, & Cancel modals templates markup.
-	 *
-	 * @internal
-	 *
-	 * @since 2.1.0-dev.1
-	 */
-	public function render_modal_templates() {
 
 	}
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -190,7 +190,7 @@ class Orders {
 		<button
 			id="btn-ok"
 			class="button button-large button-primary"
-		><?php esc_html( $submit_label ); ?></button>
+		><?php esc_html_e( $submit_label ); ?></button>
 		<button
 			class="button button-large"
 			onclick="jQuery( '.modal-close' ).trigger( 'click' )"

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -93,9 +93,15 @@ class Orders {
 		], \WC_Facebookcommerce::VERSION );
 
 		wp_localize_script( 'wc-facebook-commerce-orders', 'wc_facebook_commerce_orders', [
-			'order_id'          => $order->get_id(),
-			'is_commerce_order' => Commerce\Orders::is_commerce_order( $order ),
-			'shipment_tracking' => $order->get_meta( '_wc_shipment_tracking_items', true ),
+			'order_id'               => $order->get_id(),
+			'is_commerce_order'      => Commerce\Orders::is_commerce_order( $order ),
+			'shipment_tracking'      => $order->get_meta( '_wc_shipment_tracking_items', true ),
+			'complete_modal_message' => $this->get_complete_modal_message(),
+			'complete_modal_buttons' => $this->get_complete_modal_buttons(),
+			'refund_modal_message'   => $this->get_refund_modal_message(),
+			'refund_modal_buttons'   => $this->get_refund_modal_buttons(),
+			'cancel_modal_message'   => $this->get_cancel_modal_message(),
+			'cancel_modal_buttons'   => $this->get_cancel_modal_buttons(),
 		] );
 	}
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -168,6 +168,78 @@ class Orders {
 
 
 	/**
+	 * Gets the markup for the message used in the Complete modal.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	private function get_complete_modal_message() {
+
+	}
+
+
+	/**
+	 * Gets the markup for the buttons used in the Complete modal.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	private function get_complete_modal_buttons() {
+
+	}
+
+
+	/**
+	 * Gets the markup for the message used in the Refund modal.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	private function get_refund_modal_message() {
+
+	}
+
+
+	/**
+	 * Gets the markup for the buttons used in the Refund modal.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	private function get_refund_modal_buttons() {
+
+	}
+
+
+	/**
+	 * Gets the markup for the message used in the Cancel modal.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	private function get_cancel_modal_message() {
+
+	}
+
+
+	/**
+	 * Gets the markup for the buttons used in the Cancel modal.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string
+	 */
+	private function get_cancel_modal_buttons() {
+
+	}
+
+
+	/**
 	 * Renders the refund reason field.
 	 *
 	 * @internal

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -12,6 +12,7 @@ namespace SkyVerge\WooCommerce\Facebook\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Facebook\API;
 use SkyVerge\WooCommerce\Facebook\Commerce;
 use SkyVerge\WooCommerce\Facebook\Utilities\Shipment;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
@@ -192,13 +193,13 @@ class Orders {
 		$shipment_utilities = new Shipment();
 
 		woocommerce_wp_select( [
-			'id'      => 'wc-facebook-carrier',
+			'id'      => 'wc_facebook_carrier',
 			'label'   => __( 'Carrier', 'facebook-for-woocommerce' ),
 			'options' => $shipment_utilities->get_carrier_options(),
 		] );
 
 		woocommerce_wp_text_input( [
-			'id'    => 'wc-facebook-tracking-number',
+			'id'    => 'wc_facebook_tracking_number',
 			'label' => __( 'Tracking number', 'facebook-for-woocommerce' ),
 		] );
 
@@ -265,6 +266,19 @@ class Orders {
 	 */
 	private function get_cancel_modal_message() {
 
+		ob_start();
+
+		?>
+		<p><?php esc_html_e( 'Select a reason for cancelling this order:', 'facebook-for-woocommerce' ); ?></p>
+		<?php
+
+		woocommerce_wp_select( [
+			'id'      => 'wc_facebook_cancellation_reason',
+			'label'   => '',
+			'options' => facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->get_cancellation_reasons(),
+		] );
+
+		return ob_get_clean();
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -297,7 +297,7 @@ class Orders {
 		<?php
 
 		woocommerce_wp_select( [
-			'id'      => 'wc_facebook_cancellation_reason',
+			'id'      => 'wc_facebook_cancel_reason',
 			'label'   => '',
 			'options' => facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->get_cancellation_reasons(),
 		] );

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -10,7 +10,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Commerce;
 
-use SkyVerge\WooCommerce\Facebook\API\Orders\Cancel\Request;
+use SkyVerge\WooCommerce\Facebook\API\Orders\Cancel\Request as Cancellation_Request;
 use SkyVerge\WooCommerce\Facebook\API\Orders\Order;
 use SkyVerge\WooCommerce\Facebook\Products;
 use SkyVerge\WooCommerce\Facebook\API\Orders\Refund\Request as Refund_Request;
@@ -645,16 +645,10 @@ class Orders {
 
 		$api = $plugin->get_api( $plugin->get_connection_handler()->get_page_access_token() );
 
-		$valid_reason_codes = [
-			Request::REASON_CUSTOMER_REQUESTED,
-			Request::REASON_INVALID_ADDRESS,
-			Request::REASON_OTHER,
-			Request::REASON_OUT_OF_STOCK,
-			Request::REASON_SUSPICIOUS_ORDER,
-		];
+		$valid_reason_codes = array_keys( $this->get_cancellation_reasons() );
 
 		if ( ! in_array( $reason_code, $valid_reason_codes, true ) ) {
-			$reason_code = Request::REASON_OTHER;
+			$reason_code = Cancellation_Request::REASON_OTHER;
 		}
 
 		try {
@@ -675,6 +669,26 @@ class Orders {
 
 			throw $exception;
 		}
+	}
+
+
+	/**
+	 * Gets the valid cancellation reasons.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return array key-value array with codes and their labels
+	 */
+	public function get_cancellation_reasons() {
+
+		return [
+
+			Cancellation_Request::REASON_CUSTOMER_REQUESTED => __( 'Customer requested cancellation', 'facebook-for-woocommerce' ),
+			Cancellation_Request::REASON_OUT_OF_STOCK       => __( 'Product(s) are out of stock', 'facebook-for-woocommerce' ),
+			Cancellation_Request::REASON_INVALID_ADDRESS    => __( 'Customer address is invalid', 'facebook-for-woocommerce' ),
+			Cancellation_Request::REASON_SUSPICIOUS_ORDER   => __( 'Suspicious order', 'facebook-for-woocommerce' ),
+			Cancellation_Request::REASON_OTHER              => __( 'Other', 'facebook-for-woocommerce' ),
+		];
 	}
 
 

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -36,6 +36,21 @@ class Orders {
 	/** @var string the meta key used to store the email remarketing option */
 	const EMAIL_REMARKETING_META_KEY = '_wc_facebook_commerce_email_remarketing';
 
+	/** @var string customer requested cancellation */
+	const CANCEL_REASON_CUSTOMER_REQUESTED = 'CUSTOMER_REQUESTED';
+
+	/** @var string out of stock cancellation */
+	const CANCEL_REASON_OUT_OF_STOCK = 'OUT_OF_STOCK';
+
+	/** @var string invalid address cancellation */
+	const CANCEL_REASON_INVALID_ADDRESS = 'INVALID_ADDRESS';
+
+	/** @var string suspicious order cancellation */
+	const CANCEL_REASON_SUSPICIOUS_ORDER = 'SUSPICIOUS_ORDER';
+
+	/** @var string other reason cancellation */
+	const CANCEL_REASON_OTHER = 'CANCEL_REASON_OTHER';
+
 
 	/**
 	 * Orders constructor.
@@ -648,7 +663,7 @@ class Orders {
 		$valid_reason_codes = array_keys( $this->get_cancellation_reasons() );
 
 		if ( ! in_array( $reason_code, $valid_reason_codes, true ) ) {
-			$reason_code = Cancellation_Request::REASON_OTHER;
+			$reason_code = Orders::CANCEL_REASON_OTHER;
 		}
 
 		try {
@@ -683,11 +698,11 @@ class Orders {
 
 		return [
 
-			Cancellation_Request::REASON_CUSTOMER_REQUESTED => __( 'Customer requested cancellation', 'facebook-for-woocommerce' ),
-			Cancellation_Request::REASON_OUT_OF_STOCK       => __( 'Product(s) are out of stock', 'facebook-for-woocommerce' ),
-			Cancellation_Request::REASON_INVALID_ADDRESS    => __( 'Customer address is invalid', 'facebook-for-woocommerce' ),
-			Cancellation_Request::REASON_SUSPICIOUS_ORDER   => __( 'Suspicious order', 'facebook-for-woocommerce' ),
-			Cancellation_Request::REASON_OTHER              => __( 'Other', 'facebook-for-woocommerce' ),
+			self::CANCEL_REASON_CUSTOMER_REQUESTED => __( 'Customer requested cancellation', 'facebook-for-woocommerce' ),
+			self::CANCEL_REASON_OUT_OF_STOCK       => __( 'Product(s) are out of stock', 'facebook-for-woocommerce' ),
+			self::CANCEL_REASON_INVALID_ADDRESS    => __( 'Customer address is invalid', 'facebook-for-woocommerce' ),
+			self::CANCEL_REASON_SUSPICIOUS_ORDER   => __( 'Suspicious order', 'facebook-for-woocommerce' ),
+			self::CANCEL_REASON_OTHER              => __( 'Other', 'facebook-for-woocommerce' ),
 		];
 	}
 

--- a/tests/integration/API/Orders/Cancel/RequestTest.php
+++ b/tests/integration/API/Orders/Cancel/RequestTest.php
@@ -3,6 +3,7 @@
 namespace SkyVerge\WooCommerce\Facebook\Tests\API\Orders\Cancel;
 
 use SkyVerge\WooCommerce\Facebook\API\Orders\Cancel\Request;
+use SkyVerge\WooCommerce\Facebook\Commerce\Orders;
 
 /**
  * Tests the API\Orders\Cancel\Request class.
@@ -32,14 +33,14 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Request::__construct() */
 	public function test_constructor() {
 
-		$request = new Request( '368508827392800', Request::REASON_CUSTOMER_REQUESTED, false );
+		$request = new Request( '368508827392800', Orders::CANCEL_REASON_CUSTOMER_REQUESTED, false );
 
 		$this->assertEquals( '/368508827392800/cancellations', $request->get_path() );
 		$this->assertEquals( 'POST', $request->get_method() );
 
 		$expected_data = [
 			'cancel_reason'   => [
-				'reason_code' => Request::REASON_CUSTOMER_REQUESTED,
+				'reason_code' => Orders::CANCEL_REASON_CUSTOMER_REQUESTED,
 			],
 			'restock_items'   => false,
 			'idempotency_key' => $request->get_idempotency_key(),

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -4,6 +4,7 @@ use Codeception\Util\Stub;
 use SkyVerge\WooCommerce\Facebook\API;
 use SkyVerge\WooCommerce\Facebook\API\Request;
 use SkyVerge\WooCommerce\Facebook\API\Response;
+use SkyVerge\WooCommerce\Facebook\Commerce\Orders;
 use SkyVerge\WooCommerce\Facebook\Products\Sync;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
@@ -812,14 +813,14 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 			'do_remote_request' => \Codeception\Stub\Expected::once(),
 		] );
 
-		$api->cancel_order( '335211597203390', API\Orders\Cancel\Request::REASON_CUSTOMER_REQUESTED, true );
+		$api->cancel_order( '335211597203390', Orders::CANCEL_REASON_CUSTOMER_REQUESTED, true );
 
 		$this->assertInstanceOf( API\Orders\Cancel\Request::class, $api->get_request() );
 		$this->assertEquals( 'POST', $api->get_request()->get_method() );
 		$this->assertEquals( '/335211597203390/cancellations', $api->get_request()->get_path() );
 		$expected_data = [
 			'cancel_reason'   => [
-				'reason_code' => API\Orders\Cancel\Request::REASON_CUSTOMER_REQUESTED,
+				'reason_code' => Orders::CANCEL_REASON_CUSTOMER_REQUESTED,
 			],
 			'restock_items'   => true,
 			'idempotency_key' => $api->get_request()->get_idempotency_key(),

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -17,8 +17,13 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	protected function _before() {
 
-		require_once 'includes/Admin/Orders.php';
-		require_once 'includes/Commerce/Orders.php';
+		if ( ! class_exists( Admin\Orders::class ) ) {
+			require_once 'includes/Admin/Orders.php';
+		}
+
+		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\Commerce\Orders::class ) ) {
+			require_once 'includes/Commerce/Orders.php';
+		}
 	}
 
 

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -39,8 +39,6 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 	// TODO: add test for maybe_remove_order_metaboxes()
 
-	// TODO: add test for render_modal_templates()
-
 	// TODO: add test for render_refund_reason_field()
 
 	// TODO: add test for handle_refund()

--- a/tests/integration/Utilities/ShipmentTest.php
+++ b/tests/integration/Utilities/ShipmentTest.php
@@ -17,7 +17,9 @@ class ShipmentTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	protected function _before() {
 
-		require_once 'includes/Utilities/Shipment.php';
+		if ( ! class_exists( Shipment::class ) ) {
+			require_once 'includes/Utilities/Shipment.php';
+		}
 	}
 
 


### PR DESCRIPTION
# Summary

This PRs implements the methods used to generate the modal content for the modals on the edit order page.

### Story: [CH 63786](https://app.clubhouse.io/skyverge/story/63786/implement-the-admin-orders-modal-messages-button-methods)
### Release: #1477 

## Details 

As already documented on the story, we opted for adding the message and buttons for each modal to the JS params, similarly to how we done for the `Product_Categories` modal. These JS params will be used by `orders.js` when opening the corresponding modals.

I've also moved the cancellation reason constants to the Commerce Orders handler and created a new helper method to return a key-value array of cancellation reason codes and labels.

## QA

### Setup

### Steps

1. Edit an order
1. In your console, open the `wc_facebook_commerce_orders` JS object
    - [x] The `complete_modal_message` param is defined and contains the markup for the complete modal content
    - [x] The `complete_modal_buttons` param is defined and contains the markup for the complete modal buttons
    - [x] The `refund_modal_message` param is defined and contains the markup for the refund modal content (for now it just contains the text above the select, because the select is being added in #1581, as it will be shared by the WC refund form and the refund modal)
    - [x] The `refund_modal_buttons` param is defined and contains the markup for the refund modal buttons
    - [x] The `cancel_modal_message` param is defined and contains the markup for the cancel modal content
    - [x] The `cancel_modal_buttons` param is defined and contains the markup for the cancel modal buttons

### Automated tests

- [x] `vendor/bin/codecept run tests/integration/API/Orders/Cancel/RequestTest.php` tests pass
- [x] `vendor/bin/codecept run tests/integration/APITest.php` tests pass
(no new tests were added, this is just to regression test the cancellation reason refactor)

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version