### PR TITLE
Enable custom retailer_id mapping for backwards compatibility

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-product-sync.css
+++ b/assets/css/admin/facebook-for-woocommerce-product-sync.css
@@ -1,0 +1,4 @@
+/** Product Sync Settings Description */
+.wc-facebook-settings table.form-table .description {
+	width: 400px;
+}

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -72,3 +72,7 @@
 .column-facebook_sync {
 	width: 11% !important;
 }
+
+.wc-facebook-settings .desc {
+	width: 400px;
+}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -104,6 +104,18 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string the hook for the recurreing action that syncs products */
 	const ACTION_HOOK_SCHEDULED_RESYNC = 'sync_all_fb_products_using_feed';
 
+	/** @var string the Facebook retailer id type setting ID */
+	const SETTING_FB_RETAILER_ID_TYPE = '_wc_facebook_retailer_id_type';
+
+	/** @var string use product SKU as the retailer ID in Facebook */
+	const FB_RETAILER_ID_TYPE_SKU = 'sku';
+
+	/** @var string use product ID as the retailer ID in Facebook */
+	const FB_RETAILER_ID_TYPE_PRODUCT_ID = 'product_id';
+
+	/** @var string use a combo of SKU and product ID as the retailer ID in Facebook */
+	const FB_RETAILER_ID_TYPE_SKU_PRODUCT_ID = 'sku_product_id';
+
 
 	/** @var string|null the configured product catalog ID */
 	public $product_catalog_id;

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -271,6 +271,22 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 			],
 
 			[
+				'id'       => \WC_Facebookcommerce_Integration::SETTING_FB_RETAILER_ID_TYPE,
+				'title'    => __( 'Product Identifier', 'facebook-for-woocommerce' ),
+				'type'     => 'select',
+				'class'    => 'product-sync-field',
+				'desc_tip' => __( 'WooCommerce product attribute mapped to retailer_id on Facebook.
+					WARNING: use with caution, as changing this option after uploading products to Facebook may
+					result in having duplicate products in your Facebook catalog.', 'facebook-for-woocommerce' ),
+				'default'  => \WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_SKU_PRODUCT_ID,
+				'options'  => [
+					\WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_SKU_PRODUCT_ID => __( 'SKU + Product ID', 'facebook-for-woocommerce' ),
+					\WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_SKU            => __( 'SKU', 'facebook-for-woocommerce' ),
+					\WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_PRODUCT_ID     => __( 'Product ID', 'facebook-for-woocommerce' ),
+				],
+			],
+
+			[
 				'id'                => \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS,
 				'title'             => __( 'Exclude categories from sync', 'facebook-for-woocommerce' ),
 				'type'              => 'multiselect',

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -63,6 +63,8 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 			return;
 		}
 
+		wp_enqueue_style( 'wc-facebook-admin-product-sync', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-product-sync.css', [], \WC_Facebookcommerce::VERSION );
+
 		wp_enqueue_script( 'wc-backbone-modal', null, [ 'backbone' ] );
 		wp_enqueue_script( 'facebook-for-woocommerce-modal', plugins_url( '/facebook-for-woocommerce/assets/js/facebook-for-woocommerce-modal.min.js' ), [ 'jquery', 'wc-backbone-modal', 'jquery-blockui' ], \WC_Facebookcommerce::PLUGIN_VERSION );
 		wp_enqueue_script( 'facebook-for-woocommerce-settings-sync', plugins_url( '/facebook-for-woocommerce/assets/js/admin/facebook-for-woocommerce-settings-sync.min.js' ), [ 'jquery', 'wc-backbone-modal', 'jquery-blockui', 'jquery-tiptip', 'facebook-for-woocommerce-modal', 'wc-enhanced-select' ], \WC_Facebookcommerce::PLUGIN_VERSION );
@@ -275,9 +277,9 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 				'title'    => __( 'Product Identifier', 'facebook-for-woocommerce' ),
 				'type'     => 'select',
 				'class'    => 'product-sync-field',
-				'desc_tip' => __( 'WooCommerce product attribute mapped to retailer_id on Facebook.
-					WARNING: use with caution, as changing this option after uploading products to Facebook may
-					result in having duplicate products in your Facebook catalog.', 'facebook-for-woocommerce' ),
+				'desc_tip' => __( 'WooCommerce product attribute mapped to retailer_id on Facebook.', 'facebook-for-woocommerce' ),
+				'desc'     => __( 'WARNING: use with caution, as changing this option after syncing products to Facebook
+					may result in having duplicate products in your Facebook catalog.', 'facebook-for-woocommerce' ),
 				'default'  => \WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_SKU_PRODUCT_ID,
 				'options'  => [
 					\WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_SKU_PRODUCT_ID => __( 'SKU + Product ID', 'facebook-for-woocommerce' ),

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -90,12 +90,25 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * @return string
 		 */
 		public static function get_fb_retailer_id( $woo_product ) {
-			$woo_id = $woo_product->get_id();
-
 			// Call $woo_product->get_id() instead of ->id to account for Variable
 			// products, which have their own variant_ids.
-			return $woo_product->get_sku() ? $woo_product->get_sku() . '_' .
-			$woo_id : self::FB_RETAILER_ID_PREFIX . $woo_id;
+			$woo_id = $woo_product->get_id();
+			$sku = $woo_product->get_sku();
+			$retailer_id = $sku ? $sku . '_' . $woo_id : self::FB_RETAILER_ID_PREFIX . $woo_id;
+
+			switch ( get_option( \WC_Facebookcommerce_Integration::SETTING_FB_RETAILER_ID_TYPE )) {
+				case \WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_SKU:
+					$retailer_id = $sku;
+					break;
+				case \WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_PRODUCT_ID:
+					$retailer_id = strval($woo_id);
+					break;
+				default:
+					// \WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_SKU_PRODUCT_ID
+					break;
+			}
+
+			return $retailer_id;
 		}
 
 		/**


### PR DESCRIPTION
Allow option to customize value used for retailer_id (sku, product_id, or sku_product_id) for compatibility with existing catalog feeds