### PR TITLE
Register WooCommerce Navigation items

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -10,6 +10,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Admin;
 
+use \Automattic\WooCommerce\Admin\Features\Navigation\Menu;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Plugin_Exception;
 
@@ -58,6 +59,48 @@ class Settings {
 	public function add_menu_item() {
 
 		add_submenu_page( 'woocommerce', __( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ), __( 'Facebook', 'facebook-for-woocommerce' ), 'manage_woocommerce', self::PAGE_ID, array( $this, 'render' ), 5 );
+
+		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu' ) ) {
+			return;
+		}
+
+		Menu::add_plugin_category(
+			array(
+				'id'         => 'facebook-for-woocommerce',
+				'title'      => __( 'Facebook', 'facebook-for-woocommerce' ),
+				'capability' => 'manage_woocommerce',
+			)
+		);
+
+		Menu::add_plugin_item(
+			array(
+				'id'     => 'facebook-for-woocommerce-connection',
+				'parent' => 'facebook-for-woocommerce',
+				'title'  => __( 'Connection', 'facebook-for-woocommerce' ),
+				'url'    => 'wc-facebook',
+				'order'  => 1,
+			)
+		);
+
+		Menu::add_plugin_item(
+			array(
+				'id'     => 'facebook-for-woocommerce-product-sync',
+				'parent' => 'facebook-for-woocommerce',
+				'title'  => __( 'Product sync', 'facebook-for-woocommerce' ),
+				'url'    => 'wc-facebook&tab=product_sync',
+				'order'  => 2,
+			)
+		);
+
+		Menu::add_plugin_item(
+			array(
+				'id'     => 'facebook-for-woocommerce-messenger',
+				'parent' => 'facebook-for-woocommerce',
+				'title'  => __( 'Messenger', 'facebook-for-woocommerce' ),
+				'url'    => 'wc-facebook&tab=messenger',
+				'order'  => 3,
+			)
+		);
 	}
 
 


### PR DESCRIPTION
Adds the menu items for the new WC nav experience.

### Screenshots
<img width="1168" alt="Screen Shot 2020-11-12 at 12 41 55 PM" src="https://user-images.githubusercontent.com/10561050/98975898-b3a4d680-24e4-11eb-99ef-66f6fb2a2180.png">


### Testing

1. Clone and install/activate https://github.com/woocommerce/woocommerce-admin
1. Enable the navigation feature at `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
1. Check that the "Facebook" extension is registered and menu items work as expected.