### PR TITLE
Fix Products::get_google_product_category_id_from_highest_category() to handle WP_Error

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -583,6 +583,11 @@ class Products {
 
 			while ( $parent_category->parent !== 0 ) {
 				$parent_category = get_term( $parent_category->parent, 'product_cat' );
+
+				if ( ! $parent_category instanceof \WP_Term ) {
+					break;
+				}
+
 				$level ++;
 			}
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -581,7 +581,8 @@ class Products {
 			$level           = 0;
 			$parent_category = $category;
 
-			while ( $parent_category->parent !== 0 ) {
+			while ( (int) $parent_category->parent !== 0 ) {
+
 				$parent_category = get_term( $parent_category->parent, 'product_cat' );
 
 				if ( ! $parent_category instanceof \WP_Term ) {

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -576,6 +576,40 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
+	 * Tests that {@see Products::get_google_product_category_id_from_highest_category()} can
+	 * handle null or WP_Error return values from {@see get_term()}
+	 *
+	 * The steps below try to reproduce the scenario described in https://secure.helpscout.net/conversation/1369552988/155780/
+	 */
+	public function test_get_google_product_category_id_when_category_parent_doesnt_exists() {
+		global $wpdb;
+
+		$product = $this->get_product();
+
+		$parent_category = wp_insert_term( 'Animals & Pet Supplies', 'product_cat' );
+		$child_category  = wp_insert_term( 'Pet Supplies', 'product_cat', [ 'parent' => $parent_category['term_id'] ] );
+
+		// set the Google Product Category for the child category
+		Product_Categories::update_google_product_category_id( $child_category['term_id'], '9' );
+
+		// assign the child category to the product
+		wp_set_post_terms( $product->get_id(), [ (int) $child_category['term_id'] ], 'product_cat' );
+
+		// remove the parent category from the database to force get_term() to return null
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->term_taxonomy} WHERE term_id = %d AND taxonomy = %s", $parent_category['term_id'], 'product_cat' ) );
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->terms} WHERE term_id = %d", $parent_category['term_id'] ) );
+
+		// make sure get_term() checks the database again
+		clean_term_cache( $parent_category['term_id'], 'product_cat' );
+
+		$method = new ReflectionMethod( Products::class, 'get_google_product_category_id_from_highest_category' );
+		$method->setAccessible( true );
+
+		$this->assertSame( '9', $method->invoke( null, $product ) );
+	}
+
+
+	/**
 	 * @see \SkyVerge\WooCommerce\Facebook\Products::update_google_product_category_id()
 	 *
 	 * @param string $google_product_category_id Google product category ID

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -581,7 +581,7 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * The steps below try to reproduce the scenario described in https://secure.helpscout.net/conversation/1369552988/155780/
 	 */
-	public function test_get_google_product_category_id_when_category_parent_doesnt_exists() {
+	public function test_get_google_product_category_id_from_highest_category() {
 		global $wpdb;
 
 		$product = $this->get_product();


### PR DESCRIPTION
# Summary

Updates `Products::get_google_product_category_id_from_highest_category()` to handle `WP_Error` and `null` return types from `get_term()` to prevent the error  below:

>[Fri Dec 25 04:56:12.669488 2020] [php7:notice] [pid 1825] [client 35.189.117.91:61792] PHP Notice: Undefined property: WP_Error::$parent in /nas/content/live/example/wp-content/plugins/facebook-for-woocommerce/includes/Products.php on line 584, referer: https://www.example.com/wp-cron.php?doing_wp_cron=1608872142.7459859848022460937500

### Story: [CH 74849](https://app.clubhouse.io/skyverge/story/74849)
### Release #1720 

## QA

- [ ] Code review
- [ ] `codecept run integration` pass