### PR TITLE
Prevent trying add Facebook refunds for non-Commerce orders

### DIFF
--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -432,7 +432,7 @@ class Orders {
 			return;
 		}
 
-		$reason_code = isset( $_POST['wc_facebook_refund_reason'] ) ? $_POST['wc_facebook_refund_reason'] : null;
+		$reason_code = wc_clean( Framework\SV_WC_Helper::get_posted_value( 'wc_facebook_refund_reason' ) );
 
 		facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->add_order_refund( $order_refund, $reason_code );
 	}

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -422,12 +422,19 @@ class Orders {
 
 		$order_refund = wc_get_order( $refund_id );
 
-		if ( $order_refund instanceof \WC_Order_Refund ) {
-
-			$reason_code = isset( $_POST['wc_facebook_refund_reason'] ) ? $_POST['wc_facebook_refund_reason'] : null;
-
-			facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->add_order_refund( $order_refund, $reason_code );
+		if ( ! $order_refund instanceof \WC_Order_Refund ) {
+			return;
 		}
+
+		$order = wc_get_order( $order_refund->get_parent_id() );
+
+		if ( ! $order instanceof \WC_Order || ! Commerce\Orders::is_commerce_order( $order ) ) {
+			return;
+		}
+
+		$reason_code = isset( $_POST['wc_facebook_refund_reason'] ) ? $_POST['wc_facebook_refund_reason'] : null;
+
+		facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler()->add_order_refund( $order_refund, $reason_code );
 	}
 
 

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -60,6 +60,7 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 		facebook_for_woocommerce()->get_connection_handler()->update_access_token( 'access_token' );
 
 		$order = new \WC_Order();
+		$order->set_created_via( 'facebook' );
 		$order->save();
 
 		$refund = new \WC_Order_Refund();

--- a/tests/integration/Admin/OrdersTest.php
+++ b/tests/integration/Admin/OrdersTest.php
@@ -73,6 +73,29 @@ class OrdersTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Admin\Orders::handle_refund() */
+	public function test_handle_refund_for_non_commerce_orders() {
+
+		$order = new \WC_Order();
+		$order->set_created_via( 'checkout' );
+		$order->save();
+
+		$refund = new \WC_Order_Refund();
+		$refund->set_parent_id( $order->get_id() );
+		$refund->save();
+
+		$commerce_orders_handler = facebook_for_woocommerce()->get_commerce_handler()->get_orders_handler();
+
+		$this->tester->setPropertyValue( facebook_for_woocommerce()->get_commerce_handler(), 'orders', $this->make( Orders::class, [
+			'add_order_refund' => \Codeception\Stub\Expected::never(),
+		] ) );
+
+		$this->get_orders_handler()->handle_refund( $refund->get_id() );
+
+		$this->tester->setPropertyValue( facebook_for_woocommerce()->get_commerce_handler(), 'orders', $commerce_orders_handler );
+	}
+
+
 	// TODO: add test for handle_bulk_update()
 
 


### PR DESCRIPTION
# Summary

This PR prevents calling `add_order_fund()` on non-Commerce orders.

### Story: [CH 66733](https://app.clubhouse.io/skyverge/story/66733)
### Release: #1669 

## QA

### Setup

- Install and configure Facebook for WooCommerce from `release/instagram-checkout` branch.
- Install and configure Authorize.Net
- Configure the gateway to use the Authorization transaction type

### Steps

1. Add a product to the cart and place a new order
1. Edit the order and attempt to do a full amount refund (including shipping and taxes)
    - [x] An alert indicates that it couldn't find the `Remote ID of the parent order`

Switch to this branch.

1. Add a product to the cart and place a new order
1. Edit the order and attempt to do a full amount refund (including shipping and taxes)
    - [x] The refund is processed successfully 
    - [x] There are no alerts 
    - [x] There are no Commerce related order notes

### Tests

- [x] `codecept run integration` pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version