### PR TITLE
Ensure additional_image_urls includes maximum 20 URLs

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -192,6 +192,23 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			return $image_urls;
 		}
 
+
+		/**
+		 * Gets the list of additional image URLs for the product from the complete list of image URLs.
+		 *
+		 * It assumes the first URL will be used as the product image.
+		 * It returns 20 or less image URLs because Facebook doesn't allow more items on the additional_image_urls field.
+		 *
+		 * @since 2.0.2-dev.1
+		 *
+		 * @param array $image_urls all image URLs for the product
+		 * @return array
+		 */
+		private function get_additional_image_urls( $image_urls ) {
+
+			return array_slice( $image_urls, 1, 20 );
+		}
+
 		// Returns the parent image id for variable products only.
 		public function get_parent_image_id() {
 			if ( WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
@@ -523,7 +540,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				),
 				'description'           => $this->get_fb_description(),
 				'image_url'             => $image_urls[0], // The array can't be empty.
-				'additional_image_urls' => array_slice( $image_urls, 1, 20 ),
+				'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
 				'url'                   => $product_url,
 				'category'              => $categories['categories'],
 				'brand'                 => Framework\SV_WC_Helper::str_truncate( $brand, 100 ),

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -523,7 +523,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				),
 				'description'           => $this->get_fb_description(),
 				'image_url'             => $image_urls[0], // The array can't be empty.
-				'additional_image_urls' => array_slice( $image_urls, 1 ),
+				'additional_image_urls' => array_slice( $image_urls, 1, 20 ),
 				'url'                   => $product_url,
 				'category'              => $categories['categories'],
 				'brand'                 => Framework\SV_WC_Helper::str_truncate( $brand, 100 ),

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -209,6 +209,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			return array_slice( $image_urls, 1, 20 );
 		}
 
+
 		// Returns the parent image id for variable products only.
 		public function get_parent_image_id() {
 			if ( WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -34,6 +34,48 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @see \WC_Facebook_Product::prepare_product()
 	 *
+	 * @dataProvider provider_prepare_product_uses_correct_number_of_additional_image_urls
+	 */
+	public function test_prepare_product_uses_correct_number_of_additional_image_urls( int $images_count ) {
+
+		$product = $this->tester->get_product();
+
+		$attachments = array_map( function() {
+
+			return wp_insert_attachment( [
+				// 'post_mime_type' => 'png',
+				// 'post_title'     => 'Fake Attachment',
+				// 'post_content'   => '',
+				// 'post_status'    => 'inheirt',
+			] );
+		}, range( 1, $images_count ) );
+
+		$product->update_meta_data( '_thumbnail_id', $attachments[0] );
+		$product->update_meta_data( '_product_image_gallery', implode( ',', array_slice( $attachments, 1 ) ) );
+		$product->save_meta_data();
+
+		$data = ( new \WC_Facebook_Product( $product->get_id() ) )->prepare_product();
+
+		$this->assertLessThanOrEqual( 20, count( $data['additional_image_urls'] ) );
+	}
+
+
+	/** @see test_prepare_product_uses_correct_number_of_additional_image_urls() */
+	public function provider_prepare_product_uses_correct_number_of_additional_image_urls() {
+
+		return [
+			[ 1 ],
+			[ 2 ],
+			[ 10 ],
+			[ 15 ],
+			[ 25 ],
+		];
+	}
+
+
+	/**
+	 * @see \WC_Facebook_Product::prepare_product()
+	 *
 	 * @param mixed $price the regular price for the product
 	 * @param bool $is_visible whether the product should visible in the Facebook Shop
 	 * @param string $visibility 'staging' or 'published'

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -42,12 +42,7 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 
 		$attachments = array_map( function() {
 
-			return wp_insert_attachment( [
-				// 'post_mime_type' => 'png',
-				// 'post_title'     => 'Fake Attachment',
-				// 'post_content'   => '',
-				// 'post_status'    => 'inheirt',
-			] );
+			return wp_insert_attachment( [] );
 		}, range( 1, $images_count ) );
 
 		$product->update_meta_data( '_thumbnail_id', $attachments[0] );


### PR DESCRIPTION
# Summary

This PR updates `prepare_product()` to ensure the `additional_image_urls` entry never includes more than 20 URLs. 

### Story: [CH 64683](https://app.clubhouse.io/skyverge/story/64683)
### Release: #1467 

## Details

The Batch API rejects product item updates that include more than 20 URLs on that field.

## UI Changes

None

## QA

I think code review and tests is fine for this small change.

- [ ] `codecept run integration WC_Facebook_Product_Test.php` pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version