### PR TITLE
Implement the complete order AJAX callback

### DIFF
--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -116,6 +116,12 @@ class AJAX {
 				throw new Framework\SV_WC_Plugin_Exception( 'Invalid nonce', 403 );
 			}
 
+			$order_id        = (int) Framework\SV_WC_Helper::get_posted_value( 'order_id' );
+
+			if ( empty( $order_id ) ) {
+				throw new Framework\SV_WC_Plugin_Exception( __( 'Order ID is required', 'facebook-for-woocommerce' ), 400 );
+			}
+
 		} catch ( Framework\SV_WC_Plugin_Exception $exception ) {
 
 			wp_send_json_error( $exception->getMessage(), $exception->getCode() );

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -117,9 +117,14 @@ class AJAX {
 			}
 
 			$order_id        = (int) Framework\SV_WC_Helper::get_posted_value( 'order_id' );
+			$tracking_number = wc_clean( Framework\SV_WC_Helper::get_posted_value( 'tracking_number' ) );
 
 			if ( empty( $order_id ) ) {
 				throw new Framework\SV_WC_Plugin_Exception( __( 'Order ID is required', 'facebook-for-woocommerce' ), 400 );
+			}
+
+			if ( empty( $tracking_number ) ) {
+				throw new Framework\SV_WC_Plugin_Exception( __( 'Tracking number is required', 'facebook-for-woocommerce' ), 400 );
 			}
 
 		} catch ( Framework\SV_WC_Plugin_Exception $exception ) {

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -52,6 +52,9 @@ class AJAX {
 
 		// search a product's attributes for the given term
 		add_action( 'wp_ajax_' . self::ACTION_SEARCH_PRODUCT_ATTRIBUTES, [ $this, 'admin_search_product_attributes' ] );
+
+		// complete a Facebook order for the given order ID
+		add_action( 'wp_ajax_' . self::ACTION_COMPLETE_ORDER, [ $this, 'admin_complete_order' ] );
 	}
 
 

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -102,6 +102,23 @@ class AJAX {
 
 
 	/**
+	 * Completes a Facebook order for the given order ID.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function admin_complete_order() {
+
+		try {
+
+		} catch ( Framework\SV_WC_Plugin_Exception $exception ) {
+
+		}
+	}
+
+
+	/**
 	 * Syncs all products via AJAX.
 	 *
 	 * @internal

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -118,6 +118,7 @@ class AJAX {
 
 			$order_id        = (int) Framework\SV_WC_Helper::get_posted_value( 'order_id' );
 			$tracking_number = wc_clean( Framework\SV_WC_Helper::get_posted_value( 'tracking_number' ) );
+			$carrier_code    = wc_clean( Framework\SV_WC_Helper::get_posted_value( 'carrier_code' ) );
 
 			if ( empty( $order_id ) ) {
 				throw new Framework\SV_WC_Plugin_Exception( __( 'Order ID is required', 'facebook-for-woocommerce' ), 400 );
@@ -125,6 +126,10 @@ class AJAX {
 
 			if ( empty( $tracking_number ) ) {
 				throw new Framework\SV_WC_Plugin_Exception( __( 'Tracking number is required', 'facebook-for-woocommerce' ), 400 );
+			}
+
+			if ( empty( $carrier_code ) ) {
+				throw new Framework\SV_WC_Plugin_Exception( __( 'Carrier code is required', 'facebook-for-woocommerce' ), 400 );
 			}
 
 		} catch ( Framework\SV_WC_Plugin_Exception $exception ) {

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -138,6 +138,10 @@ class AJAX {
 				throw new Framework\SV_WC_Plugin_Exception( __( 'Order not found', 'facebook-for-woocommerce' ), 404 );
 			}
 
+			facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->fulfill_order( $order, $tracking_number, $carrier_code );
+
+			wp_send_json_success();
+
 		} catch ( Framework\SV_WC_Plugin_Exception $exception ) {
 
 			wp_send_json_error( $exception->getMessage(), $exception->getCode() );

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -26,6 +26,9 @@ class AJAX {
 	/** @var string the product attribute search AJAX action */
 	const ACTION_SEARCH_PRODUCT_ATTRIBUTES = 'wc_facebook_search_product_attributes';
 
+	/** @var string the complete order AJAX action */
+	const ACTION_COMPLETE_ORDER = 'wc_facebook_complete_order';
+
 
 	/**
 	 * AJAX handler constructor.

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -112,8 +112,13 @@ class AJAX {
 
 		try {
 
+			if ( ! wp_verify_nonce( Framework\SV_WC_Helper::get_posted_value( 'nonce' ), self::ACTION_COMPLETE_ORDER ) ) {
+				throw new Framework\SV_WC_Plugin_Exception( 'Invalid nonce', 403 );
+			}
+
 		} catch ( Framework\SV_WC_Plugin_Exception $exception ) {
 
+			wp_send_json_error( $exception->getMessage(), $exception->getCode() );
 		}
 	}
 

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -132,6 +132,12 @@ class AJAX {
 				throw new Framework\SV_WC_Plugin_Exception( __( 'Carrier code is required', 'facebook-for-woocommerce' ), 400 );
 			}
 
+			$order = wc_get_order( $order_id );
+
+			if ( ! $order instanceof \WC_Order ) {
+				throw new Framework\SV_WC_Plugin_Exception( __( 'Order not found', 'facebook-for-woocommerce' ), 404 );
+			}
+
 		} catch ( Framework\SV_WC_Plugin_Exception $exception ) {
 
 			wp_send_json_error( $exception->getMessage(), $exception->getCode() );


### PR DESCRIPTION
# Summary

Handles the AJAX callback for completing an order.

### Story: [CH 63782](https://app.clubhouse.io/skyverge/story/63782)
### Release: #1477 

## Details

The JS to handle the modal and AJAX request will be added in a later story.

## UI Changes

N/A

## QA

This will be testable once the modal is implemented, but a simpler check can be made to ensure the request is handled. From the browser console:

```javascript
jQuery.post( '{your-site}/wp-admin/admin-ajax.php', {"action":"wc_facebook_complete_order","nonce":"12345","order_id":"12345","tracking_number":"12345","carrier_code":"OTHER"}, function( response ) { console.log( response ) } );
```

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version