### PR TITLE
Implement the admin orders handle refund

### DIFF
--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -354,6 +354,9 @@ class Orders {
 	 */
 	public function handle_refund( $refund_id ) {
 
+		$order_refund = wc_get_order( $refund_id );
+
+		Commerce\Orders::add_order_refund( $order_refund, null );
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -351,6 +351,8 @@ class Orders {
 	 * @since 2.1.0-dev.1
 	 *
 	 * @param int $refund_id refund ID
+	 *
+	 * @throws Framework\SV_WC_Plugin_Exception
 	 */
 	public function handle_refund( $refund_id ) {
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -356,7 +356,9 @@ class Orders {
 
 		$order_refund = wc_get_order( $refund_id );
 
-		Commerce\Orders::add_order_refund( $order_refund, null );
+		$reason_code = isset( $_POST['wc_facebook_refund_reason'] ) ? $_POST['wc_facebook_refund_reason'] : null;
+
+		Commerce\Orders::add_order_refund( $order_refund, $reason_code );
 	}
 
 

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -358,9 +358,12 @@ class Orders {
 
 		$order_refund = wc_get_order( $refund_id );
 
-		$reason_code = isset( $_POST['wc_facebook_refund_reason'] ) ? $_POST['wc_facebook_refund_reason'] : null;
+		if ( $order_refund instanceof \WC_Order_Refund ) {
 
-		Commerce\Orders::add_order_refund( $order_refund, $reason_code );
+			$reason_code = isset( $_POST['wc_facebook_refund_reason'] ) ? $_POST['wc_facebook_refund_reason'] : null;
+
+			Commerce\Orders::add_order_refund( $order_refund, $reason_code );
+		}
 	}
 
 

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use SkyVerge\WooCommerce\Facebook\Admin;
+use SkyVerge\WooCommerce\Facebook\Commerce\Orders;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Plugin_Exception;
 
 /**
  * Tests the Admin\Orders class.
@@ -46,7 +48,26 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 
 	// TODO: add test for render_refund_reason_field()
 
-	// TODO: add test for handle_refund()
+
+	/**
+	 * @see Admin\Orders::handle_refund()
+	 *
+	 * @throws SV_WC_Plugin_Exception
+	 */
+	public function test_handle_refund() {
+
+		// the API cannot be instantiated if an access token is not defined
+		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
+
+		$_POST[ 'wc_facebook_refund_reason' ] = Orders::REFUND_REASON_QUALITY_ISSUE;
+
+		$order = new \WC_Order_Refund();
+		$order->set_status( 'pending' );
+		$order->save();
+
+		$this->get_orders_handler()->handle_refund( $order->get_id() );
+	}
+
 
 	// TODO: add test for handle_bulk_update()
 

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -23,7 +23,7 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 			require_once 'includes/Admin/Orders.php';
 		}
 
-		if ( ! class_exists( \SkyVerge\WooCommerce\Facebook\Commerce\Orders::class ) ) {
+		if ( ! class_exists( Orders::class ) ) {
 			require_once 'includes/Commerce/Orders.php';
 		}
 	}


### PR DESCRIPTION
# Summary

This PR will add an implementation to `Admin\Orders:handle_refund()`.

### Story: [CH 63862](https://app.clubhouse.io/skyverge/story/63862/implement-the-admin-orders-handle-refund-callback-method)
### Release: #1477 (release PR)

## QA

- [x] `tests/integration/Admin/OrdersTest.php` tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version