### PR TITLE
Update the Commerce\Orders::fulfill_order() method to validate the carrier

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -14,6 +14,7 @@ use SkyVerge\WooCommerce\Facebook\API\Orders\Cancel\Request as Cancellation_Requ
 use SkyVerge\WooCommerce\Facebook\API\Orders\Order;
 use SkyVerge\WooCommerce\Facebook\Products;
 use SkyVerge\WooCommerce\Facebook\API\Orders\Refund\Request as Refund_Request;
+use SkyVerge\WooCommerce\Facebook\Utilities;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Exception;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Plugin_Exception;
 
@@ -517,6 +518,13 @@ class Orders {
 
 			if ( ! $remote_id ) {
 				throw new SV_WC_Plugin_Exception( __( 'Remote ID not found.', 'facebook-for-woocommerce' ) );
+			}
+
+			$shipment_utilities = new Utilities\Shipment();
+
+			if ( ! $shipment_utilities->is_valid_carrier( $carrier ) ) {
+				/** translators: Placeholders: %s - shipping carrier code */
+				throw new SV_WC_Plugin_Exception( sprintf( __( '%s is not a valid shipping carrier code.', 'facebook-for-woocommerce' ), $carrier ) );
 			}
 
 			$items = [];

--- a/includes/Utilities/Shipment.php
+++ b/includes/Utilities/Shipment.php
@@ -648,7 +648,7 @@ class Shipment {
 
 
 	/**
-	 * Determines whether the given carrier is a one of the valid carrier options.
+	 * Determines whether the given carrier is one of the valid carrier options.
 	 *
 	 * @since 2.1.0-dev.1
 	 *

--- a/includes/Utilities/Shipment.php
+++ b/includes/Utilities/Shipment.php
@@ -648,6 +648,20 @@ class Shipment {
 
 
 	/**
+	 * Determines whether the given carrier is a one of the valid carrier options.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $carrier
+	 * @return bool
+	 */
+	public function is_valid_carrier( $carrier ) {
+
+		return array_key_exists( $carrier, $this->get_carrier_options() );
+	}
+
+
+	/**
 	 * Finds the proper Facebook carrier code, given a Shipment Tracking carrier.
 	 *
 	 * @since 2.1.0-dev.1

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -3,7 +3,6 @@
 use SkyVerge\WooCommerce\Facebook\API;
 use SkyVerge\WooCommerce\Facebook\API\Request;
 use SkyVerge\WooCommerce\Facebook\API\Response;
-use SkyVerge\WooCommerce\Facebook\Commerce\Orders;
 use SkyVerge\WooCommerce\Facebook\Products\Sync;
 use SkyVerge\WooCommerce\Facebook\Commerce\Orders;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -487,6 +487,8 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Orders::schedule_local_orders_update() */
 	public function test_schedule_local_orders_update() {
 
+		facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->schedule_local_orders_update();
+
 		$this->assertNotFalse( as_next_scheduled_action( Orders::ACTION_FETCH_ORDERS, [], \WC_Facebookcommerce::PLUGIN_ID ) );
 	}
 

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -369,6 +369,10 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Orders::update_local_orders() */
 	public function test_update_local_orders_create() {
 
+		// ensure Commerce is connected
+		facebook_for_woocommerce()->get_connection_handler()->update_page_access_token( '1234' );
+		facebook_for_woocommerce()->get_connection_handler()->update_commerce_manager_id( '1234' );
+
 		$product = $this->tester->get_product();
 
 		$response_data = $this->get_test_response_data( Order::STATUS_CREATED, $product );
@@ -394,6 +398,10 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 	/** @see Orders::update_local_orders() */
 	public function test_update_local_orders_update() {
+
+		// ensure Commerce is connected
+		facebook_for_woocommerce()->get_connection_handler()->update_page_access_token( '1234' );
+		facebook_for_woocommerce()->get_connection_handler()->update_commerce_manager_id( '1234' );
 
 		$product = $this->tester->get_product();
 
@@ -428,6 +436,10 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 	/** @see Orders::update_local_orders() */
 	public function test_update_local_orders_acknowledge() {
+
+		// ensure Commerce is connected
+		facebook_for_woocommerce()->get_connection_handler()->update_page_access_token( '1234' );
+		facebook_for_woocommerce()->get_connection_handler()->update_commerce_manager_id( '1234' );
 
 		$product = $this->tester->get_product();
 
@@ -486,6 +498,10 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 	/** @see Orders::schedule_local_orders_update() */
 	public function test_schedule_local_orders_update() {
+
+		// ensure Commerce is connected
+		facebook_for_woocommerce()->get_connection_handler()->update_page_access_token( '1234' );
+		facebook_for_woocommerce()->get_connection_handler()->update_commerce_manager_id( '1234' );
 
 		facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->schedule_local_orders_update();
 

--- a/tests/integration/Commerce/OrdersTest.php
+++ b/tests/integration/Commerce/OrdersTest.php
@@ -505,6 +505,26 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @see Orders::fulfill_order() */
+	public function test_fulfill_order_invalid_carrier() {
+
+		$item = new \WC_Order_Item_Product();
+		$item->set_name( 'Test' );
+		$item->set_quantity( 2 );
+		$item->set_total( 1.00 );
+
+		$order = new \WC_Order();
+		$order->add_item( $item );
+		$order->update_meta_data( Orders::REMOTE_ID_META_KEY, '1234' );
+		$order->save();
+
+		$this->expectException( SV_WC_Plugin_Exception::class );
+		$this->expectExceptionMessage( 'NOT_A_CARRIER is not a valid shipping carrier code.' );
+
+		$this->get_commerce_orders_handler()->fulfill_order( $order, '1234', 'NOT_A_CARRIER' );
+	}
+
+
+	/** @see Orders::fulfill_order() */
 	public function test_fulfill_order_no_valid_items() {
 
 		$order = new \WC_Order();

--- a/tests/integration/Utilities/ShipmentTest.php
+++ b/tests/integration/Utilities/ShipmentTest.php
@@ -46,6 +46,28 @@ class ShipmentTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
+	 * @see Shipment::is_valid_carrier()
+	 *
+	 * @param string $carrier a shipment carrier
+	 * @dataProvider provider_is_valid_carrier
+	 */
+	public function test_is_valid_carrier( string $carrier, bool $valid ) {
+
+		$this->assertSame( $valid, $this->get_shipment_utilities()->is_valid_carrier( $carrier ) );
+	}
+
+
+	/** @see test_is_valid_carrier() */
+	public function provider_is_valid_carrier() {
+
+		return [
+			'valid'   => [ 'RAM',           true ],
+			'invalid' => [ 'NOT_A_CARRIER', false ],
+		];
+	}
+
+
+	/**
 	 * @see Shipment::convert_shipment_tracking_carrier_code()
 	 *
 	 * @param string $carrier Shipment Tracking carrier


### PR DESCRIPTION
# Summary

I decided to add a small `is_valid_carrier()` method to the `Shipment` utility class to perform the validation. The functionality is very close to the responsibility of that class and having a public helper makes tests a bit easier.

### Story: [CH 63762](https://app.clubhouse.io/skyverge/story/63762)
### Release: #1477 

## UI Changes

None.

## QA

- [x] `codecept run tests/integration/Commerce/OrdersTest.php` pass
- [x] `codecept run tests/integration/Utilities/ShipmentTest.php` pass
- [x] `codecept run tests/integration/APITest.php` pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version