### PR TITLE
Fix PHP-7.3 only syntax 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Facebook for WooCommerce Changelog ***
 
 2020.nn.nn - version 2.1.1-dev.1
+ * Fix - Adjust code syntax that may have issued errors in installations running PHP lower than 7.3
 
 2020.10.26 - version 2.1.0
  * Feature - Set Google category at the shop level for the Facebook catalog sync (on the product sync tab).

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -81,7 +81,8 @@ class Enhanced_Catalog_Attribute_Fields {
 					$this->extract_attribute( $optional_attributes, 'gender' ),
 				),
 				function( $attr ) {
-					return ! is_null( $attr ); },
+					return ! is_null( $attr );
+				}
 			);
 		}
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1174,13 +1174,12 @@ class Products {
 			function( $attrs, $attr_key ) use ( $prefix ) {
 				return array_merge(
 					$attrs,
-					array(
-						str_replace( $prefix, '', $attr_key ) =>
-																wc_clean( Framework\SV_WC_Helper::get_posted_value( $attr_key ) ),
-					),
+					[
+						str_replace( $prefix, '', $attr_key ) => wc_clean( Framework\SV_WC_Helper::get_posted_value( $attr_key ) ),
+					]
 				);
 			},
-			array(),
+			[]
 		);
 	}
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1152,12 +1152,13 @@ class Products {
 
 
 	/**
-	 * Helper function that gets and cleans the submitted values for enhanced
-	 * catalog attributes from the request. Is used by both product categories
-	 * and product pages.
-	 * Returns an array that maps key to value.
+	 * Gets and cleans the submitted values for enhanced catalog attributes from the request.
 	 *
-	 * @return array
+	 * Helper function used by both product categories and product pages.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return array associative array
 	 */
 	public static function get_enhanced_catalog_attributes_from_request() {
 		$prefix     = Admin\Enhanced_Catalog_Attribute_Fields::FIELD_ENHANCED_CATALOG_ATTRIBUTE_PREFIX;

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 == Changelog ==
 
 = 2020.nn.nn - version 2.1.1-dev.1 =
+ * Fix - Adjust code syntax that may have issued errors in installations running PHP lower than 7.3
 
 = 2020.10.26 - version 2.1.0 =
  * Feature - Set Google category at the shop level for the Facebook catalog sync (on the product sync tab).


### PR DESCRIPTION
## Summary

Removes trailing commas in anonymous function - syntax not supported in PHP versions < 7.3

#### Story [CH 66475](https://app.clubhouse.io/skyverge/story/66475/synthax-error-in-includes-products-php-php-7-3-code-trailing-comma-in-function-calls-27)

#### PR #1655 

## QA

- [x] Code review
- [x] Activate the plugin in a installation running PHP < 7.3
- [x] No errors thrown

## Before merge


- [ ] I have confirmed these changes in each supported minor WooCommerce version