### PR TITLE
Use the long user error messages for order API failures

### DIFF
--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -100,18 +100,11 @@ class AJAX {
 
 			facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->cancel_order( $order, $reason_code );
 
-			wp_send_json_success( 'cancelled' );
+			wp_send_json_success();
 
 		} catch ( Framework\SV_WC_Plugin_Exception $exception ) {
 
-			$message = sprintf( __( 'Could not cancel order. %s', 'facebook-for-woocommerce' ), $exception->getMessage() );
-
-			if ( $order instanceof \WC_Abstract_Order ) {
-				/* translators: Placeholder: %s - error message */
-				$order->add_order_note( $message );
-			}
-
-			wp_send_json_error( $message );
+			wp_send_json_error( $exception->getMessage() );
 		}
 	}
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -130,7 +130,7 @@ class API extends Framework\SV_WC_API_Base {
 		if ( $response && $response->has_api_error() ) {
 
 			$code    = $response->get_api_error_code();
-			$message = sprintf( '%s: %s', $response->get_api_error_type(), $response->get_api_error_message() );
+			$message = sprintf( '%s: %s', $response->get_api_error_type(), $response->get_user_error_message() ?: $response->get_api_error_message() );
 
 			/**
 			 * Graph API

--- a/includes/API/Response.php
+++ b/includes/API/Response.php
@@ -92,4 +92,17 @@ class Response extends Framework\SV_WC_API_JSON_Response {
 	}
 
 
+	/**
+	 * Gets the user error message.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return string|null
+	 */
+	public function get_user_error_message() {
+
+		return isset( $this->error->error_user_msg ) ? $this->error->error_user_msg : null;
+	}
+
+
 }

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -763,7 +763,7 @@ class Orders {
 			$api->cancel_order( $remote_id, $reason_code );
 
 			$order->add_order_note( sprintf(
-				/* translators: Placeholders: %s - sales channel name, like Facebook or Instagram */
+				/* translators: Placeholder: %s - sales channel name, like Facebook or Instagram */
 				__( '%s order cancelled.', 'facebook-for-woocommerce' ),
 				ucfirst( $order->get_created_via() )
 			) );

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -570,11 +570,20 @@ class Orders {
 
 			$plugin->get_api( $plugin->get_connection_handler()->get_page_access_token() )->fulfill_order( $remote_id, $fulfillment_data );
 
-			$order->add_order_note( __( 'Remote order fulfilled.', 'facebook-for-woocommerce' ) );
+			$order->add_order_note( sprintf(
+				/* translators: Placeholders: %s - sales channel name, like Facebook or Instagram */
+				__( '%s order fulfilled.', 'facebook-for-woocommerce' ),
+				ucfirst( $order->get_created_via() )
+			) );
 
 		} catch ( SV_WC_Plugin_Exception $exception ) {
 
-			$order->add_order_note( sprintf( __( 'Remote order could not be fulfilled. %s', 'facebook-for-woocommerce' ), $exception->getMessage() ) );
+			$order->add_order_note( sprintf(
+				/* translators: Placeholders: %1$s - sales channel name, like Facebook or Instagram, %2$s - error message */
+				__( '%1$s order could not be fulfilled. %2$s', 'facebook-for-woocommerce' ),
+				ucfirst( $order->get_created_via() ),
+				$exception->getMessage()
+			) );
 
 			throw $exception;
 		}
@@ -648,14 +657,26 @@ class Orders {
 
 			$api->add_order_refund( $remote_id, $refund_data );
 
-			$parent_order->add_order_note( __( 'Order refunded on Instagram.', 'facebook-for-woocommerce' ) );
+			$parent_order->add_order_note( sprintf(
+				/* translators: Placeholders: %s - sales channel name, like Facebook or Instagram */
+				__( 'Order refunded on %s.', 'facebook-for-woocommerce' ),
+				ucfirst( $parent_order->get_created_via() )
+			) );
 
 		} catch ( SV_WC_Plugin_Exception $exception ) {
 
 			if ( ! empty( $parent_order ) && $parent_order instanceof \WC_Order ) {
-				$parent_order->add_order_note( sprintf( __( 'Could not refund Instagram order: %s', 'facebook-for-woocommerce' ), $exception->getMessage() ) );
+
+				$parent_order->add_order_note( sprintf(
+					/* translators: Placeholders: %1$s - sales channel name, like Facebook or Instagram, %2$s - error message */
+					__( 'Could not refund %1$s order: %2$s', 'facebook-for-woocommerce' ),
+					ucfirst( $parent_order->get_created_via() ),
+					$exception->getMessage()
+				) );
+
 			} else {
-				facebook_for_woocommerce()->log( "Could not refund Instagram order for order refund {$refund->get_id()}: {$exception->getMessage()}" );
+
+				facebook_for_woocommerce()->log( "Could not refund remote order for order refund {$refund->get_id()}: {$exception->getMessage()}" );
 			}
 
 			// re-throw the exception so the error halts refund creation
@@ -741,11 +762,20 @@ class Orders {
 
 			$api->cancel_order( $remote_id, $reason_code );
 
-			$order->add_order_note( __( 'Remote order cancelled.', 'facebook-for-woocommerce' ) );
+			$order->add_order_note( sprintf(
+				/* translators: Placeholders: %s - sales channel name, like Facebook or Instagram */
+				__( '%s order cancelled.', 'facebook-for-woocommerce' ),
+				ucfirst( $order->get_created_via() )
+			) );
 
 		} catch ( SV_WC_Plugin_Exception $exception ) {
 
-			$order->add_order_note( sprintf( __( 'Remote order could not be cancelled. %s', 'facebook-for-woocommerce' ), $exception->getMessage() ) );
+			$order->add_order_note( sprintf(
+				/* translators: Placeholders: %1$s - sales channel name, like Facebook or Instagram, %2$s - error message */
+				__( '%1$s order could not be cancelled. %2$s', 'facebook-for-woocommerce' ),
+				ucfirst( $order->get_created_via() ),
+				$exception->getMessage()
+			) );
 
 			throw $exception;
 		}

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -571,7 +571,7 @@ class Orders {
 			$plugin->get_api( $plugin->get_connection_handler()->get_page_access_token() )->fulfill_order( $remote_id, $fulfillment_data );
 
 			$order->add_order_note( sprintf(
-				/* translators: Placeholders: %s - sales channel name, like Facebook or Instagram */
+				/* translators: Placeholder: %s - sales channel name, like Facebook or Instagram */
 				__( '%s order fulfilled.', 'facebook-for-woocommerce' ),
 				ucfirst( $order->get_created_via() )
 			) );

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -658,7 +658,7 @@ class Orders {
 			$api->add_order_refund( $remote_id, $refund_data );
 
 			$parent_order->add_order_note( sprintf(
-				/* translators: Placeholders: %s - sales channel name, like Facebook or Instagram */
+				/* translators: Placeholder: %s - sales channel name, like Facebook or Instagram */
 				__( 'Order refunded on %s.', 'facebook-for-woocommerce' ),
 				ucfirst( $parent_order->get_created_via() )
 			) );

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -188,7 +188,13 @@ class Orders {
 			// check if the local order already has this item
 			foreach ( $local_order->get_items() as $wc_order_item ) {
 
-				if ( $wc_order_item instanceof \WC_Order_Item_Product && $product->get_id() === $wc_order_item->get_product_id() ) {
+				if ( ! $wc_order_item instanceof \WC_Order_Item_Product ) {
+					continue;
+				}
+
+				$order_item_product_id = $wc_order_item->get_variation_id() ?: $wc_order_item->get_product_id();
+
+				if ( $product->get_id() === $order_item_product_id ) {
 					$matching_wc_order_item = $wc_order_item;
 					break;
 				}

--- a/tests/acceptance/Admin/Orders/CommerceCest.php
+++ b/tests/acceptance/Admin/Orders/CommerceCest.php
@@ -188,8 +188,9 @@ PHP;
 		$this->prepare_request_response( $I, 'POST', "/{$remote_id}/cancellations", [
 			'response_body' => json_encode( [
 				'error' => [
-					'type'    => 'Error',
-					'message' => 'Facebook API error.',
+					'type'           => 'Error',
+					'message'        => 'Facebook API error.',
+					'error_user_msg' => 'Super detailed error message.',
 				],
 			 ] ),
 		] );
@@ -212,7 +213,7 @@ PHP;
 
 		$I->expect( 'an error to be shown' );
 
-		$I->waitForText( 'Could not cancel order. Error: Facebook API error.', 15, '.facebook-for-woocommerce-modal' );
+		$I->waitForText( 'Error: Super detailed error message.', 15, '.facebook-for-woocommerce-modal' );
 	}
 
 


### PR DESCRIPTION
# Summary

Cleans up some of the order messaging when there are API failures.

### Story: [CH 64877](https://app.clubhouse.io/skyverge/story/64877)
### Release: #1477 

## Details

The responses contain a more detailed user error message, so this PR switches to using that to keep merchants better informed. General cleanup as well, like making the channel (facebook or instagram) capitalized for the order note.

## UI Changes

- Order messages such as this are logged, rather than "Bad Request": https://cloud.skyver.ge/Z4uyvPgj

## QA

- `acceptance Admin/Orders/CommerceCest` tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version