### PR TITLE
Instagram Checkout: Fix commerce tab settings display

### DIFF
--- a/includes/Admin/Settings_Screens/Commerce.php
+++ b/includes/Admin/Settings_Screens/Commerce.php
@@ -190,9 +190,7 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	private function render_us_only_limitation_notice() {
 
 		?>
-
 		<div class="notice notice-info"><p><?php esc_html_e( 'Instagram Checkout is only available to merchants located in the United States.', 'facebook-for-woocommerce' ); ?></p></div>
-
 		<?php
 	}
 
@@ -234,6 +232,13 @@ class Commerce extends Admin\Abstract_Settings_Screen {
 	 * @return array
 	 */
 	public function get_settings() {
+
+		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
+		$commerce_handler   = facebook_for_woocommerce()->get_commerce_handler();
+
+		if ( ! $connection_handler->is_connected() || ! $commerce_handler->is_available() ) {
+			return [ [] ];
+		}
 
 		return [
 			[


### PR DESCRIPTION
## Summary

Fixes settings display on the Instagram tab according to the current Commerce connection status and store location.

#### Story:  [CH 68652](https://app.clubhouse.io/skyverge/story/68652)
#### PR: #1669 

## UI Changes

See QA steps

## QA

### Setup

Ensure that you don't have any snippet enabling FB Commerce at the beginning of the steps below, ie.:

```php
add_filter( 'wc_facebook_commerce_is_available', '__return_true' );
add_filter( 'wc_facebook_commerce_is_connected', '__return_true' );
```

### Steps

1. Make sure your store is **disconnected from FB**
1. Remove all FB options in DB
1. Go to Marketing > Facebook > Instagram
    - [x] You should see a screen like below:
    ![Screenshot from 2020-12-11 12-41-35](https://user-images.githubusercontent.com/1227930/101863815-b4e22580-3bae-11eb-9337-41a21840ca23.png)
1. In WooCommerce > Settings, update your store location to somewhere outside the US
1. Connect with FB
    - [x] Connection is successful
1. Go to Marketing > Facebook > Instagram
    - [x] The screen should now display the following (no settings are shown):
    ![Screenshot from 2020-12-11 12-22-12](https://user-images.githubusercontent.com/1227930/101864217-f5da3a00-3bae-11eb-80d6-7a55d45ccfc5.png)
1. Update your store location to the US 
1. Go back to Marketing > Facebook > Instagram
    - [x] You should see a button to connect with Instagram:
    ![Screenshot from 2020-12-11 12-40-01](https://user-images.githubusercontent.com/1227930/101864798-a2b4b700-3baf-11eb-8c0f-262f06616d71.png)
1. Add the snippet mentioned before to force enable Commerce
    - [x] The screen would then update to the follwing, showing the category setting:
    ![Screenshot from 2020-12-11 12-40-44](https://user-images.githubusercontent.com/1227930/101864870-cb3cb100-3baf-11eb-8181-345779788cbf.png)




    
