### PR TITLE
Improve refund items logic

### DIFF
--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -385,7 +385,7 @@ class Orders {
 
 			$reason_code = isset( $_POST['wc_facebook_refund_reason'] ) ? $_POST['wc_facebook_refund_reason'] : null;
 
-			Commerce\Orders::add_order_refund( $order_refund, $reason_code );
+			facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->add_order_refund( $order_refund, $reason_code );
 		}
 	}
 

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -653,9 +653,10 @@ class Orders {
 			}
 
 			if ( ! empty( $refund->get_shipping_total() ) ) {
+
 				$refund_data['shipping'] = [
 					'shipping_refund' => [
-						'amount'   => $refund->get_shipping_total(),
+						'amount'   => abs( $refund->get_shipping_total() ),
 						'currency' => $refund->get_currency(),
 					],
 				];

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -644,6 +644,9 @@ class Orders {
 			} else {
 				facebook_for_woocommerce()->log("Could not refund Instagram order for order refund {$refund->get_id()}: {$exception->getMessage()}" );
 			}
+
+			// re-throw the exception so the error halts refund creation
+			throw $exception;
 		}
 	}
 


### PR DESCRIPTION
# Summary

Improves the refund generator method for sturdier handling of refund data.

### Story: [CH 64624](https://app.clubhouse.io/skyverge/story/64624)
### Release: #1477 

## Details

- Breaks the items gathering into a dedicated method
- Ensures refund totals are always sent as positive
- Fixes tests, which had a few false-positives

## UI Changes

N/A

## QA

- [x] `codecept run integration Commerce/OrdersTest` tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version