### PR TITLE
Feature/app store webhook

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -73,6 +73,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var \SkyVerge\WooCommerce\Facebook\Handlers\Connection connection handler */
 		private $connection_handler;
 
+		/** @var \SkyVerge\WooCommerce\Facebook\Handlers\WebHook webhook handler */
+		private $webhook_handler;
+
 		/** @var \SkyVerge\WooCommerce\Facebook\Integrations\Integrations integrations handler */
 		private $integrations;
 
@@ -118,6 +121,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/includes/Locale.php';
 				require_once __DIR__ . '/includes/AJAX.php';
 				require_once __DIR__ . '/includes/Handlers/Connection.php';
+				require_once __DIR__ . '/includes/Handlers/WebHook.php';
 				require_once __DIR__ . '/includes/Integrations/Integrations.php';
 				require_once __DIR__ . '/includes/Product_Categories.php';
 				require_once __DIR__ . '/includes/Products.php';
@@ -163,6 +167,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				}
 
 				$this->connection_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\Connection( $this );
+				$this->webhook_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\WebHook( $this );
 
 				// load admin handlers, before admin_init
 				if ( is_admin() ) {

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -776,7 +776,7 @@ class Connection {
 		/**
 		 * Filters App Store login URL.
 		 *
-		 * @since 2.0.0
+		 * @since 2.2.1-dev.1
 		 *
 		 * @param string $app_store_login_url the connection App Store login URL
 		 */

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -1148,7 +1148,7 @@ class Connection {
 
 		$system_user_access_token = ! empty( $values->access_token ) ? sanitize_text_field( $values->access_token ) : '';
 		$this->update_access_token( $system_user_access_token );
-		$log_data[ self::OPTION_ACCESS_TOKEN ] = $system_user_access_token;
+		$log_data[ self::OPTION_ACCESS_TOKEN ] = 'Token was saved';
 
 		if ( ! empty( $entry['uid'] ) ) {
 			$this->update_system_user_id( sanitize_text_field( $entry['uid'] ) );
@@ -1157,7 +1157,7 @@ class Connection {
 
 		$merchant_access_token = ! empty( $values->merchant_access_token ) ? sanitize_text_field( $values->merchant_access_token ) : '';
 		$this->update_merchant_access_token( $merchant_access_token );
-		$log_data[ self::OPTION_MERCHANT_ACCESS_TOKEN ] = $merchant_access_token;
+		$log_data[ self::OPTION_MERCHANT_ACCESS_TOKEN ] = 'Token was saved';
 
 		if ( ! empty( $values->install_time ) ) {
 			update_option( \WC_Facebookcommerce_Integration::OPTION_PIXEL_INSTALL_TIME, sanitize_text_field( $values->install_time ) );
@@ -1334,7 +1334,7 @@ class Connection {
 	 */
 	public function change_permissions( $permissions ) {
 
-		if ( empty( $_REQUEST['app_name'] ) || 'Facebook for WooCommerce' !== $_REQUEST['app_name'] ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( empty( $_REQUEST['app_name'] ) || 'WooCommerce Integration' !== $_REQUEST['app_name'] ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return $permissions;
 		}
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -32,6 +32,9 @@ class Connection {
 	/** @var string WooCommerce connection proxy URL */
 	const PROXY_URL = 'https://connect.woocommerce.com/auth/facebook/';
 
+	/** @var string WooCommerce connection for APP Store login URL */
+	const APP_STORE_LOGIN_URL = 'https://connect.woocommerce.com/app-store-login/facebook/';
+
 	/** @var string the Standard Auth type */
 	const AUTH_TYPE_STANDARD = 'standard';
 
@@ -764,6 +767,26 @@ class Connection {
 
 
 	/**
+	 * Gets APP Store Login URL.
+	 *
+	 * @since 2.2.1-dev.1
+	 *
+	 * @return string URL
+	 */
+	public function get_app_store_login_url() {
+
+		/**
+		 * Filters App Store login URL.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param string $app_store_login_url the connection App Store login URL
+		 */
+		return (string) apply_filters( 'wc_facebook_connection_app_store_login_url', self::APP_STORE_LOGIN_URL );
+	}
+
+
+	/**
 	 * Gets the full redirect URL where the user will return to after OAuth.
 	 *
 	 * @since 2.0.0
@@ -1321,7 +1344,7 @@ class Connection {
 
 			$redirect_url = add_query_arg(
 				$url_params,
-				'https://connect.woocommerce.com/app-store-login/facebook'
+				$this->get_app_store_login_url()
 			);
 
 		} else {

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -1279,8 +1279,7 @@ class Connection {
 
 
 	/**
-	 * Endpoint permissions
-	 * Woo Connect Bridge is sending the WebHook request using generated key.
+	 * FBE Extras endpoint permissions
 	 *
 	 * @since 2.2.1-dev.1
 	 *
@@ -1303,16 +1302,20 @@ class Connection {
 
 
 	/**
-	 * WebHook Listener
+	 * Return FBE extras
 	 *
 	 * @since 2.2.1-dev.1
-	 * @see SkyVerge\WooCommerce\Facebook\Handlers\Connection
+	 *
+	 * @return \WP_REST_Response
 	 */
 	public function extras_callback() {
 
 		$extras = $this->get_connect_parameters_extras();
+		if ( empty( $extras ) ) {
+			return new \WP_REST_Response( null, 204 );
+		}
 
-		wp_send_json( $extras );
+		return new \WP_REST_Response( $extras, 200 );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -1150,6 +1150,9 @@ class Connection {
 		);
 
 		$values = ! empty( $event[0] ) ? $event[0]->value : '';
+		if ( empty( $values ) ) {
+			return;
+		}
 
 		/**
 		 * If profiles, pages and instagram_profiles fields are not included in the Webhook payload, this means the business has uninstalled FBE.

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -41,6 +41,9 @@ class Connection {
 	/** @var string the action callback for the disconnection */
 	const ACTION_DISCONNECT = 'wc_facebook_disconnect';
 
+	/** @var string the action callback for FBE redirection */
+	const ACTION_FBE_REDIRECT = 'wc_fbe_redirect';
+
 	/** @var string the action callback for the connection */
 	const ACTION_CONNECT_COMMERCE = 'wc_facebook_connect_commerce';
 
@@ -91,6 +94,10 @@ class Connection {
 		add_action( 'woocommerce_api_' . self::ACTION_CONNECT, [ $this, 'handle_connect' ] );
 
 		add_action( 'admin_action_' . self::ACTION_DISCONNECT, [ $this, 'handle_disconnect' ] );
+
+		add_action( 'woocommerce_api_' . self::ACTION_FBE_REDIRECT, [ $this, 'handle_fbe_redirect' ] );
+
+		add_action( 'rest_api_init', array( $this, 'init_extras_endpoint' ) );
 
 		add_filter( 'woocommerce_api_permissions_in_scope', array( $this, 'change_permissions' ) );
 	}
@@ -1034,6 +1041,100 @@ class Connection {
 	public function get_plugin() {
 
 		return $this->plugin;
+	}
+
+
+	/**
+	 * Register Extras REST API endpoint
+	 */
+	public function init_extras_endpoint() {
+
+		register_rest_route(
+			'facebook/v1',
+			'extras',
+			array(
+				array(
+					'methods'             => array( 'GET', 'POST' ),
+					'callback'            => array( $this, 'extras_callback' ),
+					'permission_callback' => array( $this, 'extras_permission_callback' ),
+				),
+			)
+		);
+	}
+
+
+	/**
+	 * Endpoint permissions
+	 * Woo Connect Bridge is sending the WebHook request using generated key.
+	 *
+	 * @return boolean
+	 */
+	public function extras_permission_callback() {
+
+		add_filter( 'woocommerce_rest_is_request_to_rest_api', '__return_true' );
+
+		$user = apply_filters( 'determine_current_user', null );
+
+		remove_filter( 'woocommerce_rest_is_request_to_rest_api', '__return_true' );
+
+		if ( empty( $user ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * WebHook Listener
+	 *
+	 * @see SkyVerge\WooCommerce\Facebook\Handlers\Connection
+	 */
+	public function extras_callback() {
+
+		$extras = $this->get_connect_parameters_extras();
+
+		wp_send_json( $extras );
+	}
+
+
+	/**
+	 * Process FBE App Store login flow redirection
+	 */
+	public function handle_fbe_redirect() {
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_die( esc_html__( 'You do not have permission to finish App Store login.', 'facebook-for-woocommerce' ) );
+		}
+
+		$redirect_uri = base64_decode( $_REQUEST['redirect_uri'] ); //phpcs:ignore
+
+		// To ensure that we are not sharing any user data with other parties, only redirect to the redirect_uri if it matches the regular expression
+		if ( empty( $redirect_uri ) || ! preg_match( '/https?:\/\/(www\.|m\.|l\.)?(\d{5}\.od\.)?(facebook|instagram|whatsapp)\.com(\/.*)?/', explode( '?', $redirect_uri )[0] ) ) {
+			wp_safe_redirect( site_url() );
+			exit;
+		}
+
+		if ( empty( $_REQUEST['success'] ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			$url_params = [
+				'store_url'    => '',
+				'redirect_uri' => rawurlencode( $redirect_uri ),
+				'errors'       => [ 'You need to grant access to Facebook.' ],
+			];
+
+			$redirect_url = add_query_arg(
+				$url_params,
+				'https://connect.woocommerce.com/app-store-login/facebook'
+			);
+
+		} else {
+
+			$redirect_url = $redirect_uri . '&extras=' . rawurlencode_deep( wp_json_encode( $this->get_connect_parameters_extras() ) );
+		}
+
+		wp_redirect( $redirect_url ); //phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+		exit;
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -115,8 +115,6 @@ class Connection {
 		add_action( 'fbe_webhook', array( $this, 'fbe_install_webhook' ) );
 
 		add_action( 'rest_api_init', array( $this, 'init_extras_endpoint' ) );
-
-		add_filter( 'woocommerce_api_permissions_in_scope', array( $this, 'change_permissions' ) );
 	}
 
 
@@ -1357,25 +1355,5 @@ class Connection {
 
 		wp_redirect( $redirect_url ); //phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		exit;
-	}
-
-
-	/**
-	 * Return WC Auth permissions
-	 *
-	 * @since 2.2.1-dev.1
-	 *
-	 * @param array $permissions Permissions.
-	 * @return array
-	 */
-	public function change_permissions( $permissions ) {
-
-		if ( empty( $_REQUEST['app_name'] ) || 'WooCommerce Integration' !== $_REQUEST['app_name'] ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return $permissions;
-		}
-
-		$permissions[] = __( 'Update FBE Installation data', 'facebook-for-wordpress' );
-
-		return $permissions;
 	}
 }

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -948,7 +948,7 @@ class Connection {
 	/**
 	 * Stores the given Instagram Business ID.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param string $id the ID
 	 */
@@ -961,7 +961,7 @@ class Connection {
 	/**
 	 * Stores the given Commerce merchant settings ID.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param string $id the ID
 	 */
@@ -1089,6 +1089,7 @@ class Connection {
 	/**
 	 * Process WebHook User object, install field
 	 *
+	 * @since 2.2.1-dev.1
 	 * @link https://developers.facebook.com/docs/marketing-api/fbe/fbe2/guides/get-features#webhook
 	 *
 	 * @param object $data WebHook event data.
@@ -1234,6 +1235,8 @@ class Connection {
 
 	/**
 	 * Register Extras REST API endpoint
+	 *
+	 * @since 2.2.1-dev.1
 	 */
 	public function init_extras_endpoint() {
 
@@ -1254,6 +1257,8 @@ class Connection {
 	/**
 	 * Endpoint permissions
 	 * Woo Connect Bridge is sending the WebHook request using generated key.
+	 *
+	 * @since 2.2.1-dev.1
 	 *
 	 * @return boolean
 	 */
@@ -1276,6 +1281,7 @@ class Connection {
 	/**
 	 * WebHook Listener
 	 *
+	 * @since 2.2.1-dev.1
 	 * @see SkyVerge\WooCommerce\Facebook\Handlers\Connection
 	 */
 	public function extras_callback() {
@@ -1288,6 +1294,8 @@ class Connection {
 
 	/**
 	 * Process FBE App Store login flow redirection
+	 *
+	 * @since 2.2.1-dev.1
 	 */
 	public function handle_fbe_redirect() {
 
@@ -1328,6 +1336,8 @@ class Connection {
 
 	/**
 	 * Return WC Auth permissions
+	 *
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param array $permissions Permissions.
 	 * @return array

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -91,6 +91,8 @@ class Connection {
 		add_action( 'woocommerce_api_' . self::ACTION_CONNECT, [ $this, 'handle_connect' ] );
 
 		add_action( 'admin_action_' . self::ACTION_DISCONNECT, [ $this, 'handle_disconnect' ] );
+
+		add_filter( 'woocommerce_api_permissions_in_scope', array( $this, 'change_permissions' ) );
 	}
 
 
@@ -1035,4 +1037,20 @@ class Connection {
 	}
 
 
+	/**
+	 * Return WC Auth permissions
+	 *
+	 * @param array $permissions Permissions.
+	 * @return array
+	 */
+	public function change_permissions( $permissions ) {
+
+		if ( empty( $_REQUEST['app_name'] ) || 'Facebook for WooCommerce' !== $_REQUEST['app_name'] ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return $permissions;
+		}
+
+		return array(
+			__( 'Update FBE Installation data', 'facebook-for-wordpress' ),
+		);
+	}
 }

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -1338,8 +1338,8 @@ class Connection {
 			return $permissions;
 		}
 
-		return array(
-			__( 'Update FBE Installation data', 'facebook-for-wordpress' ),
-		);
+		$permissions[] = __( 'Update FBE Installation data', 'facebook-for-wordpress' );
+
+		return $permissions;
 	}
 }

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -71,6 +71,18 @@ class Connection {
 	/** @var string the Commerce manager ID option name */
 	const OPTION_COMMERCE_MANAGER_ID = 'wc_facebook_commerce_manager_id';
 
+	/** @var string webhook event subscribed object */
+	const WEBHOOK_SUBSCRIBED_OBJECT = 'user';
+
+	/** @var string webhook event subscribed field */
+	const WEBHOOK_SUBSCRIBED_FIELD = 'fbe_install';
+
+	/** @var string the Instagram business ID option name */
+	const OPTION_INSTAGRAM_BUSINESS_ID = 'wc_facebook_instagram_business_id';
+
+	/** @var string the Commerce merchant settings ID option name */
+	const OPTION_COMMERCE_MERCHANT_SETTINGS_ID = 'wc_facebook_commerce_merchant_settings_id';
+
 	/** @var string|null the generated external merchant settings ID */
 	private $external_business_id;
 
@@ -96,6 +108,8 @@ class Connection {
 		add_action( 'admin_action_' . self::ACTION_DISCONNECT, [ $this, 'handle_disconnect' ] );
 
 		add_action( 'woocommerce_api_' . self::ACTION_FBE_REDIRECT, [ $this, 'handle_fbe_redirect' ] );
+
+		add_action( 'fbe_webhook', array( $this, 'fbe_install_webhook' ) );
 
 		add_action( 'rest_api_init', array( $this, 'init_extras_endpoint' ) );
 
@@ -348,6 +362,8 @@ class Connection {
 		$this->update_system_user_id( '' );
 		$this->update_business_manager_id( '' );
 		$this->update_ad_account_id( '' );
+		$this->update_instagram_business_id( '' );
+		$this->update_commerce_merchant_settings_id( '' );
 
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
@@ -930,6 +946,32 @@ class Connection {
 
 
 	/**
+	 * Stores the given Instagram Business ID.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param string $id the ID
+	 */
+	public function update_instagram_business_id( $id ) {
+
+		update_option( self::OPTION_INSTAGRAM_BUSINESS_ID, $id );
+	}
+
+
+	/**
+	 * Stores the given Commerce merchant settings ID.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param string $id the ID
+	 */
+	public function update_commerce_merchant_settings_id( $id ) {
+
+		update_option( self::OPTION_COMMERCE_MERCHANT_SETTINGS_ID, $id );
+	}
+
+
+	/**
 	 * Stores the given token value.
 	 *
 	 * @since 2.0.0
@@ -1041,6 +1083,152 @@ class Connection {
 	public function get_plugin() {
 
 		return $this->plugin;
+	}
+
+
+	/**
+	 * Process WebHook User object, install field
+	 *
+	 * @link https://developers.facebook.com/docs/marketing-api/fbe/fbe2/guides/get-features#webhook
+	 *
+	 * @param object $data WebHook event data.
+	 */
+	public function fbe_install_webhook( $data ) {
+
+		// Reject other objects other than subscribed object
+		if ( empty( $data ) || ! isset( $data->object ) || self::WEBHOOK_SUBSCRIBED_OBJECT !== $data->object ) {
+
+			if ( $this->get_plugin()->get_integration()->is_debug_mode_enabled() ) {
+				$this->get_plugin()->log( 'Wrong (or empty) WebHook Event received' );
+				$this->get_plugin()->log( print_r( $data, true ) ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+			}
+
+			return;
+		}
+
+		$log_data = array();
+		if ( $this->get_plugin()->get_integration()->is_debug_mode_enabled() ) {
+			$this->get_plugin()->log( 'WebHook User Event received' );
+			$this->get_plugin()->log( print_r( $data, true ) ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		}
+
+		$entry = (array) $data->entry[0];
+		if ( empty( $entry ) ) {
+			return;
+		}
+
+		// Filter event by subscribed field
+		$event = array_filter(
+			$entry['changes'],
+			function( $change ) {
+				return self::WEBHOOK_SUBSCRIBED_FIELD === $change->field;
+			}
+		);
+
+		$values = ! empty( $event[0] ) ? $event[0]->value : '';
+
+		/**
+		 * If profiles, pages and instagram_profiles fields are not included in the Webhook payload, this means the business has uninstalled FBE.
+		 * In this case also the field access_token will not be included.
+		 *
+		 * @link https://developers.facebook.com/docs/marketing-api/fbe/fbe2/guides/get-features#what-s-included-with-webhooks-
+		 */
+		if ( empty( $values->access_token ) ) {
+
+			delete_option( 'wc_facebook_has_connected_fbe_2' );
+			delete_option( 'wc_facebook_has_authorized_pages_read_engagement' );
+
+			$this->disconnect();
+
+			return;
+		}
+
+		update_option( 'wc_facebook_has_connected_fbe_2', 'yes' );
+		update_option( 'wc_facebook_has_authorized_pages_read_engagement', 'yes' );
+
+		$system_user_access_token = ! empty( $values->access_token ) ? sanitize_text_field( $values->access_token ) : '';
+		$this->update_access_token( $system_user_access_token );
+		$log_data[ self::OPTION_ACCESS_TOKEN ] = $system_user_access_token;
+
+		if ( ! empty( $entry['uid'] ) ) {
+			$this->update_system_user_id( sanitize_text_field( $entry['uid'] ) );
+			$log_data[ self::OPTION_SYSTEM_USER_ID ] = sanitize_text_field( $entry['uid'] );
+		}
+
+		$merchant_access_token = ! empty( $values->merchant_access_token ) ? sanitize_text_field( $values->merchant_access_token ) : '';
+		$this->update_merchant_access_token( $merchant_access_token );
+		$log_data[ self::OPTION_MERCHANT_ACCESS_TOKEN ] = $merchant_access_token;
+
+		if ( ! empty( $values->install_time ) ) {
+			update_option( \WC_Facebookcommerce_Integration::OPTION_PIXEL_INSTALL_TIME, sanitize_text_field( $values->install_time ) );
+			$log_data[ \WC_Facebookcommerce_Integration::OPTION_PIXEL_INSTALL_TIME ] = sanitize_text_field( $values->install_time );
+		}
+
+		if ( ! empty( $values->business_id ) ) {
+			update_option( self::OPTION_EXTERNAL_BUSINESS_ID, sanitize_text_field( $values->business_id ) );
+			$log_data[ self::OPTION_EXTERNAL_BUSINESS_ID ] = sanitize_text_field( $values->business_id );
+		}
+
+		if ( ! empty( $values->pixel_id ) ) {
+			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, sanitize_text_field( $values->pixel_id ) );
+			$log_data[ \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID ] = sanitize_text_field( $values->pixel_id );
+		}
+
+		if ( ! empty( $values->catalog_id ) ) {
+			update_option( \WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, sanitize_text_field( $values->catalog_id ) );
+			$log_data[ \WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID ] = sanitize_text_field( $values->catalog_id );
+		}
+
+		if ( ! empty( $values->business_manager_id ) ) {
+			$this->update_business_manager_id( sanitize_text_field( $values->business_manager_id ) );
+			$log_data[ self::OPTION_BUSINESS_MANAGER_ID ] = sanitize_text_field( $values->business_manager_id );
+		}
+
+		if ( ! empty( $values->ad_account_id ) ) {
+			$this->update_ad_account_id( sanitize_text_field( $values->ad_account_id ) );
+			$log_data[ self::OPTION_AD_ACCOUNT_ID ] = sanitize_text_field( $values->ad_account_id );
+		}
+
+		if ( ! empty( $values->instagram_profiles ) ) {
+
+			$instagram_business_id = current( $values->instagram_profiles );
+
+			$this->update_instagram_business_id( sanitize_text_field( $instagram_business_id ) );
+			$log_data[ self::OPTION_INSTAGRAM_BUSINESS_ID ] = sanitize_text_field( $instagram_business_id );
+		}
+
+		if ( ! empty( $values->commerce_merchant_settings_id ) ) {
+			$this->update_commerce_merchant_settings_id( sanitize_text_field( $values->commerce_merchant_settings_id ) );
+			$log_data[ self::OPTION_COMMERCE_MERCHANT_SETTINGS_ID ] = sanitize_text_field( $values->commerce_merchant_settings_id );
+		}
+
+		if ( ! empty( $values->pages ) ) {
+
+			$page_id = current( $values->pages );
+
+			try {
+
+				update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $page_id ) );
+				$log_data[ \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID ] = sanitize_text_field( $page_id );
+
+				// get and store a current access token for the configured page
+				$page_access_token = $this->retrieve_page_access_token( $page_id );
+
+				$this->update_page_access_token( $page_access_token );
+				$log_data[ self::OPTION_PAGE_ACCESS_TOKEN ] = sanitize_text_field( $page_access_token );
+
+			} catch ( \Exception $e ) {
+
+				if ( $this->get_plugin()->get_integration()->is_debug_mode_enabled() ) {
+					$this->get_plugin()->log( 'Could not request Page Token: ' . $e->getMessage() );
+				}
+			}
+		}//end if
+
+		if ( $this->get_plugin()->get_integration()->is_debug_mode_enabled() ) {
+			$this->get_plugin()->log( 'WebHook User event saved data' );
+			$this->get_plugin()->log( print_r( $log_data, true ) ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		}
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -1265,7 +1265,7 @@ class Connection {
 	public function init_extras_endpoint() {
 
 		register_rest_route(
-			'facebook/v1',
+			'wc-facebook/v1',
 			'extras',
 			array(
 				array(
@@ -1287,17 +1287,7 @@ class Connection {
 	 */
 	public function extras_permission_callback() {
 
-		add_filter( 'woocommerce_rest_is_request_to_rest_api', '__return_true' );
-
-		$user = apply_filters( 'determine_current_user', null );
-
-		remove_filter( 'woocommerce_rest_is_request_to_rest_api', '__return_true' );
-
-		if ( empty( $user ) ) {
-			return false;
-		}
-
-		return true;
+		return current_user_can( 'manage_woocommerce' );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -1308,7 +1308,7 @@ class Connection {
 			$url_params = [
 				'store_url'    => '',
 				'redirect_uri' => rawurlencode( $redirect_uri ),
-				'errors'       => [ 'You need to grant access to Facebook.' ],
+				'errors'       => [ 'You need to grant access to WooCommerce.' ],
 			];
 
 			$redirect_url = add_query_arg(

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -91,16 +91,19 @@ class WebHook {
 	 * @see SkyVerge\WooCommerce\Facebook\Handlers\Connection
 	 *
 	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response
 	 */
 	public function webhook_callback( \WP_REST_Request $request ) {
 
 		$request_body = json_decode( $request->get_body() );
+
 		if ( empty( $request_body ) ) {
+			return new \WP_REST_Response( null, 204 );
 			wp_send_json_error( null, 204 );
 		}
 
 		do_action( 'fbe_webhook', $request_body );
 
-		wp_send_json_success();
+		return new \WP_REST_Response( null, 200 );
 	}
 }

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -16,9 +16,9 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper;
 defined( 'ABSPATH' ) or exit;
 
 /**
- * The connection handler.
+ * The WebHook handler.
  *
- * @since 2.0.0
+ * @since 2.2.1-dev.1
  */
 class WebHook {
 

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -46,7 +46,7 @@ class WebHook {
 	public function init_webhook_endpoint() {
 
 		register_rest_route(
-			'facebook/v1',
+			'wc-facebook/v1',
 			'webhook',
 			array(
 				array(
@@ -69,17 +69,7 @@ class WebHook {
 	 */
 	public function permission_callback() {
 
-		add_filter( 'woocommerce_rest_is_request_to_rest_api', '__return_true' );
-
-		$user = apply_filters( 'determine_current_user', null );
-
-		remove_filter( 'woocommerce_rest_is_request_to_rest_api', '__return_true' );
-
-		if ( empty( $user ) ) {
-			return false;
-		}
-
-		return true;
+		return current_user_can( 'manage_woocommerce' );
 	}
 
 

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -30,7 +30,7 @@ class WebHook {
 	 *
 	 * @param \WC_Facebookcommerce $plugin Plugin instance.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 */
 	public function __construct( \WC_Facebookcommerce $plugin ) {
 
@@ -41,7 +41,7 @@ class WebHook {
 	/**
 	 * Register WebHook REST API endpoint
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 */
 	public function init_webhook_endpoint() {
 
@@ -62,6 +62,8 @@ class WebHook {
 	/**
 	 * Endpoint permissions
 	 * Woo Connect Bridge is sending the WebHook request using generated key.
+	 *
+	 * @since 2.2.1-dev.1
 	 *
 	 * @return boolean
 	 */
@@ -84,6 +86,7 @@ class WebHook {
 	/**
 	 * WebHook Listener
 	 *
+	 * @since 2.2.1-dev.1
 	 * @see SkyVerge\WooCommerce\Facebook\Handlers\Connection
 	 */
 	public function webhook_callback() {

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -85,6 +85,7 @@ class WebHook {
 
 	/**
 	 * WebHook Listener
+	 * Send a JSON response back to Woo Connect Bridge.
 	 *
 	 * @since 2.2.1-dev.1
 	 * @see SkyVerge\WooCommerce\Facebook\Handlers\Connection
@@ -93,31 +94,13 @@ class WebHook {
 	 */
 	public function webhook_callback( \WP_REST_Request $request ) {
 
-		$request_body = $this->parse_body( $request );
+		$request_body = json_decode( $request->get_body() );
 		if ( empty( $request_body ) ) {
-			return;
+			wp_send_json_error( null, 204 );
 		}
 
-		do_action( 'fbe_webhook', json_decode( file_get_contents( 'php://input' ) ) );
-	}
+		do_action( 'fbe_webhook', $request_body );
 
-
-	/**
-	 * Return request's body parsed
-	 *
-	 * @since 2.2.1-dev.1
-	 *
-	 * @param \WP_REST_Request $request The request.
-	 * @return array
-	 */
-	protected function parse_body( \WP_REST_Request $request ) {
-
-		$body = $request->get_body();
-
-		// "Sanitize" JSON object (trim object, remove tabs)
-		$body = trim( preg_replace( '/\t+/', '', $body ) );
-
-		// Transform JSON into a PHP array
-		return json_decode( $body, true );
+		wp_send_json_success();
 	}
 }

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -88,9 +88,36 @@ class WebHook {
 	 *
 	 * @since 2.2.1-dev.1
 	 * @see SkyVerge\WooCommerce\Facebook\Handlers\Connection
+	 *
+	 * @param \WP_REST_Request $request The request.
 	 */
-	public function webhook_callback() {
+	public function webhook_callback( \WP_REST_Request $request ) {
+
+		$request_body = $this->parse_body( $request );
+		if ( empty( $request_body ) ) {
+			return;
+		}
 
 		do_action( 'fbe_webhook', json_decode( file_get_contents( 'php://input' ) ) );
+	}
+
+
+	/**
+	 * Return request's body parsed
+	 *
+	 * @since 2.2.1-dev.1
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return array
+	 */
+	protected function parse_body( \WP_REST_Request $request ) {
+
+		$body = $request->get_body();
+
+		// "Sanitize" JSON object (trim object, remove tabs)
+		$body = trim( preg_replace( '/\t+/', '', $body ) );
+
+		// Transform JSON into a PHP array
+		return json_decode( $body, true );
 	}
 }

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Handlers;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_API_Exception;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * The connection handler.
+ *
+ * @since 2.0.0
+ */
+class WebHook {
+
+	/** @var string auth page ID */
+	const WEBHOOK_PAGE_ID = 'wc-facebook-webhook';
+
+	/**
+	 * Constructs a new WebHook.
+	 *
+	 * @param \WC_Facebookcommerce $plugin Plugin instance.
+	 *
+	 * @since 2.1.5
+	 */
+	public function __construct( \WC_Facebookcommerce $plugin ) {
+
+		add_action( 'rest_api_init', array( $this, 'init_webhook_endpoint' ) );
+	}
+
+
+	/**
+	 * Register WebHook REST API endpoint
+	 *
+	 * @since 2.1.5
+	 */
+	public function init_webhook_endpoint() {
+
+		register_rest_route(
+			'facebook/v1',
+			'webhook',
+			array(
+				array(
+					'methods'             => array( 'GET', 'POST' ),
+					'callback'            => array( $this, 'webhook_callback' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+			)
+		);
+	}
+
+
+	/**
+	 * Endpoint permissions
+	 * Woo Connect Bridge is sending the WebHook request using generated key.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+
+		add_filter( 'woocommerce_rest_is_request_to_rest_api', '__return_true' );
+
+		$user = apply_filters( 'determine_current_user', null );
+
+		remove_filter( 'woocommerce_rest_is_request_to_rest_api', '__return_true' );
+
+		if ( empty( $user ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * WebHook Listener
+	 *
+	 * @see SkyVerge\WooCommerce\Facebook\Handlers\Connection
+	 */
+	public function webhook_callback() {
+
+		do_action( 'fbe_webhook', json_decode( file_get_contents( 'php://input' ) ) );
+	}
+}

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -75,7 +75,6 @@ class WebHook {
 
 	/**
 	 * WebHook Listener
-	 * Send a JSON response back to Woo Connect Bridge.
 	 *
 	 * @since 2.2.1-dev.1
 	 * @see SkyVerge\WooCommerce\Facebook\Handlers\Connection
@@ -89,7 +88,6 @@ class WebHook {
 
 		if ( empty( $request_body ) ) {
 			return new \WP_REST_Response( null, 204 );
-			wp_send_json_error( null, 204 );
 		}
 
 		do_action( 'fbe_webhook', $request_body );


### PR DESCRIPTION
## Summary
Add endpoints to cover App Store login flows.
Add WebHook action and methods to update FBE data using WebHook events.

## Note
Test's last step depends on Connect Bridge to be live.

## UI Changes
N/A

## QA
### Setup:
- Install Facebook for WooCommerce from this PR.

### Steps:
1. Browse this page after replacing {PAGE_ID} with your Facebook Page ID:
https://connectbridge.ngrok.io/app-store-login/facebook/?redirect_uri=https%3A%2F%2Fwww.facebook.com%2Flocal%2Fdev%2Ftransaction_tool_selector%2Fredirect%3Fapp_id%3D474166926521348%26app_name%3DWooCommerce%2BIntegration%26page_id%3D{PAGE_ID}
2. Connect Bridge will ask for your Store URL. Provide your Store URL and press connect.
3. Grant access to your site.
4. Browse Admin > Marketing > Facebook to see if you are connected.
