### PR TITLE
Fetching Google Product Category terms

### DIFF
--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -92,7 +92,7 @@ class Google_Product_Category_Field {
 		if ( is_array( $categories_response ) && isset( $categories_response['body'] ) ) {
 
 			$categories_body = $categories_response['body'];
-			$categories_body = explode( PHP_EOL, $categories_body );
+			$categories_body = explode( "\n", $categories_body );
 
 			// format: ID - Top level category > ... > Parent category > Category label
 			// example: 7385 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -56,7 +56,7 @@ class Google_Product_Category_Field {
 		if ( empty ( $categories ) ) {
 
 			// fetch from the URL
-			$categories_response = wp_remote_get( 'https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt', [ 'timeout' => 1 ] );
+			$categories_response = wp_remote_get( 'https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt' );
 
 			$categories = $this->parse_categories_response( $categories_response );
 


### PR DESCRIPTION
# Summary

When adding or editing new product category or product where the GPC field displayed, it shows only one parent term.

### Story: [CH 65080](https://app.clubhouse.io/skyverge/story/65080/fetching-google-product-category-terms)
### Release: #1477 

## Details

- HTTP GET request to load Google Product Category list timeout is set to short
- Parsing the list using `PHP_EOL` constant which is platform environment dependent causing it not working on Windows OS as Google uses Linux where end of line uses `\n` but on Windows end of line is `\n\r`

## UI Changes

Google Product Category field shows all terms fetched

![image](https://user-images.githubusercontent.com/3770036/94558292-0e99ab80-0260-11eb-818d-3100acb07afa.png)

## QA

### Steps

#### Add/Edit Product Category
1. Use `add_filter( 'wc_facebook_commerce_is_connected', '__return_true' );` to simulate a Commerce conneciton
2. Add or edit a product category
    - [x] Default Google product category field shows all terms normally

#### Add/Edit Product 

1. Use `add_filter( 'wc_facebook_commerce_is_connected', '__return_true' );` to simulate a Commerce conneciton
2. Add or edit a simple product
    - [x] Set price
    - [x] Toggle Manage stock on under Inventory tab
    - [x] Toggle Sell on Instagram on under Facebook tab
    - [x] the Google product category field shows all terms normally

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version

## Open Questions
- A question, I noticed that the list get cached for an hour ... shouldn't we increase that for something like a month? the list doesn't get updated that often ... the last update on it was more [than a year ago](https://user-images.githubusercontent.com/3770036/94559115-0a21c280-0261-11eb-940f-bde398965249.png)
