### PR TITLE
Rework filter placement to disable pixel tracking

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 = 2020.nn.nn - version 2.2.0-dev.1 =
  * Feature - Add an Advertise tab in the Facebook settings page to manage Facebook ads from within WooCommerce
  * Tweak - Move the Facebook settings page into the Marketing menu item (WooCommerce 4.0+)
- * Fix - Move the filter `facebook_for_woocommerce_integration_pixel_enabled` at `init` time to avoid possible uncaught JavaScript errors in front end
+ * Fix - Move the filter `facebook_for_woocommerce_integration_pixel_enabled` initialization to avoid possible uncaught JavaScript errors in front end
 
 2020.10.29 - version 2.1.3
  * Fix - Prevent error triggered while trying to refund orders

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 2020.nn.nn - version 2.2.0-dev.1 =
  * Feature - Add an Advertise tab in the Facebook settings page to manage Facebook ads from within WooCommerce
  * Tweak - Move the Facebook settings page into the Marketing menu item (WooCommerce 4.0+)
+ * Fix - Move the filter `facebook_for_woocommerce_integration_pixel_enabled` at `init` time to avoid possible uncaught JavaScript errors in front end
 
 2020.10.29 - version 2.1.3
  * Fix - Prevent error triggered while trying to refund orders

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -22,51 +22,86 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 	}
 
 	class WC_Facebookcommerce_EventsTracker {
-		private $pixel;
-		private static $isEnabled = true;
-		const FB_PRIORITY_HIGH    = 2;
-		const FB_PRIORITY_LOW     = 11;
 
+
+		/** @deprecated since 2.3.0-dev.1 */
+		const FB_PRIORITY_HIGH = 2;
+		/** @deprecated since 2.3.0-dev.1 */
+		const FB_PRIORITY_LOW = 11;
+
+
+		/** @var \WC_Facebookcommerce_Pixel instance */
+		private $pixel;
 
 		/** @var string name of the session variable used to store search event data */
 		private $search_event_data_session_variable = 'wc_facebook_search_event_data';
 
 		/** @var Event search event instance */
 		private $search_event;
+
 		/** @var array with events tracked */
 		private $tracked_events;
+
 		/** @var AAMSettings aam settings instance, used to filter advanced matching fields*/
 		private $aam_settings;
 
+
+		/**
+		 * Events tracker constructor.
+		 *
+		 * @param $user_info
+		 * @param $aam_settings
+		 */
 		public function __construct( $user_info, $aam_settings ) {
-			$this->pixel = new WC_Facebookcommerce_Pixel( $user_info );
-			$this->aam_settings = $aam_settings;
-			$this->tracked_events = array();
 
-			add_action( 'init', [ $this, 'apply_filters' ], 1 );
+			if ( ! $this->is_pixel_enabled() ) {
+				return;
+			}
 
-			// Pixel Tracking Hooks
-			add_action(
-				'wp_head',
-				array( $this, 'inject_base_pixel' )
-			);
-			add_action(
-				'wp_footer',
-				array( $this, 'inject_base_pixel_noscript' )
-			);
+			$this->pixel          = new \WC_Facebookcommerce_Pixel( $user_info );
+			$this->aam_settings   = $aam_settings;
+			$this->tracked_events = [];
+
+			$this->add_hooks();
+		}
+
+
+		/**
+		 * Determines whether the Pixel should be enabled.
+		 *
+		 * @since 2.3.0-dev.1
+		 *
+		 * @return bool
+		 */
+		private function is_pixel_enabled() {
+
+			/**
+			 * Filters whether the Pixel should be enabled.
+			 *
+			 * @param bool $enabled default true
+			 */
+			return (bool) apply_filters( 'facebook_for_woocommerce_integration_pixel_enabled', true );
+		}
+
+
+		/**
+		 * Add events tracker hooks.
+		 *
+		 * @since 2.3.0-dev.1
+		 */
+		private function add_hooks() {
+
+			// inject Pixel
+			add_action( 'wp_head',   [ $this, 'inject_base_pixel' ] );
+			add_action( 'wp_footer', [ $this, 'inject_base_pixel_noscript' ] );
 
 			// ViewContent for individual products
 			add_action( 'woocommerce_after_single_product', [ $this, 'inject_view_content_event' ] );
 			add_action( 'woocommerce_after_single_product', [ $this, 'maybe_inject_search_event' ] );
 
-			add_action(
-				'woocommerce_after_shop_loop',
-				array( $this, 'inject_view_category_event' )
-			);
-			add_action(
-				'pre_get_posts',
-				array( $this, 'inject_search_event' )
-			);
+			add_action( 'woocommerce_after_shop_loop', [ $this, 'inject_view_category_event' ] );
+
+			add_action( 'pre_get_posts',                             [ $this, 'inject_search_event' ] );
 			add_filter( 'woocommerce_redirect_single_search_result', [ $this, 'maybe_add_product_search_event_to_session' ] );
 
 			// AddToCart events
@@ -87,15 +122,20 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			add_action( 'woocommerce_thankyou',                   [ $this, 'inject_purchase_event' ], 40 );
 
 			// TODO move this in some 3rd party plugin integrations handler at some point {FN 2020-03-20}
-			add_action( 'wpcf7_contact_form', [ $this, 'inject_lead_event_hook' ], self::FB_PRIORITY_LOW );
+			add_action( 'wpcf7_contact_form', [ $this, 'inject_lead_event_hook' ], 2 );
 		}
 
 
+		/**
+		 * Adds filter hooks.
+		 *
+		 * @internal
+		 *
+		 * @deprecated since 2.3.0-dev.1
+		 */
 		public function apply_filters() {
-			self::$isEnabled = (bool) apply_filters(
-				'facebook_for_woocommerce_integration_pixel_enabled',
-				self::$isEnabled
-			);
+
+			wc_deprecated_function( __METHOD__, '2.3.0-dev.1' );
 		}
 
 
@@ -104,7 +144,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_base_pixel() {
 
-			if ( self::$isEnabled ) {
+			if ( $this->is_pixel_enabled() ) {
 				// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				echo $this->pixel->pixel_base_code();
 			}
@@ -118,7 +158,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_base_pixel_noscript() {
 
-			if ( self::$isEnabled ) {
+			if ( $this->is_pixel_enabled() ) {
 				// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				echo $this->pixel->pixel_base_code_noscript();
 			}
@@ -131,7 +171,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		public function inject_view_category_event() {
 			global $wp_query;
 
-			if ( ! self::$isEnabled || ! is_product_category() ) {
+			if ( ! $this->is_pixel_enabled() || ! is_product_category() ) {
 				return;
 			}
 
@@ -263,7 +303,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function maybe_inject_search_event() {
 
-			if ( ! self::$isEnabled ) {
+			if ( ! $this->is_pixel_enabled() ) {
 				return;
 			}
 
@@ -323,7 +363,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_search_event() {
 
-			if ( ! self::$isEnabled ) {
+			if ( ! $this->is_pixel_enabled() ) {
 				return;
 			}
 
@@ -440,7 +480,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		public function inject_view_content_event() {
 			global $post;
 
-			if ( ! self::$isEnabled || ! isset( $post->ID ) ) {
+			if ( ! $this->is_pixel_enabled() || ! isset( $post->ID ) ) {
 				return;
 			}
 
@@ -503,7 +543,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		public function inject_add_to_cart_event( $cart_item_key, $product_id, $quantity, $variation_id ) {
 
 			// bail if pixel tracking disabled or invalid variables
-			if ( ! self::$isEnabled || ! $product_id || ! $quantity ) {
+			if ( ! $this->is_pixel_enabled() || ! $product_id || ! $quantity ) {
 				return;
 			}
 
@@ -570,7 +610,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function add_add_to_cart_event_fragment( $fragments ) {
 
-			if ( self::$isEnabled ) {
+			if ( $this->is_pixel_enabled() ) {
 
 				$params = [
 					'content_ids'  => $this->get_cart_content_ids(),
@@ -627,7 +667,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function add_conditional_add_to_cart_event_fragment( $fragments ) {
 
-			if ( self::$isEnabled ) {
+			if ( $this->is_pixel_enabled() ) {
 
 				$params = [
 					'content_ids'  => $this->get_cart_content_ids(),
@@ -719,7 +759,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_add_to_cart_redirect_event() {
 
-			if ( ! self::$isEnabled ) {
+			if ( ! $this->is_pixel_enabled() ) {
 				return;
 			}
 
@@ -741,7 +781,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_initiate_checkout_event() {
 
-			if ( ! self::$isEnabled || $this->pixel->is_last_event( 'InitiateCheckout' ) ) {
+			if ( ! $this->is_pixel_enabled() || $this->pixel->is_last_event( 'InitiateCheckout' ) ) {
 				return;
 			}
 
@@ -803,7 +843,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$event_name = 'Purchase';
 
-			if ( ! self::$isEnabled || $this->pixel->is_last_event( $event_name ) ) {
+			if ( ! $this->is_pixel_enabled() || $this->pixel->is_last_event( $event_name ) ) {
 				return;
 			}
 
@@ -897,7 +937,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_subscribe_event( $order_id ) {
 
-			if ( ! self::$isEnabled || ! function_exists( 'wcs_get_subscriptions_for_order' ) || $this->pixel->is_last_event( 'Subscribe' )  ) {
+			if ( ! function_exists( 'wcs_get_subscriptions_for_order' ) || ! $this->is_pixel_enabled() || $this->pixel->is_last_event( 'Subscribe' )  ) {
 				return;
 			}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$this->aam_settings = $aam_settings;
 			$this->tracked_events = array();
 
-			add_action( 'wp_head', array( $this, 'apply_filters' ) );
+			add_action( 'init', [ $this, 'apply_filters' ], 1 );
 
 			// Pixel Tracking Hooks
 			add_action(
@@ -90,8 +90,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			add_action( 'wpcf7_contact_form', [ $this, 'inject_lead_event_hook' ], self::FB_PRIORITY_LOW );
 		}
 
+
 		public function apply_filters() {
-			self::$isEnabled = apply_filters(
+			self::$isEnabled = (bool) apply_filters(
 				'facebook_for_woocommerce_integration_pixel_enabled',
 				self::$isEnabled
 			);

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -24,9 +24,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 	class WC_Facebookcommerce_EventsTracker {
 
 
-		/** @deprecated since 2.3.0-dev.1 */
+		/** @deprecated since 2.2.0-dev.1 */
 		const FB_PRIORITY_HIGH = 2;
-		/** @deprecated since 2.3.0-dev.1 */
+		/** @deprecated since 2.2.0-dev.1 */
 		const FB_PRIORITY_LOW = 11;
 
 
@@ -69,7 +69,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		/**
 		 * Determines whether the Pixel should be enabled.
 		 *
-		 * @since 2.3.0-dev.1
+		 * @since 2.2.0-dev.1
 		 *
 		 * @return bool
 		 */
@@ -87,7 +87,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		/**
 		 * Add events tracker hooks.
 		 *
-		 * @since 2.3.0-dev.1
+		 * @since 2.2.0-dev.1
 		 */
 		private function add_hooks() {
 
@@ -131,11 +131,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 *
 		 * @internal
 		 *
-		 * @deprecated since 2.3.0-dev.1
+		 * @deprecated since 2.2.0-dev.1
 		 */
 		public function apply_filters() {
 
-			wc_deprecated_function( __METHOD__, '2.3.0-dev.1' );
+			wc_deprecated_function( __METHOD__, '2.2.0-dev.1' );
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -45,6 +45,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		/** @var AAMSettings aam settings instance, used to filter advanced matching fields*/
 		private $aam_settings;
 
+		/** @var bool whether the pixel should be enabled */
+		private $is_pixel_enabled;
+
 
 		/**
 		 * Events tracker constructor.
@@ -75,12 +78,17 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		private function is_pixel_enabled() {
 
-			/**
-			 * Filters whether the Pixel should be enabled.
-			 *
-			 * @param bool $enabled default true
-			 */
-			return (bool) apply_filters( 'facebook_for_woocommerce_integration_pixel_enabled', true );
+			if ( null === $this->is_pixel_enabled ) {
+
+				/**
+				 * Filters whether the Pixel should be enabled.
+				 *
+				 * @param bool $enabled default true
+				 */
+				$this->is_pixel_enabled = (bool) apply_filters( 'facebook_for_woocommerce_integration_pixel_enabled', true );
+			}
+
+			return $this->is_pixel_enabled;
 		}
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 = 2020.nn.nn - version 2.2.0-dev.1 =
  * Feature - Add an Advertise tab in the Facebook settings page to manage Facebook ads from within WooCommerce
  * Tweak - Move the Facebook settings page into the Marketing menu item (WooCommerce 4.0+)
+ * Fix - Move the filter `facebook_for_woocommerce_integration_pixel_enabled` at `init` time to avoid possible uncaught JavaScript errors in front end
 
 = 2020.10.29 - version 2.1.3 =
  * Fix - Prevent error triggered while trying to refund orders

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 = 2020.nn.nn - version 2.2.0-dev.1 =
  * Feature - Add an Advertise tab in the Facebook settings page to manage Facebook ads from within WooCommerce
  * Tweak - Move the Facebook settings page into the Marketing menu item (WooCommerce 4.0+)
- * Fix - Move the filter `facebook_for_woocommerce_integration_pixel_enabled` at `init` time to avoid possible uncaught JavaScript errors in front end
+ * Fix - Move the filter `facebook_for_woocommerce_integration_pixel_enabled` initialization to avoid possible uncaught JavaScript errors in front end
 
 = 2020.10.29 - version 2.1.3 =
  * Fix - Prevent error triggered while trying to refund orders


### PR DESCRIPTION
## Summary

Reworks the way the filter `facebook_for_woocommerce_integration_pixel_enabled` is triggered within `WC_Facebookcommerce_EventsTracker` so that it doesn't cause frontend JS errors.

#### Story: [CH 55524](https://app.clubhouse.io/skyverge/story/55524)
#### PR: #1663 (v2.2.0)

## Details

Rather than changing the filter hook that would have called the filter added by Facebook, I figured it's simple enough to have a method called from constructor that checks whether the pixel should be enabled or not via `facebook_for_woocommerce_integration_pixel_enabled`. Then, just bail from applying all the filters the constructor is attaching (and move those into a separate method as well).

I checked the references of those methods and the public ones do not look to be called from elsewhere. Anyway, many of them already had some checks to see if the former `$isEnabled` flag was set, I merely replaced that with a call to the new method.

## QA

### Setup

- Make sure you are connected with Facebook and your pixel is working
- Install the Facebook Pixel helper from the Chrome web store to check pixel status on a page and inspect your analytics while browsing pages where the pixel is expected to track events
- Keep your console open to check for errors

### Steps

#### No filter applied

1. Visit front end with a customer user
   - [x] The FB Pixel helper is active and tracking occurs
1. Add product to cart, wait for page reload, visit cart and then checkout
   - [x] Events are correctly tracked
   - [x] No JS error appears in console

#### Apply filter

1. Add a filter `add_filter( 'facebook_for_woocommerce_integration_pixel_enabled', '__return_false' );` with Code Snippets or similar
1. Visit the shop front end and perform some activity (page browsing, search, add to cart...)
    - [x] No pixel is loaded at all, no events are tracked
1. Add product to cart, wait for reload page and visit cart/checkout
    - [x] No JS errors appear in console


## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version