### PR TITLE
Update product stock status in Facebook catalog when stock changes in the store

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Facebook for WooCommerce Changelog ***
 
 2020.nn.nn - version 2.0.5-dev.1
+ * Tweak - Update product availability when stock changes in the store
  * Fix - Prevent an error during the feed generation when variable products are still using deleted terms
 
 2020.nn.nn - version 2.0.4

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -61,6 +61,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var Background_Remove_Duplicate_Visibility_Meta job handler instance */
 		protected $background_remove_duplicate_visibility_meta;
 
+		/** @var \SkyVerge\WooCommerce\Facebook\Products\Stock products stock handler */
+		private $products_stock_handler;
+
 		/** @var \SkyVerge\WooCommerce\Facebook\Products\Sync products sync handler */
 		private $products_sync_handler;
 
@@ -113,6 +116,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/includes/Integrations/Integrations.php';
 				require_once __DIR__ . '/includes/Products.php';
 				require_once __DIR__ . '/includes/Products/Feed.php';
+				require_once __DIR__ . '/includes/Products/Stock.php';
 				require_once __DIR__ . '/includes/Products/Sync.php';
 				require_once __DIR__ . '/includes/Products/Sync/Background.php';
 				require_once __DIR__ . '/includes/fbproductfeed.php';
@@ -122,6 +126,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/includes/Events/AAMSettings.php';
 
 				$this->product_feed            = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
+				$this->products_stock_handler  = new \SkyVerge\WooCommerce\Facebook\Products\Stock();
 				$this->products_sync_handler   = new \SkyVerge\WooCommerce\Facebook\Products\Sync();
 				$this->sync_background_handler = new \SkyVerge\WooCommerce\Facebook\Products\Sync\Background();
 
@@ -522,6 +527,19 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		public function get_background_remove_duplicate_visibility_meta_instance() {
 
 			return $this->background_remove_duplicate_visibility_meta;
+		}
+
+
+		/**
+		 * Gets the products stock handler.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @return \SkyVerge\WooCommerce\Facebook\Products\Stock
+		 */
+		public function get_products_stock_handler() {
+
+			return $this->products_stock_handler;
 		}
 
 

--- a/includes/Products/Stock.php
+++ b/includes/Products/Stock.php
@@ -12,12 +12,35 @@ namespace SkyVerge\WooCommerce\Facebook\Products;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Facebook\Products;
+
 /**
  * The product stock handler.
  *
  * @since 2.0.0
  */
 class Stock {
+
+
+	/**
+	 * Schedules a product sync to update its stock status.
+	 *
+	 * The product is removed from Facebook if it is out of stock and the plugin is configured to remove out of stock products form the catalog.
+	 *
+	 * @since 2.0.4-dev.1
+	 *
+	 * @param \WC_Product $product a product object
+	 */
+	private function maybe_sync_product_stock_status( \WC_Product $product ) {
+
+		if ( Products::product_should_be_deleted( $product ) ) {
+
+			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( [ \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ) ] );
+			return;
+		}
+
+		facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( [ $product->get_id() ] );
+	}
 
 
 }

--- a/includes/Products/Stock.php
+++ b/includes/Products/Stock.php
@@ -38,7 +38,7 @@ class Stock {
 	 *
 	 * @since 2.0.4-dev.1
 	 */
-	public function add_hooks() {
+	private function add_hooks() {
 
 		add_action( 'woocommerce_variation_set_stock', [ $this, 'set_product_stock' ] );
 		add_action( 'woocommerce_product_set_stock',   [ $this, 'set_product_stock' ] );

--- a/includes/Products/Stock.php
+++ b/includes/Products/Stock.php
@@ -93,7 +93,7 @@ class Stock {
 	/**
 	 * Schedules a product sync to update the product's stock status.
 	 *
-	 * The product is removed from Facebook if it is out of stock and the plugin is configured to remove out of stock products form the catalog.
+	 * The product is removed from Facebook if it is out of stock and the plugin is configured to remove out of stock products from the catalog.
 	 *
 	 * @since 2.0.4-dev.1
 	 *

--- a/includes/Products/Stock.php
+++ b/includes/Products/Stock.php
@@ -17,7 +17,7 @@ use SkyVerge\WooCommerce\Facebook\Products;
 /**
  * The product stock handler.
  *
- * @since 2.0.0
+ * @since 2.0.4-dev.1
  */
 class Stock {
 
@@ -25,7 +25,7 @@ class Stock {
 	/**
 	 * Stock constructor.
 	 *
-	 * @since 2.0.0
+	 * @since 2.0.4-dev.1
 	 */
 	public function __construct() {
 
@@ -36,7 +36,7 @@ class Stock {
 	/**
 	 * Adds needed hooks to keep product stock in sync.
 	 *
-	 * @since 2.0.0
+	 * @since 2.0.4-dev.1
 	 */
 	public function add_hooks() {
 
@@ -91,7 +91,7 @@ class Stock {
 
 
 	/**
-	 * Schedules a product sync to update its stock status.
+	 * Schedules a product sync to update the product's stock status.
 	 *
 	 * The product is removed from Facebook if it is out of stock and the plugin is configured to remove out of stock products form the catalog.
 	 *

--- a/includes/Products/Stock.php
+++ b/includes/Products/Stock.php
@@ -23,6 +23,74 @@ class Stock {
 
 
 	/**
+	 * Stock constructor.
+	 *
+	 * @since 2.0.0
+	 */
+	public function __construct() {
+
+		$this->add_hooks();
+	}
+
+
+	/**
+	 * Adds needed hooks to keep product stock in sync.
+	 *
+	 * @since 2.0.0
+	 */
+	public function add_hooks() {
+
+		add_action( 'woocommerce_variation_set_stock', [ $this, 'set_product_stock' ] );
+		add_action( 'woocommerce_product_set_stock',   [ $this, 'set_product_stock' ] );
+	}
+
+
+	/**
+	 * Attempts to sync a product when its stock changes.
+	 *
+	 * @internal
+	 *
+	 * @since 2.0.4-dev.1
+	 *
+	 * @param \WC_Product $product the product that was updated
+	 */
+	public function set_product_stock( $product ) {
+
+		if ( ! $product instanceof \WC_Product ) {
+			return;
+		}
+
+		foreach ( $this->get_products_to_sync( $product ) as $item ) {
+			$this->maybe_sync_product_stock_status( $item );
+		}
+	}
+
+
+	/**
+	 * Gets an array of product objects that could be synced using the Batch API.
+	 *
+	 * This method returns the product variations of variable products, or the product itself for other product types.
+	 * Variable products cannot be synced through the Batch API as they are represented as Product Groups instead of Product Items on Facebook.
+	 *
+	 * @since 2.0.4-dev.1
+	 *
+	 * @param \WC_Product $product a product object
+	 * @return \WC_Product[]
+	 */
+	private function get_products_to_sync( \WC_Product $product ) {
+
+		if ( $product->is_type( 'variable' ) ) {
+
+			return array_filter( array_map( 'wc_get_product', $product->get_children() ), function ( $item ) {
+				return $item instanceof \WC_Product;
+			} );
+		}
+
+		return [ $product ];
+	}
+
+
+	/**
 	 * Schedules a product sync to update its stock status.
 	 *
 	 * The product is removed from Facebook if it is out of stock and the plugin is configured to remove out of stock products form the catalog.

--- a/includes/Products/Stock.php
+++ b/includes/Products/Stock.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Products;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * The product stock handler.
+ *
+ * @since 2.0.0
+ */
+class Stock {
+
+
+}

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 == Changelog ==
 
 = 2020.nn.nn - version 2.0.5-dev.1 =
+ * Tweak - Update product availability when stock changes in the store
  * Fix - Prevent an error during the feed generation when variable products are still using deleted terms
 
 = 2020.10.08 - version 2.0.4 =

--- a/tests/_support/IntegrationTester.php
+++ b/tests/_support/IntegrationTester.php
@@ -131,6 +131,15 @@ class IntegrationTester extends \Codeception\Actor {
 	/** Sync methods **************************************************************************************************/
 
 
+	/**
+	 * Clears sync requests stored in the product sync handler instance.
+	 */
+	public function clearSyncRequests() {
+
+		$this->setPropertyValue( facebook_for_woocommerce()->get_products_sync_handler(), 'requests', [] );
+	}
+
+
 	public function assertSyncRequestsExist( $request_keys = [], $requests = null ) {
 
 		if ( null === $requests ) {

--- a/tests/_support/IntegrationTester.php
+++ b/tests/_support/IntegrationTester.php
@@ -140,6 +140,12 @@ class IntegrationTester extends \Codeception\Actor {
 	}
 
 
+	/**
+	 * Asserts that the given sync request keys are included in the given list of sync requests.
+	 *
+	 * @param array $request_keys sync requests keys to search for
+	 * @param array|null $requests array of stored sync requests (defaults to the requests from the product sync handler)
+	 */
 	public function assertSyncRequestsExist( $request_keys = [], $requests = null ) {
 
 		if ( null === $requests ) {
@@ -152,6 +158,12 @@ class IntegrationTester extends \Codeception\Actor {
 	}
 
 
+	/**
+	 * Asserts that the given sync request keys are not included in the given list of sync requests.
+	 *
+	 * @param array $request_keys sync requests keys that shouldn't be included
+	 * @param array|null $requests array of stored sync requests (defaults to the requests from the product sync handler)
+	 */
 	public function assertSyncRequestsNotExist( $request_keys = [], $requests = null ) {
 
 		if ( null === $requests ) {
@@ -173,6 +185,12 @@ class IntegrationTester extends \Codeception\Actor {
 	}
 
 
+	/**
+	 * Asserts that the given product IDs are scheduled for sync.
+	 *
+	 * @param array $product_ids product IDs
+	 * @param array|null $requests array of stored sync requests (defaults to the requests from the product sync handler)
+	 */
 	public function assertProductsAreScheduledForSync( $product_ids = [], $requests = null ) {
 
 		$this->assertSyncRequestsExist(
@@ -184,6 +202,12 @@ class IntegrationTester extends \Codeception\Actor {
 	}
 
 
+	/**
+	 * Asserts that the given product IDs are not scheduled for sync.
+	 *
+	 * @param array $product_ids product IDs
+	 * @param array|null $requests array of stored sync requests (defaults to the requests from the product sync handler)
+	 */
 	public function assertProductsAreNotScheduledForSync( $product_ids = [], $requests = null ) {
 
 		$this->assertSyncRequestsNotExist(
@@ -195,6 +219,12 @@ class IntegrationTester extends \Codeception\Actor {
 	}
 
 
+	/**
+	 * Asserts that the given product IDs are scheduled to be deleted.
+	 *
+	 * @param array $product_ids product IDs
+	 * @param array|null $requests array of stored sync requests (defaults to the requests from the product sync handler)
+	 */
 	public function assertProductsAreScheduledForDelete( $product_ids = [], $requests = null ) {
 
 		$this->assertSyncRequestsExist(
@@ -206,6 +236,12 @@ class IntegrationTester extends \Codeception\Actor {
 	}
 
 
+	/**
+	 * Asserts that the given product IDs are not scheduled to be deleted.
+	 *
+	 * @param array $product_ids product IDs
+	 * @param array|null $requests array of stored sync requests (defaults to the requests from the product sync handler)
+	 */
 	public function assertProductsAreNotScheduledForDelete( $product_ids = [], $requests = null ) {
 
 		$this->assertSyncRequestsNotExist(

--- a/tests/integration/Products/StockTest.php
+++ b/tests/integration/Products/StockTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use SkyVerge\WooCommerce\Facebook\Products\Stock;
+
+/**
+ * Tests the Stock class.
+ */
+class StockTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/** Test methods **************************************************************************************************/
+
+
+	public function test_set_product_stock_with_simple_product() {
+
+		$product = $this->tester->get_product();
+
+		$this->tester->clearSyncRequests();
+
+		$this->get_stock()->set_product_stock( $product );
+
+		$this->tester->assertProductsAreScheduledForSync( [ $product->get_id() ] );
+	}
+
+
+	public function test_set_product_stock_with_variable_product() {
+
+		$product = $this->tester->get_variable_product();
+
+		$this->tester->clearSyncRequests();
+
+		$this->get_stock()->set_product_stock( $product );
+
+		$this->tester->assertProductsAreScheduledForSync( $product->get_children() );
+	}
+
+
+	public function test_set_product_stock_with_invalid_product() {
+
+		$this->tester->clearSyncRequests();
+
+		$this->get_stock()->set_product_stock( null );
+
+		$this->tester->assertProductsAreNotScheduledForSync();
+	}
+
+
+	public function test_set_product_stock_with_out_of_stock_product() {
+
+		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
+
+		$product = $this->tester->get_product();
+
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 0 );
+		$product->save();
+
+		$this->tester->clearSyncRequests();
+
+		$this->get_stock()->set_product_stock( $product );
+
+		$this->tester->assertProductsAreScheduledForDelete( [ $product->get_id() ] );
+	}
+
+
+	/** Helper methods **************************************************************************************************/
+
+
+	/**
+	 * Gets the handler instance.
+	 *
+	 * @return Stock
+	 */
+	private function get_stock() {
+
+		return new Stock();
+	}
+
+
+}

--- a/tests/integration/Products/StockTest.php
+++ b/tests/integration/Products/StockTest.php
@@ -15,6 +15,7 @@ class StockTest extends \Codeception\TestCase\WPTestCase {
 	/** Test methods **************************************************************************************************/
 
 
+	/** @see Stock::set_product_stock() */
 	public function test_set_product_stock_with_simple_product() {
 
 		$product = $this->tester->get_product();
@@ -27,6 +28,7 @@ class StockTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Stock::set_product_stock() */
 	public function test_set_product_stock_with_variable_product() {
 
 		$product = $this->tester->get_variable_product();
@@ -39,6 +41,7 @@ class StockTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Stock::set_product_stock() */
 	public function test_set_product_stock_with_invalid_product() {
 
 		$this->tester->clearSyncRequests();
@@ -49,6 +52,7 @@ class StockTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Stock::set_product_stock() */
 	public function test_set_product_stock_with_out_of_stock_product() {
 
 		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );


### PR DESCRIPTION
# Summary

This PR schedules products for sync or delete when WooCommerce increases or decreases the product stock.

### Story: [CH 61245](https://app.clubhouse.io/skyverge/story/61245)
### Release: #1623 

## Details

WooCommerce routes all product stock changes through the `wc_update_product_stock()` function. This PR adds callbacks for the `woocommerce_variation_set_stock` and `woocommerce_product_set_stock` hooks to schedule products for sync as soon as their stock is increased or decreased.

## UI Changes

None

## QA

### Setup

1. Connect your store to Facebook
1. Create a Simple Product with Facebook sync enabled
    1. Enable **Manage stock?** and set the stock quantity to 1
    1. Define a price for the product
1. Create a Variable product
    1. Enable **Manage stock?** at the Variable product level and set the stock quantity to 1
    1. Make sure the product has at least two variations with a price and Facebook sync enabled
    1. Enable **Manage stock?** at the variation level for one of the variations and set the stock quantity to 1. Lets call this variation the **Variation with Stock**.

### Steps

#### Simple Product

1. Go to the Product Catalog on Facebook
     - [x] The Simple product's availability is set to `In stock`
1. Add the simple product to the cart and place an order
1. Ensure the Order status is one of On Hold, Processing, or Completed
1. Go to the Product Catalog on Facebook
     - [x] The Simple products availability is set to `Out of stock`
1. Cancel the order
1. Go to the Product Catalog on Facebook
     - [x] The Simple products availability is set to `In stock`

#### Variable Product

1. Go to the Product Catalog on Facebook
     - [x] The availability for all product variants is set to `In stock` (click the product card, then the **Variants** tab)
1. Add the **Variation with Stock** product to the cart and place an order
1. Ensure the Order status is one of On Hold, Processing, or Completed
1. Go to the Product Catalog on Facebook
     - [x] The **Variation with Stock** availability is set to `Out of stock`
     - [x] The availability for the other variants is set to `In stock`
1. Add one of the other variations to the cart and place an order
1. Ensure the Order status is one of On Hold, Processing, or Completed
1. Go to the Product Catalog on Facebook
     - [x] The **Variation with Stock** availability is set to `Out of stock`
     - [x] The availability for the others variants is set to `Out of stock`
1. Cancel the order for the **Variation with Stock**
1. Go to the Product Catalog on Facebook
     - [x] The **Variation with Stock** availability is set to `In stock`
     - [x] The availability for the others variants is set to `Out of stock`


## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version