### PR TITLE
Address a potential connection error when connecting from a site with special chars in title

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2020.nn.nn - version 2.0.2-dev.1
  * Fix - Update connection parameters to use an array to pass the Messenger domain
+ * Fix - Address a potential error when connecting from a site whose title contains special characters
 
 2020.08.17 - version 2.0.1
  * Fix - Ensure the configured business name is never empty when connecting to Facebook

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -449,16 +449,32 @@ class Connection {
 
 		if ( ! is_string( $this->external_business_id ) ) {
 
-			$value = get_option( self::OPTION_EXTERNAL_BUSINESS_ID );
+			$external_id = get_option( self::OPTION_EXTERNAL_BUSINESS_ID );
 
-			if ( ! is_string( $value ) ) {
+			if ( ! is_string( $external_id ) ) {
 
-				$value = uniqid( sanitize_title( $this->get_business_name() ) . '-', false );
+				/**
+				 * Filters the shop's business external ID.
+				 *
+				 * This is passed to Facebook when connecting.
+				 * Should be non-empty and without special characters, otherwise the ID will be obtained from the site URL as fallback.
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param string $external_id the shop's business external ID
+				 */
+				$external_id = sanitize_key( (string) apply_filters( 'wc_facebook_connection_business_id', get_bloginfo( 'name' ) ) );
 
-				update_option( self::OPTION_EXTERNAL_BUSINESS_ID, $value );
+				if ( empty( $external_id ) ) {
+					$external_id = sanitize_key( str_replace( [ 'http', 'https', 'www' ], '', get_bloginfo( 'url' ) ) );
+				}
+
+				$external_id = uniqid( sprintf( '%s-', $external_id ), false );
+
+				update_option( self::OPTION_EXTERNAL_BUSINESS_ID, $external_id );
 			}
 
-			$this->external_business_id = $value;
+			$this->external_business_id = $external_id;
 		}
 
 		/**


### PR DESCRIPTION
# Summary

This PR attempts to address an error that might be tricky to reproduce. 


### Story: [CH 63508](https://app.clubhouse.io/skyverge/story/63508/site-titles-that-use-non-standard-ascii-cannot-connect-6)
### Release: #1467  

## Additional details

The issue might be tricky to reproduce and you really need to clean up your data between your site and FB. I was able to spot the issue, and then with the change in this PR was gone. 

I think it may be safe to just not allow any special characters in the business ID. After all this is an internal identifier, we don't have to match it exactly with the business name, do we? 

So, I chose to parse again the site name, but run it through a different filter and then strip all special chars with `sanitize_key()` rather than `sanitize_title()`. Finally, if that results in empty string, the URL will be used again (but without the http, www parts).

## UI Changes

none

## QA

### Setup

You need to start from scratch, either from a new WC installation or ensuring you have uninstalled FB and cleaned up all its data from the `wp_options` table.

Your site title needs to use special characters. Try non-latin characters - use Google Translate to learn a new word in a new language or check a Wikipedia article in a different language if you're out of ideas! :)

### Steps

1. Activate the plugin and go to WooCommerce > Facebook
1. Try to connect and follow all the steps from Facebook
   - [x] Setup completes successfully and you are redirected back to WordPress 
   - [x] You shop is successfully connected to FB
   - [x] The `wc_facebook_external_business_id` option doesn't contain special characters

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version