### PR TITLE
Issue/1674 attribute check error on variants

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Facebook for WooCommerce Changelog ***
 
 = 2020.nn.nn - version 2.1.4-dev.1
+ * Fix - Ensure product variant attributes are correctly handled when checking for enhanced attribute values.
 
 2020.10.29 - version 2.1.3
  * Fix - Prevent error triggered while trying to refund orders

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1112,8 +1112,16 @@ class Products {
 		if ( empty( $value ) ) {
 			// Check normal product attributes
 			foreach ( self::get_available_product_attributes( $product ) as $slug => $attribute ) {
-				if ( strtolower( $attribute->get_name() ) === $key ) {
-					$value = $product->get_attribute( $slug );
+				if ( $product->is_type( 'variation' ) ) {
+					$attr_name = $slug;
+					$attr_val  = $attribute;
+				} else {
+					$attr_name = $attribute->get_name();
+					$attr_val  = $product->get_attribute( $slug );
+				}
+
+				if ( strtolower( $attr_name ) === $key ) {
+					$value = $attr_val;
 					break;
 				}
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 == Changelog ==
 
 = 2020.nn.nn - version 2.1.4-dev.1
+ * Fix - Ensure product variant attributes are correctly handled when checking for enhanced attribute values.
 
 = 2020.10.29 - version 2.1.3 =
  * Fix - Prevent error triggered while trying to refund orders


### PR DESCRIPTION
Fix the issue https://github.com/facebookincubator/facebook-for-woocommerce/issues/1674 where variants with attributes that match enhanced catalog attributes were erroring when we tried to read those attributes.

This change preserves those variant attributes on the sync.