### PR TITLE
Set request authorization header when setting a new access token

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -47,12 +47,7 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function __construct( $access_token ) {
 
-		$this->access_token = $access_token;
-
-		$this->request_headers = [
-			'Authorization' => "Bearer {$access_token}",
-		];
-
+		$this->set_access_token( $access_token );
 		$this->set_request_content_type_header( 'application/json' );
 		$this->set_request_accept_header( 'application/json' );
 	}
@@ -80,7 +75,10 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function set_access_token( $access_token ) {
 
-		$this->access_token = $access_token;
+		$this->access_token    = $access_token;
+		$this->request_headers = [
+			'Authorization' => "Bearer {$access_token}",
+		];
 	}
 
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -75,10 +75,22 @@ class API extends Framework\SV_WC_API_Base {
 	 */
 	public function set_access_token( $access_token ) {
 
-		$this->access_token    = $access_token;
-		$this->request_headers = [
-			'Authorization' => "Bearer {$access_token}",
-		];
+		$this->access_token = $access_token;
+
+		$this->set_request_authorization_header( $access_token );
+	}
+
+
+	/**
+	 * Sets the Authorization request header.
+	 *
+	 * @since 2.3.0-dev.1
+	 *
+	 * @param string $access_token the access token
+	 */
+	protected function set_request_authorization_header( $access_token ) {
+
+		$this->request_headers['Authorization'] = "Bearer {$access_token}";
 	}
 
 

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -64,6 +64,26 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see API::set_request_authorization_header() */
+	public function test_set_request_authorization_header() {
+
+		$api = new API( 'access_token' );
+
+		$property = new ReflectionProperty( $api, 'request_headers' );
+		$property->setAccessible( true );
+
+		$method = new ReflectionMethod( $api, 'set_request_authorization_header' );
+		$method->setAccessible( true );
+		$method->invokeArgs( $api, [ 'new_access_token' ] );
+
+		$request_headers = $property->getValue( $api );
+
+		$this->assertIsArray( $request_headers );
+		$this->assertArrayHasKey( 'Authorization', $request_headers );
+		$this->assertEquals( 'Bearer new_access_token', $request_headers['Authorization'] );
+	}
+
+
 	/** @see API::perform_request() */
 	public function test_do_post_parse_response_validation_retry() {
 


### PR DESCRIPTION
## Summary

Ensures the authorization header of an API request carries the current access token for the bearer.

#### Story:  [CH 66252](https://app.clubhouse.io/skyverge/story/66252)
#### PR: #1669 

## UI Changes

None

## QA

### Setup

I am not sure if I could replicate this correctly. Please check the story details.

Two API requests should be logged when you execute the scenario steps. One should be should be for the business config refresh on `init`, then one that's run by `wc_facebook_commerce_fetch_orders` in the same thread. If those are both run, then the `Bearer` in the `Authorization` header may be different because a new access token is passed: the first should be the main access token, and the second should be the page access token, which was generated when connected to Commerce.

Note that to read the `Authorization` value from the headers, you need to temporarily override `get_sanitized_request_headers()` in the `API` handler, otherwise the value will be obfuscated (default normal behavior) as sensitive information.

### Steps

1. Connect the plugin to Commerce using the Connection & orders instructions in epic [64675](https://app.clubhouse.io/skyverge/story/64675/epic-acceptance-criteria-met)
1. Go to the Scheduled Actions page
1. Delete the wc_facebook_business_configuration_refresh transient in the database
1. Manually run the wc_facebook_commerce_fetch_orders action
   - [x] You do not see the "Your connection is invalid" notice

### Tests

1. Run `codecept run integration APITest.php`
   - [x] Integration tests pass
