### PR TITLE
Fix SQL errors in background job query

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Facebook for WooCommerce Changelog ***
 
 2020.nn.nn - version 2.0.4
+ * Fix - Fix SQL errors triggered while trying to remove duplicate visibility meta entries from postmeta table
 
 2020.10.02 - version 2.0.3
  * Tweak - Pixel events now can include advanced matching information

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -41,6 +41,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 			'1.11.0',
 			'2.0.0',
 			'2.0.3',
+			'2.0.4',
 		];
 	}
 
@@ -315,6 +316,24 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 		}
 
 		return false;
+	}
+
+
+	/**
+	 * Upgrades to version 2.0.4
+	 *
+	 * @since 2.0.4
+	 */
+	protected function upgrade_to_2_0_4() {
+
+		// if unfinished jobs are stuck, give the handlers a chance to complete them
+		if ( $handler = $this->get_plugin()->get_background_handle_virtual_products_variations_instance() ) {
+			$handler->dispatch();
+		}
+
+		if ( $handler = $this->get_plugin()->get_background_remove_duplicate_visibility_meta_instance() ) {
+			$handler->dispatch();
+		}
 	}
 
 

--- a/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
+++ b/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
@@ -202,11 +202,13 @@ class Background_Handle_Virtual_Products_Variations extends Framework\SV_WP_Back
 			return 0;
 		}
 
-		$values_str = '';
+		$values = [];
 
 		foreach ( $post_ids as $post_id ) {
-			$values_str .= "('{$post_id}', 'fb_visibility', 'no')";
+			$values[] = "('{$post_id}', 'fb_visibility', 'no')";
 		}
+
+		$values_str = implode( ',', $values );
 
 		// we need to explicitly insert the metadata and set it to no, because not having it means it is visible
 		$sql = "

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 == Changelog ==
 
 = 2020.nn.nn - version 2.0.4 =
+ * Fix - Fix SQL errors triggered while trying to remove duplicate visibility meta entries from postmeta table
 
 = 2020.10.02 - version 2.0.3 =
  * Tweak - Pixel events now can include advanced matching information


### PR DESCRIPTION
# Summary

This PRs updates the handle virtual products variations background job handler to fix a SQL error triggered while trying to insert multiple meta entries.

### Story: [CH 65583](https://app.clubhouse.io/skyverge/story/65583)
### Release: #1623 

## QA

### Setup

1. Delete all `%facebook%` and `%fb%` options from the database
1. Install Facebook for WooCommerce 1.10.2

#### Simple Product

1. Create a Simple product
1. Define a price
1. Make the product virtual
1. Enable Facebook sync

#### Variable Product

1. Create a Variable Product
1. Add an attribute with two terms
1. Create a variation for each attribute
1. Define a price for each variation
1. Make one variation virtual
1. Enable Facebook sync for both variations

#### Set visibility

The next steps will ensure that `fb_visibility` is set to `yes` instead of `1`.

1. Go to the Products page
    1. Use the Hide button to hide the new products from the Catalog
    1. Use the Show button to show the new products again 
1. Run `SELECT COUNT(meta_id) FROM wp_postmeta WHERE meta_key = 'fb_visibility'` and **take note of the number of meta entries**.

Then, to trigger the path that leads to SQL errors:

1. Remove all the `fb_visibility` meta entries from the post meta table (that way the background job inserts new rows instead of updating them).

### Steps

#### Reproduce the bug

1. Upgrade to Facebook for WooCommerce 2.0.3
1. Go to the Dashboard to trigger the lifecycle events
    - [x] Lots of SQL errors start to appear in `wp-content/debug.log`

#### Solution

1. Upgrade to this branch.
1. SQL errors should stop appearing in `wp-content/debug.log`
1. The `wc_facebook_background_handle_virtual_products_variations_complete` option is set to `yes` (may take about a minute to appear)
1. The `wc_facebook_background_remove_duplicate_visibility_meta_complete` option is set to `yes` (may take about a minute to appear)
1. Run `SELECT COUNT(meta_id) FROM wp_postmeta WHERE meta_key = 'fb_visibility'` a couple of times against the website's database: 
    - [x] The number of `fb_visibility` meta entries is at least `2` (one for the virtual simple product and one for the virtual variation) and not greater than the number you got at the beginning 
1. Run `SELECT post_id, COUNT(meta_key) entries, MAX(meta_id) last_meta_id FROM wp_postmeta WHERE meta_key = 'fb_visibility' GROUP BY post_id HAVING entries > 1` against the website's database:
    - [x] No results are returned - there are no posts with duplicate `fb_visibility` meta

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version