### PR TITLE
Load & initialize LWI Ads

### DIFF
--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -10,7 +10,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Admin;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Plugin_Exception;
+use SkyVerge\WooCommerce\PluginFramework\v5_9_0 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -83,11 +83,30 @@ abstract class Abstract_Settings_Screen {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @throws SV_WC_Plugin_Exception
+	 * @throws Framework\SV_WC_Plugin_Exception
 	 */
 	public function save() {
 
 		woocommerce_update_options( $this->get_settings() );
+	}
+
+
+	/**
+	 * Determines whether the current screen is the same as identified by the current class.
+	 *
+	 * @since 2.1.0-dev.1
+	 *
+	 * @return bool
+	 */
+	protected function is_current_screen() {
+
+		if ( Settings::PAGE_ID !== Framework\SV_WC_Helper::get_requested_value( 'page' ) ) {
+			return false;
+		}
+
+		$tab = Framework\SV_WC_Helper::get_requested_value( 'tab' );
+
+		return ! empty( $tab ) && $tab === $this->get_id();
 	}
 
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -42,6 +42,7 @@ class Settings {
 			Settings_Screens\Connection::ID   => new Settings_Screens\Connection(),
 			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 			Settings_Screens\Messenger::ID    => new Settings_Screens\Messenger(),
+			Settings_Screens\Advertise::ID    => new Settings_Screens\Advertise(),
 		);
 
 		add_action( 'admin_menu', array( $this, 'add_menu_item' ) );

--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Admin\Settings_Screens;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\Admin;
+use SkyVerge\WooCommerce\PluginFramework\v5_9_0;
+
+/**
+ * The Advertise settings screen object.
+ */
+class Advertise extends Admin\Abstract_Settings_Screen {
+
+
+	/** @var string screen ID */
+	const ID = 'advertise';
+
+
+	/**
+	 * Advertise settings constructor.
+	 *
+	 * @since 2.2.0-dev.1
+	 */
+	public function __construct() {
+
+		$this->id    = self::ID;
+		$this->label = __( 'Advertise', 'facebook-for-woocommerce' );
+		$this->title = __( 'Advertise', 'facebook-for-woocommerce' );
+	}
+
+
+	/**
+	 * Gets the screen settings.
+	 *
+	 * @since 2.2.0-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_settings() {
+
+		return [];
+	}
+
+
+}

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -37,6 +37,8 @@ class Connection extends Admin\Abstract_Settings_Screen {
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 
+		add_action( 'admin_head', [ $this, 'output_lwi_ads_script' ] );
+
 		add_action( 'admin_notices', [ $this, 'add_notices' ] );
 	}
 
@@ -67,6 +69,42 @@ class Connection extends Admin\Abstract_Settings_Screen {
 
 			delete_transient( 'wc_facebook_connection_failed' );
 		}
+	}
+
+
+	/**
+	 * Outputs the LWI Ads script.
+	 *
+	 * @internal
+	 *
+	 * @since 2.1.0-dev.1
+	 */
+	public function output_lwi_ads_script() {
+
+		$tab = SV_WC_Helper::get_requested_value( 'tab' );
+
+		if ( Admin\Settings::PAGE_ID !== SV_WC_Helper::get_requested_value( 'page' ) || ( $tab && $this->get_id() !== SV_WC_Helper::get_requested_value( 'tab' ) ) ) {
+			return;
+		}
+
+		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
+
+		if ( ! $connection_handler || ! $connection_handler->is_connected() ) {
+			return;
+		}
+
+		?>
+		<script>
+			window.fbAsyncInit = function() {
+				FB.init( {
+					appId            : '<?php echo esc_js( $connection_handler->get_client_id() ); ?>',
+					autoLogAppEvents : true,
+					xfbml            : true,
+					version          : 'v8.0',
+				} );
+			};
+		</script>
+		<?php
 	}
 
 

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -13,8 +13,7 @@ namespace SkyVerge\WooCommerce\Facebook\Admin\Settings_Screens;
 defined( 'ABSPATH' ) or exit;
 
 use SkyVerge\WooCommerce\Facebook\Admin;
-use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Exception;
-use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper;
+use SkyVerge\WooCommerce\PluginFramework\v5_9_0\SV_WC_API_Exception;
 
 /**
  * The Connection settings screen object.
@@ -81,15 +80,9 @@ class Connection extends Admin\Abstract_Settings_Screen {
 	 */
 	public function output_lwi_ads_script() {
 
-		$tab = SV_WC_Helper::get_requested_value( 'tab' );
-
-		if ( Admin\Settings::PAGE_ID !== SV_WC_Helper::get_requested_value( 'page' ) || ( $tab && $this->get_id() !== SV_WC_Helper::get_requested_value( 'tab' ) ) ) {
-			return;
-		}
-
 		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
 
-		if ( ! $connection_handler || ! $connection_handler->is_connected() ) {
+		if ( ! $connection_handler || ! $connection_handler->is_connected() || ! $this->is_current_screen() ) {
 			return;
 		}
 
@@ -117,9 +110,7 @@ class Connection extends Admin\Abstract_Settings_Screen {
 	 */
 	public function enqueue_assets() {
 
-		$tab = SV_WC_Helper::get_requested_value( 'tab' );
-
-		if ( Admin\Settings::PAGE_ID !== SV_WC_Helper::get_requested_value( 'page' ) || ( $tab && $this->get_id() !== SV_WC_Helper::get_requested_value( 'tab' ) ) ) {
+		if ( ! $this->is_current_screen() ) {
 			return;
 		}
 

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -59,9 +59,7 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 	 */
 	public function enqueue_assets() {
 
-		$tab = SV_WC_Helper::get_requested_value( 'tab' );
-
-		if ( Admin\Settings::PAGE_ID !== SV_WC_Helper::get_requested_value( 'page' ) || ( $tab && self::ID !== $tab ) ) {
+		if ( ! $this->is_current_screen() ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary 

Loads & Initializes the LWI Ads script in the Connections page.

#### Story: [CH 66402](https://app.clubhouse.io/skyverge/story/66419)
#### Release PR: #1645

## Details

## UI Changes

Tweaks the FB connection box once connected so that "Create Ad" will open a popup to create ads without leaving the site. 

Displays the created ads in the connection box iframe replacement.

## QA

### Setup

Install & activate the plugin.

### Steps

tba

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version