### PR TITLE
Allow Sell on Instagram checkbox to be unchecked

### DIFF
--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -228,7 +228,7 @@ class Products {
 			<input type="checkbox" class="enable-if-sync-enabled"
 			       name="<?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>"
 			       id="<?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>" value="yes"
-			       checked="<?php echo Products_Handler::is_commerce_enabled_for_product( $product ) ? 'checked' : ''; ?>">
+			       <?php checked( Products_Handler::is_commerce_enabled_for_product( $product ) ); ?> />
 		</p>
 
 		<div id="product-not-ready-notice" style="display:none;">

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -224,6 +224,7 @@ class Products {
 				<span class="woocommerce-help-tip"
 				      data-tip="<?php echo esc_attr_e( 'Enable to sell this product on Instagram. Products that are hidden in the Facebook catalog can be synced, but won’t be available for purchase.', 'facebook-for-woocommerce' ); ?>"></span>
 			</label>
+			<input type="hidden" name="<?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>" value="no" />
 			<input type="checkbox" class="enable-if-sync-enabled"
 			       name="<?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>"
 			       id="<?php echo esc_attr( self::FIELD_COMMERCE_ENABLED ); ?>" value="yes"

--- a/tests/acceptance/Admin/ProductCommerceSettingsCest.php
+++ b/tests/acceptance/Admin/ProductCommerceSettingsCest.php
@@ -1,6 +1,7 @@
 <?php
 
 use SkyVerge\WooCommerce\Facebook\Handlers\Connection;
+use SkyVerge\WooCommerce\Facebook\Products;
 
 class ProductCommerceSettingsCest {
 
@@ -281,6 +282,8 @@ class ProductCommerceSettingsCest {
 	 */
 	private function see_missing_google_product_category_alert( AcceptanceTester $I, \WC_Product $product, array $categories ) {
 
+		Products::update_commerce_enabled_for_product( $product, true );
+
 		$I->amEditingPostWithId( $product->get_id() );
 
 		$I->wantTo( "Test that an alert is shown if the user doesn't select a Google product sub-category" );
@@ -307,7 +310,7 @@ class ProductCommerceSettingsCest {
 
 
 	/** @see try_missing_google_product_category_alert_is_shown */
-	public function provider_missing_google_product_category_alert_is_shown() {
+	protected function provider_missing_google_product_category_alert_is_shown() {
 
 		return [
 			'no category selected'     => [ 'categories' => [] ],


### PR DESCRIPTION
# Summary

This PR adds a hidden field fallback for the Sell on Instagram checkbox to ensure a value is posted when merchants uncheck the checkbox.

### Story: [CH 64841](https://app.clubhouse.io/skyverge/story/64841)
### Release: #1477 

## Details

The PR also ensures that the checkbox is checked by default when the product is enabled for Commerce only. It was previously always rendered as checked.

## UI Changes

None. Only behavior of the checkbox.

## QA

### Setup

Use the following filters to make Commerce available and be able to see the checkbox:

1. Add `add_filter( 'wc_facebook_commerce_is_available', '__return_true' );`
1. Add `add_filter( 'wc_facebook_commerce_is_connected', '__return_true' );`

### Steps

#### Product not enabled for Commerce

1. Edit a product that is not enabled for Commerce
    - [x] The Sell on Instagram checkbox is unchecked by default
1. Check the Sell on Instagram checkbox
1. Update the product
    - [x] The Sell on Instagram checkbox is checked when the page loads

#### Product enabled for Commerce

1. Edit a product that is enabled for Commerce
    - [x] The Sell on Instagram checkbox is checked
1. Uncheck the Sell on Instagram checkbox
1. Update the product
    - [x] The Sell on Instagram checkbox is unchecked when the page loads

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version