### PR TITLE
Move the settings page under "Marketing" menu item

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -314,6 +314,23 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					'notice_class' => 'notice-error',
 				] );
 			}
+
+			if ( Framework\SV_WC_Plugin_Compatibility::is_enhanced_admin_available() ) {
+
+				$this->get_admin_notice_handler()->add_admin_notice(
+					sprintf(
+						/* translators: Placeholders: %1$s - opening <a> HTML link tag, %2$s - closing </a> HTML link tag */
+						esc_html__( 'Heads up! The Facebook menu is now located under the %1$sMarketing%2$s menu.', 'facebook-for-woocommerce' ),
+						'<a href="' . esc_url( $this->get_settings_url() ) . '">','</a>'
+					),
+					'settings_moved_to_marketing',
+					[
+						'dismissible'             => true,
+						'always_show_on_settings' => false,
+						'notice_class'            => 'notice-info',
+					]
+				);
+			}
 		}
 
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -56,8 +56,14 @@ class Settings {
 	 */
 	public function add_menu_item() {
 
+		if ( Framework\SV_WC_Plugin_Compatibility::is_enhanced_admin_available() ) {
+			$root_menu_item = 'woocommerce-marketing';
+		} else {
+			$root_menu_item = 'woocommerce';
+		}
+
 		add_submenu_page(
-			'woocommerce',
+			$root_menu_item,
 			__( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ),
 			__( 'Facebook', 'facebook-for-woocommerce' ),
 			'manage_woocommerce', self::PAGE_ID,

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -10,9 +10,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Admin;
 
-use Codeception\Lib\Framework;
-use SkyVerge\WooCommerce\PluginFramework\v5_9_0\SV_WC_Helper;
-use SkyVerge\WooCommerce\PluginFramework\v5_9_0\SV_WC_Plugin_Exception;
+use SkyVerge\WooCommerce\PluginFramework\v5_9_0 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -90,7 +88,7 @@ class Settings {
 	public function render() {
 
 		$tabs        = $this->get_tabs();
-		$current_tab = SV_WC_Helper::get_requested_value( 'tab' );
+		$current_tab = Framework\SV_WC_Helper::get_requested_value( 'tab' );
 
 		if ( ! $current_tab ) {
 			$current_tab = current( array_keys( $tabs ) );
@@ -134,17 +132,17 @@ class Settings {
 	 */
 	public function save() {
 
-		if ( ! is_admin() || SV_WC_Helper::get_requested_value( 'page' ) !== self::PAGE_ID ) {
+		if ( ! is_admin() || Framework\SV_WC_Helper::get_requested_value( 'page' ) !== self::PAGE_ID ) {
 			return;
 		}
 
-		$screen = $this->get_screen( SV_WC_Helper::get_posted_value( 'screen_id' ) );
+		$screen = $this->get_screen( Framework\SV_WC_Helper::get_posted_value( 'screen_id' ) );
 
 		if ( ! $screen ) {
 			return;
 		}
 
-		if ( ! SV_WC_Helper::get_posted_value( 'save_' . $screen->get_id() . '_settings' ) ) {
+		if ( ! Framework\SV_WC_Helper::get_posted_value( 'save_' . $screen->get_id() . '_settings' ) ) {
 			return;
 		}
 
@@ -160,7 +158,7 @@ class Settings {
 
 			facebook_for_woocommerce()->get_message_handler()->add_message( __( 'Your settings have been saved.', 'facebook-for-woocommerce' ) );
 
-		} catch ( SV_WC_Plugin_Exception $exception ) {
+		} catch ( Framework\SV_WC_Plugin_Exception $exception ) {
 
 			facebook_for_woocommerce()->get_message_handler()->add_error(
 				sprintf(

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -10,6 +10,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Admin;
 
+use Codeception\Lib\Framework;
 use SkyVerge\WooCommerce\PluginFramework\v5_9_0\SV_WC_Helper;
 use SkyVerge\WooCommerce\PluginFramework\v5_9_0\SV_WC_Plugin_Exception;
 
@@ -57,7 +58,14 @@ class Settings {
 	 */
 	public function add_menu_item() {
 
-		add_submenu_page( 'woocommerce', __( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ), __( 'Facebook', 'facebook-for-woocommerce' ), 'manage_woocommerce', self::PAGE_ID, array( $this, 'render' ), 5 );
+		add_submenu_page(
+			'woocommerce',
+			__( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ),
+			__( 'Facebook', 'facebook-for-woocommerce' ),
+			'manage_woocommerce', self::PAGE_ID,
+			[ $this, 'render' ],
+			5
+		);
 
 		// enables the WC Admin top bar for the settings page
 		if ( is_callable( 'wc_admin_connect_page' ) ) {

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -74,7 +74,17 @@ class Settings {
 			5
 		);
 
-		// enables the WC Admin top bar for the settings page
+		$this->connect_to_enhanced_admin();
+	}
+
+
+	/**
+	 * Enables enhanced admin support for the main Facebook settings page.
+	 *
+	 * @since 2.2.0-dev.1
+	 */
+	private function connect_to_enhanced_admin() {
+
 		if ( is_callable( 'wc_admin_connect_page' ) ) {
 
 			$crumbs = [
@@ -96,10 +106,10 @@ class Settings {
 			}
 
 			wc_admin_connect_page( [
-				'id'        => self::PAGE_ID,
-				'screen_id' => 'marketing_page_wc-facebook',
-				'path'      => add_query_arg( 'page', self::PAGE_ID, 'admin.php' ),
-				'title'     => $crumbs
+					'id'        => self::PAGE_ID,
+					'screen_id' => 'marketing_page_wc-facebook',
+					'path'      => add_query_arg( 'page', self::PAGE_ID, 'admin.php' ),
+					'title'     => $crumbs
 			] );
 		}
 	}

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -10,6 +10,9 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Admin;
 
+use SkyVerge\WooCommerce\Facebook\Admin\Settings_Screens\Connection;
+use SkyVerge\WooCommerce\Facebook\Admin\Settings_Screens\Messenger;
+use SkyVerge\WooCommerce\Facebook\Admin\Settings_Screens\Product_Sync;
 use SkyVerge\WooCommerce\PluginFramework\v5_9_0 as Framework;
 
 defined( 'ABSPATH' ) or exit;
@@ -74,13 +77,29 @@ class Settings {
 		// enables the WC Admin top bar for the settings page
 		if ( is_callable( 'wc_admin_connect_page' ) ) {
 
+			$crumbs = [
+				__( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ),
+			];
+
+			if ( ! empty( $_GET['tab'] ) ) {
+				switch ( $_GET['tab'] ) {
+					case Connection::ID :
+						$crumbs[] = __( 'Connection', 'facebook-for-woocommerce' );
+					break;
+					case Messenger::ID :
+						$crumbs[] = __( 'Messenger', 'facebook-for-woocommerce' );
+					break;
+					case Product_Sync::ID :
+						$crumbs[] = __( 'Product sync', 'facebook-for-woocommerce' );
+					break;
+				}
+			}
+
 			wc_admin_connect_page( [
 				'id'        => self::PAGE_ID,
 				'screen_id' => 'marketing_page_wc-facebook',
 				'path'      => add_query_arg( 'page', self::PAGE_ID, 'admin.php' ),
-				'title'     => [
-					__( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ),
-				],
+				'title'     => $crumbs
 			] );
 		}
 	}

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -58,6 +58,19 @@ class Settings {
 	public function add_menu_item() {
 
 		add_submenu_page( 'woocommerce', __( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ), __( 'Facebook', 'facebook-for-woocommerce' ), 'manage_woocommerce', self::PAGE_ID, array( $this, 'render' ), 5 );
+
+		// enables the WC Admin top bar for the settings page
+		if ( is_callable( 'wc_admin_connect_page' ) ) {
+
+			wc_admin_connect_page( [
+				'id'        => self::PAGE_ID,
+				'screen_id' => 'marketing_page_wc-facebook',
+				'path'      => add_query_arg( 'page', self::PAGE_ID, 'admin.php' ),
+				'title'     => [
+					__( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ),
+				],
+			] );
+		}
 	}
 
 


### PR DESCRIPTION
## Summary 

Moves the plugin settings page under "Marketing".

It also displays the WC Admin top bar in the settings page.

#### Stories: 

- [CH 66402](https://app.clubhouse.io/skyverge/story/66402)
- [CH 66409](https://app.clubhouse.io/skyverge/story/66409)
- [CH 66680](https://app.clubhouse.io/skyverge/story/66680)

**Release branch: #1663** 

## Details

Since Marketing may not be available in all WC versions, it only adds this changes from WC 4.0 onward. 

I did not find a way to display the full breadcrumbs in the top bar that also includes the `Marketing` root, but this might be a limitation when enabling WC Admin support for non-REACT pages: https://github.com/woocommerce/woocommerce-admin/blob/main/docs/page-controller.md

## UI Changes

- Updated menu item position
- WC Admin top bar
- A notice is displayed when upgrading to this version

![image](https://user-images.githubusercontent.com/1227930/97137217-424cf000-1790-11eb-925b-a90b777c1c83.png)


## QA

### Setup

Install & activate the plugin.

### Steps

- Visit admin in WC 4.0 and above
   - [x] The Facebook page is listed under `Marketing`
   - [x] The WC Admin top bar is visible
   - [x] The breadcrumbs in the top bar follow the available setting screens (minus the root Marketing, see note above)
   - [x] A notice is displayed to warn the merchant about the change
- Visit admin in WC below 4.0
   - [x] The Facebook page is listed under `WooCommerce`
   - [x] The WC Admin top bar is not visible
   - [x] You can click on the WC Admin top bar inbox and this opens correctly
   - [x] No JS conflicts or errors in console
- Both cases
   - [x] The page identifier or admin URL to get to the page hasn't changed

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version