### PR TITLE
Fix for handling custom retailer ID on product lookup

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1304,7 +1304,17 @@ class Products {
 		if ( strpos( $fb_retailer_id, \WC_Facebookcommerce_Utils::FB_RETAILER_ID_PREFIX ) !== false ) {
 			$product_id = str_replace( \WC_Facebookcommerce_Utils::FB_RETAILER_ID_PREFIX, '', $fb_retailer_id );
 		} else {
-			$product_id = substr( $fb_retailer_id, strrpos( $fb_retailer_id, '_' ) + 1 );
+			switch ( get_option( \WC_Facebookcommerce_Integration::SETTING_FB_RETAILER_ID_TYPE )) {
+				case \WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_SKU:
+					$product_id = wc_get_product_id_by_sku( $fb_retailer_id );
+					break;
+				case \WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_PRODUCT_ID:
+					$product_id = $fb_retailer_id;
+					break;
+				default:
+					$product_id = substr( $fb_retailer_id, strrpos( $fb_retailer_id, '_' ) + 1 );
+					break;
+			}
 		}
 
 		$product = wc_get_product( $product_id );

--- a/tests/integration/Products_Test.php
+++ b/tests/integration/Products_Test.php
@@ -1244,6 +1244,39 @@ class Products_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Products::get_product_by_fb_retailer_id() */
+	public function test_get_product_by_fb_retailer_id_type_sku() {
+
+		update_option( \WC_Facebookcommerce_Integration::SETTING_FB_RETAILER_ID_TYPE, \WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_SKU );
+
+		$product = $this->get_product();
+		$product->set_sku( '123456_a' );
+		$product->save();
+
+		$retailer_id = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product );
+
+		$product_found = Facebook\Products::get_product_by_fb_retailer_id( $retailer_id );
+		$this->assertInstanceOf( \WC_Product::class, $product_found );
+		$this->assertEquals( $product->get_id(), $product_found->get_id() );
+	}
+
+
+		/** @see Products::get_product_by_fb_retailer_id() */
+	public function test_get_product_by_fb_retailer_id_type_product_id() {
+
+		update_option( \WC_Facebookcommerce_Integration::SETTING_FB_RETAILER_ID_TYPE, \WC_Facebookcommerce_Integration::FB_RETAILER_ID_TYPE_PRODUCT_ID );
+
+		$product = $this->get_product();
+		$product->set_sku( '123456_a' );
+		$product->save();
+
+		$retailer_id = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product );
+
+		$product_found = Facebook\Products::get_product_by_fb_retailer_id( $retailer_id );
+		$this->assertInstanceOf( \WC_Product::class, $product_found );
+		$this->assertEquals( $product->get_id(), $product_found->get_id() );
+	}
+
 	/** Helper methods ************************************************************************************************/
 
 


### PR DESCRIPTION
This change ensures the custom retailer ID setting is honored when lookup up the product by retailer ID