### PR TITLE
Partial fix for search events not firing for product search requests that have a single result

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Facebook for WooCommerce Changelog ***
 
-2020.nn.nn - version 2.1.2
+2020.nn.nn - version 2.1.2-dev.1
+ * Fix - Trigger a pixel Search event for product search request with a single result (works for logged in users or visitors with an active WooCommerce session)
 
 2020.10.27 - version 2.1.1
  * Fix - Adjust code syntax that may have issued errors in installations running PHP lower than 7.3

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -66,6 +66,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'pre_get_posts',
 				array( $this, 'inject_search_event' )
 			);
+			add_filter( 'woocommerce_redirect_single_search_result', [ $this, 'maybe_add_product_search_event_to_session' ] );
 
 			// AddToCart events
 			add_action( 'woocommerce_add_to_cart', [ $this, 'inject_add_to_cart_event' ], 40, 4 );

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -253,6 +253,29 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 
 		/**
+		 * Attempts to create an Event instance for a product search event using session data.
+		 *
+		 * @since 2.0.6-dev.1
+		 *
+		 * @return Event|null
+		 */
+		private function get_product_search_event_from_session() {
+
+			if ( ! isset( WC()->session ) || ! is_callable( [ WC()->session, 'get' ] ) ) {
+				return null;
+			}
+
+			$data = WC()->session->get( $this->search_event_data_session_variable );
+
+			if ( ! is_array( $data ) || empty( $data ) ) {
+				return null;
+			}
+
+			return new Event( $data );
+		}
+
+
+		/**
 		 * Triggers Search for result pages (deduped)
 		 *
 		 * @internal

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -276,6 +276,21 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 
 		/**
+		 * Deletes a session variable.
+		 *
+		 * @since 2.0.6-dev.1
+		 *
+		 * @param string $key name of the variable to delete
+		 */
+		private function delete_session_data( $key ) {
+
+			if ( isset( WC()->session->$key ) ) {
+				unset( WC()->session->$key );
+			}
+		}
+
+
+		/**
 		 * Triggers Search for result pages (deduped)
 		 *
 		 * @internal

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -27,6 +27,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		const FB_PRIORITY_HIGH    = 2;
 		const FB_PRIORITY_LOW     = 11;
 
+
+		/** @var string name of the session variable used to store search event data */
+		private $search_event_data_session_variable = 'wc_facebook_search_event_data';
+
 		/** @var Event search event instance */
 		private $search_event;
 		/** @var array with events tracked */
@@ -199,6 +203,23 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			global $wp_query;
 
 			return is_search() && is_post_type_archive( 'product' ) && 1 === absint( $wp_query->found_posts );
+		}
+
+
+		/**
+		 * Adds search event data to the session.
+		 *
+		 * This does nothing if there is no session set.
+		 *
+		 * @since 2.0.6-dev.1
+		 *
+		 * @return void
+		 */
+		private function add_product_search_event_to_session( Event $event ) {
+
+			if ( isset( WC()->session ) && is_callable( [ WC()->session, 'set' ] ) ) {
+				WC()->session->set( $this->search_event_data_session_variable, $event->get_data() );
+			}
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -253,6 +253,30 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 
 		/**
+		 * Injects a frontend search event if the session has stored event data.
+		 *
+		 * @internal
+		 *
+		 * @since 2.0.6-dev.1
+		 */
+		public function maybe_inject_search_event() {
+
+			if ( ! self::$isEnabled ) {
+				return;
+			}
+
+			$this->search_event = $this->get_product_search_event_from_session();
+
+			if ( ! $this->search_event  ) {
+				return;
+			}
+
+			$this->delete_session_data( $this->search_event_data_session_variable );
+			$this->actually_inject_search_event();
+		}
+
+
+		/**
 		 * Attempts to create an Event instance for a product search event using session data.
 		 *
 		 * @since 2.0.6-dev.1

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -187,6 +187,21 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$this->pixel->inject_event( $event_name, $event_data, 'trackCustom' );
 		}
 
+
+		/**
+		 * Determines whether the current request is a product search with a single result.
+		 *
+		 * @since 2.0.6-dev.1
+		 *
+		 * @return bool
+		 */
+		private function is_single_search_result() {
+			global $wp_query;
+
+			return is_search() && is_post_type_archive( 'product' ) && 1 === absint( $wp_query->found_posts );
+		}
+
+
 		/**
 		 * Triggers Search for result pages (deduped)
 		 *

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -232,7 +232,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		private function is_single_search_result() {
 			global $wp_query;
 
-			return is_search() && is_post_type_archive( 'product' ) && 1 === absint( $wp_query->found_posts );
+			return is_search() && 1 === absint( $wp_query->found_posts ) && is_post_type_archive( 'product' );
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -193,6 +193,34 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 
 		/**
+		 * Attempts to add a session variable to indicate that a product search event occurred.
+		 *
+		 * The session variable is used to catch search events that have a single result.
+		 * In those cases WooCommerce redirects customers to the product page instead of showing the search results.
+		 *
+		 * The plugin can't inject a Pixel event code on redirect responses, but it can check for the presence of the variable on the product page.
+		 *
+		 * This method is hooked to woocommerce_redirect_single_search_result which is triggered right before redirecting.
+		 *
+		 * @internal
+		 *
+		 * @since 2.0.6-dev.1
+		 *
+		 * @param bool $redirect whether to redirect to the product page
+		 * @return bool
+		 */
+		public function maybe_add_product_search_event_to_session( $redirect ) {
+
+			if ( $redirect && $this->search_event && $this->is_single_search_result() ) {
+
+				$this->add_product_search_event_to_session( $this->search_event );
+			}
+
+			return $redirect;
+		}
+
+
+		/**
 		 * Determines whether the current request is a product search with a single result.
 		 *
 		 * @since 2.0.6-dev.1

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -57,6 +57,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			// ViewContent for individual products
 			add_action( 'woocommerce_after_single_product', [ $this, 'inject_view_content_event' ] );
+			add_action( 'woocommerce_after_single_product', [ $this, 'maybe_inject_search_event' ] );
 
 			add_action(
 				'woocommerce_after_shop_loop',

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -247,7 +247,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		private function add_product_search_event_to_session( Event $event ) {
 
-			if ( isset( WC()->session ) && is_callable( [ WC()->session, 'set' ] ) ) {
+			if ( isset( WC()->session ) && is_callable( [ WC()->session, 'has_session' ] ) && WC()->session->has_session() ) {
 				WC()->session->set( $this->search_event_data_session_variable, $event->get_data() );
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 == Changelog ==
 
 = 2020.nn.nn - version 2.1.2-dev.1 =
+ * Fix - Trigger a pixel Search event for product search request with a single result (works for logged in users or visitors with an active WooCommerce session)
 
 = 2020.10.27 - version 2.1.1 =
  * Fix - Adjust code syntax that may have issued errors in installations running PHP lower than 7.3

--- a/tests/_support/IntegrationTester.php
+++ b/tests/_support/IntegrationTester.php
@@ -390,6 +390,23 @@ class IntegrationTester extends \Codeception\Actor {
 
 
 	/**
+	 * Uses reflection to invoke a method on the given object.
+	 *
+	 * The method can be private, protected, or public.
+	 *
+	 * @param object $object the instance to invoke the method on
+	 * @param string $method_name the name of the method
+	 * @param array $parameters zero or more parameters for the method
+	 * @return mixed
+	 * @throws ReflectionException
+	 */
+	public function invokeReflectionMethod( $object, $method_name, ...$parameters ) {
+
+		return $this->getMethod( $object, $method_name )->invokeArgs( $object, $parameters );
+	}
+
+
+	/**
 	 * Uses reflection to make a property public so we can test it.
 	 *
 	 * Copied from Jilt for WooCommerce.

--- a/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
+++ b/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
@@ -17,6 +17,65 @@ class WC_Facebookcommerce_EventsTracker_Test extends \Codeception\TestCase\WPTes
 	/** Test methods **************************************************************************************************/
 
 
+	/**
+	 * @see WC_Facebookcommerce_EventsTracker::is_single_search_result()
+	 *
+	 * @dataProvider provider_is_single_search_result
+	 */
+	public function test_is_single_search_result( $is_single_search_result, $url ) {
+
+		// TODO: delete all existing products to avoid false positives {WV 2020-10-23}
+
+		$this->tester->get_product( [
+			'name'          => 'Duplicate Product 1',
+			'regular_price' => 10,
+			'status'        => 'publish',
+		] );
+
+		$this->tester->get_product( [
+			'name'          => 'Duplicate Product 2',
+			'regular_price' => 10,
+			'status'        => 'publish',
+		] );
+
+		$this->tester->get_product( [
+			'name'          => 'Unique Product',
+			'regular_price' => 10,
+			'status'        => 'publish',
+		] );
+
+		$this->go_to( $url );
+
+		$tracker = $this->get_events_tracker();
+
+		$this->assertSame( $is_single_search_result, $this->tester->getMethod( $tracker, 'is_single_search_result' )->invoke( $tracker ) );
+	}
+
+
+	/** @see test_is_single_search_result() */
+	public function provider_is_single_search_result() {
+
+		return [
+			[
+				true,
+				add_query_arg( [ 's' => 'Unique Product', 'post_type' => 'product' ], home_url() ),
+			],
+			[
+				false,
+				add_query_arg( [ 's' => 'Unique Product' ], home_url() ),
+			],
+			[
+				false,
+				add_query_arg( [ 's' => 'Duplicate Product', 'post_type' => 'product' ], home_url() ),
+			],
+			[
+				false,
+				home_url(),
+			],
+		];
+	}
+
+
 	/** @see WC_Facebookcommerce_EventsTracker::get_search_event() */
 	public function test_get_search_event() {
 		global $wp_query;

--- a/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
+++ b/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
@@ -17,6 +17,36 @@ class WC_Facebookcommerce_EventsTracker_Test extends \Codeception\TestCase\WPTes
 	/** Test methods **************************************************************************************************/
 
 
+	/** @see WC_Facebookcommerce_EventsTracker::add_product_search_event_to_session() */
+	public function test_add_product_search_event_to_session() {
+
+		$tracker = $this->get_events_tracker();
+
+		$variable_name = $this->tester->getPropertyValue( $tracker, 'search_event_data_session_variable' );
+
+		$event = new Event( [ 'user_data' => [ 'foo' => 'bar' ] ] );
+
+		$this->tester->invokeReflectionMethod( $tracker, 'add_product_search_event_to_session', $event );
+
+		$this->assertSame( WC()->session->{$variable_name}, $event->get_data() );
+	}
+
+
+	/** @see WC_Facebookcommerce_EventsTracker::add_product_search_event_to_session() */
+	public function test_add_product_search_event_to_session_if_session_is_not_available() {
+
+		unset( WC()->session );
+
+		$tracker = $this->get_events_tracker();
+
+		$event = $this->make( Event::class, [
+			'get_data' => \Codeception\Stub\Expected::never(),
+		] );
+
+		$this->tester->invokeReflectionMethod( $tracker, 'add_product_search_event_to_session', $event );
+	}
+
+
 	/**
 	 * @see WC_Facebookcommerce_EventsTracker::is_single_search_result()
 	 *

--- a/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
+++ b/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
@@ -26,6 +26,9 @@ class WC_Facebookcommerce_EventsTracker_Test extends \Codeception\TestCase\WPTes
 
 		$event = new Event( [ 'user_data' => [ 'foo' => 'bar' ] ] );
 
+		// the session variable is set only if WC()->session->has_session() returns true
+		WC()->session->set_customer_session_cookie( true );
+
 		$this->tester->invokeReflectionMethod( $tracker, 'add_product_search_event_to_session', $event );
 
 		$this->assertSame( WC()->session->{$variable_name}, $event->get_data() );

--- a/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
+++ b/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
@@ -35,6 +35,8 @@ class WC_Facebookcommerce_EventsTracker_Test extends \Codeception\TestCase\WPTes
 	/** @see WC_Facebookcommerce_EventsTracker::add_product_search_event_to_session() */
 	public function test_add_product_search_event_to_session_if_session_is_not_available() {
 
+		$session = WC()->session;
+
 		unset( WC()->session );
 
 		$tracker = $this->get_events_tracker();
@@ -44,6 +46,9 @@ class WC_Facebookcommerce_EventsTracker_Test extends \Codeception\TestCase\WPTes
 		] );
 
 		$this->tester->invokeReflectionMethod( $tracker, 'add_product_search_event_to_session', $event );
+
+		// restore WooCommerce session to avoid unexpected Fatal errors
+		WC()->session = $session;
 	}
 
 

--- a/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
+++ b/tests/integration/WC_Facebookcommerce_EventsTracker_Test.php
@@ -52,6 +52,54 @@ class WC_Facebookcommerce_EventsTracker_Test extends \Codeception\TestCase\WPTes
 	}
 
 
+	/** @see WC_Facebookcommerce_EventsTracker::get_product_search_event_from_session() */
+	public function test_get_product_search_event_from_session() {
+
+		$tracker = $this->get_events_tracker();
+
+		$variable_name = $this->tester->getPropertyValue( $tracker, 'search_event_data_session_variable' );
+
+		WC()->session->set( $variable_name, [ 'user_data' => [ 'foo' => 'bar' ] ] );
+
+		$event = $this->tester->invokeReflectionMethod( $tracker, 'get_product_search_event_from_session' );
+
+		$this->assertInstanceOf( Event::class, $event );
+		$this->assertArrayHasKey( 'foo', $event->get_user_data() );
+	}
+
+
+	/** @see WC_Facebookcommerce_EventsTracker::get_product_search_event_from_session() */
+	public function test_get_product_search_event_from_session_if_session_is_not_available() {
+
+		$session = WC()->session;
+
+		unset( WC()->session );
+
+		$tracker = $this->get_events_tracker();
+		$event   = $this->tester->invokeReflectionMethod( $tracker, 'get_product_search_event_from_session' );
+
+		$this->assertNull( $event );
+
+		// restore WooCommerce session to avoid unexpected Fatal errors
+		WC()->session = $session;
+	}
+
+
+	/** @see WC_Facebookcommerce_EventsTracker::get_product_search_event_from_session() */
+	public function test_get_product_search_event_from_session_if_session_has_no_data() {
+
+		$tracker = $this->get_events_tracker();
+
+		$variable_name = $this->tester->getPropertyValue( $tracker, 'search_event_data_session_variable' );
+
+		WC()->session->{$variable_name} = null;
+
+		$event   = $this->tester->invokeReflectionMethod( $tracker, 'get_product_search_event_from_session' );
+
+		$this->assertNull( $event );
+	}
+
+
 	/**
 	 * @see WC_Facebookcommerce_EventsTracker::is_single_search_result()
 	 *


### PR DESCRIPTION
# Summary

This PR updates the plugin to inject search events on the product page if the customer was redirected to that page after performing a product searching that ended up with a single result.

### Story: [CH 59890](https://app.clubhouse.io/skyverge/story/59890)
### Release: #1658 

## Details

The frontend search event doesn't fire because WooCommerce redirects customers to the product page if the search returns a single result:

https://github.com/woocommerce/woocommerce/blob/1427a39be142da796856b75a1e2a32b913236ad4/includes/wc-template-functions.php#L57-L65

In most cases we can't determine whether a product page visit is the result of a single search result. However, if the customer already has a session (for example after adding one product to the cart), then we can store the event data on the session before the redirect occurs and inject it when the product page loads. That's the approach used in this PR.

Please note that the plugin currently sends a server search event even when there is only one result. That means those events are not completely ignored for customers that have no session. We can't send a pixel event in that scenario, but the event is still tracked.

## QA

### Setup

- Activate and configure Facebook for WooCommerce

### Steps

#### Multiple results search

1. Perform a product search that returns multiple results
    - [x] The Pixel helper reports a Search event

#### Single result (logged in)

1. Perform a product search that returns a single result
    - [x] You are redirected to the product page
    - [x] The Pixel helper reports a Search event
1. Reload the page
    - [x] No search event is reported 
 
#### Single result (logged out)

1. Perform a product search that returns a single result
    - [x] You are redirected to the product page
    - [ ] No search event is reported

#### Tests

- [x] `codecept run integration` pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version