### PR TITLE
Poll specifically for cancelled orders

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -675,6 +675,33 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/**
+	 * Gets the latest cancelled orders.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @param string $page_id page ID
+	 * @return API\Orders\Response
+	 * @throws Framework\SV_WC_API_Exception
+	 */
+	public function get_cancelled_orders( $page_id ) {
+
+		$request_args = [
+			'state' => [
+				Order::STATUS_COMPLETED,
+			],
+			'updated_after' => time() - facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->get_order_update_interval(),
+			'filters'       => 'has_cancellations',
+		];
+
+		$request = new API\Orders\Request( $page_id, $request_args );
+
+		$this->set_response_handler( API\Orders\Response::class );
+
+		return $this->perform_request( $request );
+	}
+
+
+	/**
 	 * Gets a single order based on its remote ID.
 	 *
 	 * @since 2.1.0-dev.1

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -428,6 +428,45 @@ class Orders {
 				}
 			}
 		}
+
+		// update any local orders that have since been cancelled on Facebook
+		$this->update_cancelled_orders();
+	}
+
+
+	/**
+	 * Updates any local orders that have since been cancelled on Facebook.
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function update_cancelled_orders() {
+
+		$page_id = facebook_for_woocommerce()->get_integration()->get_facebook_page_id();
+
+		try {
+
+			$response = facebook_for_woocommerce()->get_api( facebook_for_woocommerce()->get_connection_handler()->get_page_access_token() )->get_cancelled_orders( $page_id );
+
+		} catch ( SV_WC_API_Exception $exception ) {
+
+			facebook_for_woocommerce()->log( 'Error fetching Commerce orders from the Orders API: ' . $exception->getMessage() );
+
+			return;
+		}
+
+		foreach ( $response->get_orders() as $remote_order ) {
+
+			$local_order = $this->find_local_order( $remote_order->get_id() );
+
+			if ( ! $local_order instanceof \WC_Order || 'cancelled' === $local_order->get_status() ) {
+				continue;
+			}
+
+			$local_order->set_status( 'cancelled' );
+			$local_order->save();
+
+			wc_increase_stock_levels( $local_order );
+		}
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -704,6 +704,33 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see API::get_cancelled_orders() */
+	public function test_get_cancelled_orders() {
+
+		// test will fail if do_remote_request() is not called once
+		$api = $this->make( API::class, [
+			'do_remote_request' => \Codeception\Stub\Expected::once(),
+		] );
+
+		$api->get_cancelled_orders( '1234' );
+
+		$this->assertInstanceOf( API\Orders\Request::class, $api->get_request() );
+		$this->assertEquals( 'GET', $api->get_request()->get_method() );
+		$this->assertEquals( '/1234/commerce_orders', $api->get_request()->get_path() );
+		$this->assertEquals( [], $api->get_request()->get_data() );
+		$expected_params = [
+			'state'  => implode( ',', [
+				API\Orders\Order::STATUS_COMPLETED,
+			] ),
+			'updated_after' => time() - 5 * MINUTE_IN_SECONDS,
+			'filters' => 'has_cancellations',
+		];
+		$this->assertEquals( $expected_params, $api->get_request()->get_params() );
+
+		$this->assertInstanceOf( API\Orders\Response::class, $api->get_response() );
+	}
+
+
 	/** @see API::get_order() */
 	public function test_get_order() {
 


### PR DESCRIPTION
# Summary

Adds a method to poll for cancelled orders and update WooCommerce order status.

### Story: [CH 64878](https://app.clubhouse.io/skyverge/story/64878)
### Release: #1477 

## Details

This should be relatively infrequent, but we need to check for any IG orders that were cancelled by the customer in their 30 minute remorse window, and then cancel the WooCommerce order to release the stock.

Currently the Facebook cancellation UI does not allow for cancelling specific line items.

## UI Changes

None

## QA

- `integration Commerce/OrdersTest` tests pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version