### PR TITLE
Maxphi/fix for additional features error

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -673,7 +673,12 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$all_attributes = $category['attributes'];
 			foreach ( $all_attributes as $attribute ) {
 				$value            = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
-				$convert_to_array = ( true === $attribute['can_have_multiple_values'] && 'string' === $attribute['type'] );
+				$convert_to_array = (
+					isset( $attribute['can_have_multiple_values'] ) &&
+					true === $attribute['can_have_multiple_values'] &&
+					'string' === $attribute['type']
+				);
+
 				if ( ! empty( $value ) &&
 					$category_handler->is_valid_value_for_attribute( $google_category_id, $attribute['key'], $value )
 				) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -672,11 +672,14 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$category       = $category_handler->get_category_with_attrs( $google_category_id );
 			$all_attributes = $category['attributes'];
 			foreach ( $all_attributes as $attribute ) {
-				$value = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
-
+				$value            = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
+				$convert_to_array = ( true === $attribute['can_have_multiple_values'] && 'string' === $attribute['type'] );
 				if ( ! empty( $value ) &&
 					$category_handler->is_valid_value_for_attribute( $google_category_id, $attribute['key'], $value )
 				) {
+					if ( $convert_to_array ) {
+						$value = array_map( 'trim', explode( ',', $value ) );
+					}
 					$enhanced_data[ $attribute['key'] ] = $value;
 				}
 			}

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -70,6 +70,21 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 		$this->assertSame( '1234', $data['google_product_category'] );
 	}
 
+	/**
+	 * This is a regression test, used to check that we correctly set string
+	 * lists as arrays before we send them
+	 *
+	 * @see \WC_Facebook_Product::apply_enhanced_catalog_fields_from_attributes()
+	 * */
+	public function test_prepare_product_ready_for_commerce_google_product_category_with_additional_features() {
+		$product = $this->get_product_ready_for_commerce();
+		Products::update_google_product_category_id( $product, '1604' );
+		Products::update_product_enhanced_catalog_attribute( $product, 'additional_features', 'Embroidered, Nice' );
+		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product( null, \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH );
+
+		$this->assertIsArray( $data['additional_features'] );
+		$this->assertSame( array( 'Embroidered', 'Nice' ), $data['additional_features'] );
+	}
 
 	/**
 	 * @see \WC_Facebook_Product::prepare_product()


### PR DESCRIPTION
Fix to make sure that 'list of strings' params are now converted to actual arrays. This broke as Facebook became stricter about how they ingested this parameter type.

Should fix the issue raised by the user using the 'additional_features' parameter.