### PR TITLE
Feature/product set

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-product-sets-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-product-sets-admin.css
@@ -1,0 +1,8 @@
+body.taxonomy-fb_product_set .term-parent-wrap,
+body.taxonomy-fb_product_set .term-slug-wrap {
+	display: none;
+}
+
+.wc-facebook.product_cats.select2.visible {
+	display: block;
+}

--- a/assets/css/admin/facebook-for-woocommerce-product-sets-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-product-sets-admin.css
@@ -6,3 +6,11 @@ body.taxonomy-fb_product_set .term-slug-wrap {
 .wc-facebook.product_cats.select2.visible {
 	display: block;
 }
+
+body.taxonomy-fb_product_set .select2-container {
+	display: table;
+	margin-bottom: 0;
+	position: relative;
+	table-layout: fixed;
+	width: 95% !important;
+}

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -1,3 +1,7 @@
+#newfb_product_set_parent {
+	display: none;
+}
+
 #woocommerce-product-data .fb-product-image-source-field .wc-radios {
 	width: auto;
 }

--- a/assets/js/admin/facebook-for-woocommerce-product-sets-admin.js
+++ b/assets/js/admin/facebook-for-woocommerce-product-sets-admin.js
@@ -9,7 +9,23 @@
 
 jQuery( document ).ready( function( $ ) {
 
-	jQuery( '.select2.wc-facebook' ).select2().addClass( 'visible' ).attr( 'disabled', false );
-	jQuery( '.select2.updating-message' ).addClass( 'hidden' );
+	if ( jQuery( '.select2.wc-facebook' ).length ) {
+		wcFacebookProductSetInit();
+	}
+
+	function wcFacebookProductSetInit() {
+
+		jQuery( '.select2.wc-facebook' ).select2().addClass( 'visible' ).attr( 'disabled', false );
+		jQuery( '.select2.updating-message' ).addClass( 'hidden' );
+
+		jQuery( document ).ajaxSuccess( function( e, request, settings ) {
+			var obj = new URLSearchParams( settings.data )
+			if ( obj.has( 'action' ) && 'add-tag' === obj.get( 'action' ) && obj.has( 'taxonomy' ) && 'fb_product_set' === obj.get( 'taxonomy' ) ) {
+	console.log('YEAH');
+				jQuery( '.select2.wc-facebook' ).select2().val( null ).trigger( 'change' );
+			}
+	    });
+
+	}
 
 } );

--- a/assets/js/admin/facebook-for-woocommerce-product-sets-admin.js
+++ b/assets/js/admin/facebook-for-woocommerce-product-sets-admin.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+jQuery( document ).ready( function( $ ) {
+
+	jQuery( '.select2.wc-facebook' ).select2().addClass( 'visible' ).attr( 'disabled', false );
+	jQuery( '.select2.updating-message' ).addClass( 'hidden' );
+
+} );

--- a/assets/js/admin/facebook-for-woocommerce-product-sets-admin.js
+++ b/assets/js/admin/facebook-for-woocommerce-product-sets-admin.js
@@ -21,7 +21,6 @@ jQuery( document ).ready( function( $ ) {
 		jQuery( document ).ajaxSuccess( function( e, request, settings ) {
 			var obj = new URLSearchParams( settings.data )
 			if ( obj.has( 'action' ) && 'add-tag' === obj.get( 'action' ) && obj.has( 'taxonomy' ) && 'fb_product_set' === obj.get( 'taxonomy' ) ) {
-	console.log('YEAH');
 				jQuery( '.select2.wc-facebook' ).select2().val( null ).trigger( 'change' );
 			}
 	    });

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -114,6 +114,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 			add_action( 'init', [ $this, 'get_integration' ] );
 			add_action( 'init', [ $this, 'register_custom_taxonomy' ] );
+			add_action( 'add_meta_boxes_product' , [ $this, 'remove_product_fb_product_set_metabox' ], 50 );
 			add_filter( 'fb_product_set_row_actions', [ $this, 'product_set_links' ] );
 			add_filter( 'manage_edit-fb_product_set_columns', [ $this, 'manage_fb_product_set_columns' ] );
 
@@ -380,6 +381,15 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			}
 
 			parent::log_api_request( $request, $response, $log_id );
+		}
+
+		/**
+		 * Remove Product Set metabox from Product edit page
+		 *
+		 * @since 2.2.1-dev.1
+		 */
+		public function remove_product_fb_product_set_metabox() {
+			remove_meta_box( 'fb_product_setdiv', 'product', 'side' );
 		}
 
 		/**

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -33,6 +33,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var string the integration ID */
 		const INTEGRATION_ID = 'facebookcommerce';
 
+		/** @var string the product set categories meta name */
+		const PRODUCT_SET_META = 'wc_product_cats';
+
 
 		/** @var \WC_Facebookcommerce singleton instance */
 		protected static $instance;
@@ -69,6 +72,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 		/** @var \SkyVerge\WooCommerce\Facebook\Products\Sync\Background background sync handler */
 		private $sync_background_handler;
+
+		/** @var \SkyVerge\WooCommerce\Facebook\ProductSets\Sync product sets sync handler */
+		private $product_sets_sync_handler;
 
 		/** @var \SkyVerge\WooCommerce\Facebook\Handlers\Connection connection handler */
 		private $connection_handler;
@@ -127,6 +133,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/includes/Products/Stock.php';
 				require_once __DIR__ . '/includes/Products/Sync.php';
 				require_once __DIR__ . '/includes/Products/Sync/Background.php';
+				require_once __DIR__ . '/includes/ProductSets/Sync.php';
 				require_once __DIR__ . '/includes/fbproductfeed.php';
 				require_once __DIR__ . '/facebook-commerce-messenger-chat.php';
 				require_once __DIR__ . '/includes/Commerce.php';
@@ -135,12 +142,13 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/includes/Events/AAMSettings.php';
 				require_once __DIR__ . '/includes/Utilities/Shipment.php';
 
-				$this->product_feed            = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
-				$this->products_stock_handler  = new \SkyVerge\WooCommerce\Facebook\Products\Stock();
-				$this->products_sync_handler   = new \SkyVerge\WooCommerce\Facebook\Products\Sync();
-				$this->sync_background_handler = new \SkyVerge\WooCommerce\Facebook\Products\Sync\Background();
-				$this->commerce_handler        = new \SkyVerge\WooCommerce\Facebook\Commerce();
-				$this->fb_categories 					 = new \SkyVerge\WooCommerce\Facebook\Products\FBCategories();
+				$this->product_feed              = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
+				$this->products_stock_handler    = new \SkyVerge\WooCommerce\Facebook\Products\Stock();
+				$this->products_sync_handler     = new \SkyVerge\WooCommerce\Facebook\Products\Sync();
+				$this->sync_background_handler   = new \SkyVerge\WooCommerce\Facebook\Products\Sync\Background();
+				$this->product_sets_sync_handler = new \SkyVerge\WooCommerce\Facebook\ProductSets\Sync();
+				$this->commerce_handler          = new \SkyVerge\WooCommerce\Facebook\Commerce();
+				$this->fb_categories             = new \SkyVerge\WooCommerce\Facebook\Products\FBCategories();
 
 				if ( is_ajax() ) {
 					$this->ajax = new \SkyVerge\WooCommerce\Facebook\AJAX();
@@ -172,6 +180,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 					require_once __DIR__ . '/includes/Admin/Abstract_Settings_Screen.php';
 					require_once __DIR__ . '/includes/Admin/Settings_Screens/Connection.php';
 					require_once __DIR__ . '/includes/Admin/Settings_Screens/Product_Sync.php';
+					require_once __DIR__ . '/includes/Admin/Settings_Screens/Product_Sets.php';
 					require_once __DIR__ . '/includes/Admin/Settings_Screens/Messenger.php';
 					require_once __DIR__ . '/includes/Admin/Settings_Screens/Advertise.php';
 					require_once __DIR__ . '/includes/Admin/Google_Product_Category_Field.php';

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		const INTEGRATION_ID = 'facebookcommerce';
 
 		/** @var string the product set categories meta name */
-		const PRODUCT_SET_META = 'wc_product_cats';
+		const PRODUCT_SET_META = '_wc_facebook_product_cats';
 
 
 		/** @var \WC_Facebookcommerce singleton instance */

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -114,6 +114,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 			add_action( 'init', [ $this, 'get_integration' ] );
 			add_action( 'init', [ $this, 'register_custom_taxonomy' ] );
+			add_filter( 'fb_product_set_row_actions', [ $this, 'product_set_links' ] );
 			add_filter( 'manage_edit-fb_product_set_columns', [ $this, 'manage_fb_product_set_columns' ] );
 
 			// Product Set breadcrumb filters
@@ -417,6 +418,22 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			);
 
 			register_taxonomy( 'fb_product_set', array( 'product' ), $args );
+		}
+
+
+		/**
+		 * Filter FB Product Set Taxonomy table links
+		 *
+		 * @since 2.1.5
+		 *
+		 * @param array $actions Item Actions.
+		 *
+		 * @return array
+		 */
+		public function product_set_links( $actions ) {
+			unset( $actions['inline hide-if-no-js'] );
+			unset( $actions['view'] );
+			return $actions;
 		}
 
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -107,6 +107,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		public function init() {
 
 			add_action( 'init', [ $this, 'get_integration' ] );
+			add_action( 'init', [ $this, 'register_custom_taxonomy' ] );
 
 			if ( \WC_Facebookcommerce_Utils::isWoocommerceIntegration() ) {
 
@@ -364,6 +365,42 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			}
 
 			parent::log_api_request( $request, $response, $log_id );
+		}
+
+		/**
+		 * Register FB Product Set Taxonomy
+		 *
+		 * @since 2.1.5
+		 */
+		public function register_custom_taxonomy() {
+
+			$plural   = esc_html__( 'FB Product Sets', 'facebook-for-woocommerce' );
+			$singular = esc_html__( 'FB Product Set', 'facebook-for-woocommerce' );
+
+			$args = array(
+				'labels'            => array(
+					'name'                       => $plural,
+					'singular_name'              => $singular,
+					'menu_name'                  => $plural,
+					// translators: Add new label
+					'add_new_item'               => sprintf( esc_html__( 'Add new %s', 'facebook-for-woocommerce' ), $singular ),
+					'menu_name'                  => $plural,
+					// translators: No items found text
+					'not_found'                  => sprintf( esc_html__( 'No %s found.', 'facebook-for-woocommerce' ), $plural ),
+					// translators: Search label
+					'search_items'               => sprintf( esc_html__( 'Search %s.', 'facebook-for-woocommerce' ), $plural ),
+					// translators: Text label
+					'separate_items_with_commas' => sprintf( esc_html__( 'Separate %s with commas', 'facebook-for-woocommerce' ), $plural ),
+					// translators: Text label
+					'choose_from_most_used'      => sprintf( esc_html__( 'Choose from the most used %s', 'facebook-for-woocommerce' ), $plural ),
+				),
+				'hierarchical'      => true,
+				'public'            => true,
+				'show_in_nav_menus' => false,
+				'show_tagcloud'     => false,
+			);
+
+			register_taxonomy( 'fb_product_set', array( 'product' ), $args );
 		}
 
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -395,7 +395,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Register FB Product Set Taxonomy
 		 *
-		 * @since 2.1.5
+		 * @since 2.2.1-dev.1
 		 */
 		public function register_custom_taxonomy() {
 
@@ -434,7 +434,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Filter FB Product Set Taxonomy table links
 		 *
-		 * @since 2.1.5
+		 * @since 2.2.1-dev.1
 		 *
 		 * @param array $actions Item Actions.
 		 *
@@ -450,7 +450,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Remove posts count column from FB Product Set custom taxonomy
 		 *
-		 * @since 2.1.5
+		 * @since 2.2.1-dev.1
 		 *
 		 * @param array $columns Taxonomy columns.
 		 *
@@ -465,7 +465,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Filter WC Breadcrumbs when the page is FB Product Sets
 		 *
-		 * @since 2.1.5
+		 * @since 2.2.1-dev.1
 		 *
 		 * @param array $breadcrumbs Page breadcrumbs.
 		 *
@@ -497,7 +497,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Return that FB Product Set page is a WC Conected Page
 		 *
-		 * @since 2.1.5
+		 * @since 2.2.1-dev.1
 		 *
 		 * @param boolean $is_conected If it's connected or not.
 		 *
@@ -1011,7 +1011,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Return current page ID
 		 *
-		 * @since 2.1.5
+		 * @since 2.2.1-dev.1
 		 *
 		 * @return string
 		 */

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -114,6 +114,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 			add_action( 'init', [ $this, 'get_integration' ] );
 			add_action( 'init', [ $this, 'register_custom_taxonomy' ] );
+			add_filter( 'manage_edit-fb_product_set_columns', [ $this, 'manage_fb_product_set_columns' ] );
 
 			// Product Set breadcrumb filters
 			add_filter( 'woocommerce_navigation_is_connected_page', [ $this, 'is_current_page_conected_filter' ], 99, 2 );
@@ -416,6 +417,21 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			);
 
 			register_taxonomy( 'fb_product_set', array( 'product' ), $args );
+		}
+
+
+		/**
+		 * Remove posts count column from FB Product Set custom taxonomy
+		 *
+		 * @since 2.1.5
+		 *
+		 * @param array $columns Taxonomy columns.
+		 *
+		 * @return array
+		 */
+		public function manage_fb_product_set_columns( $columns ) {
+			unset( $columns['posts'] );
+			return $columns;
 		}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1629,7 +1629,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Create or update product set
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param array $product_set_data Product Set data.
 	 * @param int   $product_set_id   Product Set Term Id.
@@ -1674,7 +1674,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Delete product set
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param int $fb_product_set_id Facebook Product Set ID.
 	 **/

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -101,7 +101,7 @@ class Admin {
 	/**
 	 * Change custom taxonomy tip text
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param string $translation Text translation.
 	 * @param string $text Original text.

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -54,8 +54,10 @@ class Admin {
 
 		require_once __DIR__ . '/Admin/Products.php';
 		require_once __DIR__ . '/Admin/Product_Categories.php';
+		require_once __DIR__ . '/Admin/Product_Sets.php';
 
 		$this->product_categories = new Admin\Product_Categories();
+		$this->product_sets = new Admin\Product_Sets();
 
 		// add a modal in admin product pages
 		add_action( 'admin_footer', array( $this, 'render_modal_template' ) );
@@ -144,7 +146,11 @@ class Admin {
 
 			if ( 'edit-fb_product_set' === $current_screen->id ) {
 
+				// enqueue WooCommerce Admin Styles because of Select2
+				wp_enqueue_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), \WC_Facebookcommerce::PLUGIN_VERSION );
 				wp_enqueue_style( 'facebook-for-woocommerce-product-sets-admin', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-product-sets-admin.css', array(), \WC_Facebookcommerce::PLUGIN_VERSION );
+
+				wp_enqueue_script( 'facebook-for-woocommerce-product-sets', facebook_for_woocommerce()->get_plugin_url() . '/assets/js/admin/facebook-for-woocommerce-product-sets-admin.js', array( 'jquery', 'select2' ), \WC_Facebookcommerce::PLUGIN_VERSION, true );
 			}
 
 			if ( 'product' === $current_screen->id || 'edit-product' === $current_screen->id ) {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -91,8 +91,31 @@ class Admin {
 		// add Variation edit fields
 		add_action( 'woocommerce_product_after_variable_attributes', array( $this, 'add_product_variation_edit_fields' ), 10, 3 );
 		add_action( 'woocommerce_save_product_variation', array( $this, 'save_product_variation_edit_fields' ), 10, 2 );
+
+		// add custom taxonomy for Product Sets
+		add_filter( 'gettext', array( $this, 'change_custom_taxonomy_tip' ), 20, 2 );
 	}
 
+	/**
+	 * Change custom taxonomy tip text
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param string $translation Text translation.
+	 * @param string $text Original text.
+	 *
+	 * @return string
+	 */
+	public function change_custom_taxonomy_tip( $translation, $text ) {
+
+		global $current_screen;
+
+		if ( isset( $current_screen->id ) && 'edit-fb_product_set' === $current_screen->id && 'The name is how it appears on your site.' === $text ) {
+			$translation = esc_html__( 'The name is how it appears on Facebook Catalog.', 'facebook-for-woocommerce' );
+		}
+
+		return $translation;
+	}
 
 	/**
 	 * Enqueues admin scripts.
@@ -117,6 +140,11 @@ class Admin {
 
 				// enqueue modal functions
 				wp_enqueue_script( 'facebook-for-woocommerce-modal', facebook_for_woocommerce()->get_plugin_url() . '/assets/js/facebook-for-woocommerce-modal.min.js', array( 'jquery', 'wc-backbone-modal', 'jquery-blockui' ), \WC_Facebookcommerce::PLUGIN_VERSION );
+			}
+
+			if ( 'edit-fb_product_set' === $current_screen->id ) {
+
+				wp_enqueue_style( 'facebook-for-woocommerce-product-sets-admin', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-product-sets-admin.css', array(), \WC_Facebookcommerce::PLUGIN_VERSION );
 			}
 
 			if ( 'product' === $current_screen->id || 'edit-product' === $current_screen->id ) {

--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Admin;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
+
+/**
+ * General handler for the product set admin functionality.
+ *
+ * @since 2.1.5
+ */
+class Product_Sets {
+
+	/**
+	 * Allowed HTML for wp_kses
+	 *
+	 * @since 2.1.5
+	 *
+	 * @var array
+	 */
+	protected $allowed_html = array(
+		'label' => array(
+			'for' => array(),
+		),
+		'input' => array(
+			'type' => array(),
+			'name' => array(),
+			'id'   => array(),
+		),
+		'p'     => array(
+			'class' => array(),
+		),
+	);
+
+	/**
+	 * Categories field name
+	 *
+	 * @since 2.1.5
+	 *
+	 * @var string
+	 */
+	protected $categories_field = 'wc_product_cats';
+
+	/**
+	 * Handler constructor.
+	 *
+	 * @since 2.1.5
+	 */
+	public function __construct() {
+
+		// add taxonomy custom field
+		add_action( 'fb_product_set_add_form_fields', array( $this, 'category_field_on_new' ) );
+		add_action( 'fb_product_set_edit_form', array( $this, 'category_field_on_edit' ) );
+
+		// save custom field data
+		add_action( 'created_fb_product_set', array( $this, 'save_custom_field' ), 10, 2 );
+		add_action( 'edited_fb_product_set', array( $this, 'save_custom_field' ), 10, 2 );
+	}
+
+	/**
+	 * Add field to FB Product Set new term
+	 *
+	 * @since 2.1.5
+	 */
+	public function category_field_on_new() {
+		?>
+		<div class="form-field">
+			<?php echo wp_kses( $this->get_field_label(), $this->allowed_html ); ?>
+			<?php echo wp_kses( $this->get_field(), $this->allowed_html ); ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Add field to FB Product Set new term
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param WP_Term $term Term object.
+	 */
+	public function category_field_on_edit( $term ) {
+
+		// gets term id
+		$term_id = empty( $term->term_id ) ? '' : $term->term_id;
+
+		?>
+		<table class="form-table" role="presentation">
+			<tbody>
+				<tr class="form-field product-categories-wrap">
+					<th scope="row"><?php echo wp_kses( $this->get_field_label(), $this->allowed_html ); ?></th>
+					<td><?php echo wp_kses( $this->get_field( $term_id ), $this->allowed_html ); ?></td>
+				</tr>
+			</tbody>
+		</table>
+
+		<?php
+	}
+
+	/**
+	 * Saves custom field data
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param int $term_id Term ID.
+	 * @param int $tt_id Term taxonomy ID.
+	 */
+	public function save_custom_field( $term_id, $tt_id ) {
+
+		$wc_product_cats_temp = empty( $_POST[ $this->categories_field ] ) ? '' : $_POST[ $this->categories_field ]; //phpcs:ignore
+		if ( ! empty( $wc_product_cats_temp ) ) {
+
+			$wc_product_cats = array_map(
+				function( $item ) {
+					return absint( $item );
+				},
+				$wc_product_cats_temp
+			);
+
+			update_term_meta( $term_id, $this->categories_field, $wc_product_cats );
+		}
+	}
+
+	/**
+	 * Return field label HTML
+	 *
+	 * @since 2.1.5
+	 */
+	protected function get_field_label() {
+		?>
+		<label for="<?php echo esc_attr( $this->categories_field ); ?>"><?php echo esc_html__( 'WC Product Categories', 'facebook-for-woocommerce' ); ?></label>
+		<?php
+	}
+
+	/**
+	 * Return field HTML
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param int $term_id The Term ID that is editing.
+	 */
+	protected function get_field( $term_id = '' ) {
+
+		$saved_items = get_term_meta( $term_id, $this->categories_field, true );
+
+		// gets Product Cats that has Google Category set
+		$product_cats_args = array(
+			'hide_empty' => 0,
+			'meta_query' => array(
+				array(
+					'key'     => \SkyVerge\WooCommerce\Facebook\Products::GOOGLE_PRODUCT_CATEGORY_META_KEY,
+					'compare' => 'EXISTS',
+				),
+			),
+		);
+		$product_cats      = get_terms( 'product_cat', $product_cats_args );
+
+		?>
+		<div class="select2 updating-message"><p></p></div>
+		<select
+		id="<?php echo esc_attr( $this->categories_field ); ?>"
+		name="<?php echo esc_attr( $this->categories_field ); ?>[]"
+		multiple="multiple"
+		disabled="disabled"
+		class="select2 wc-facebook product_cats"
+		style="display:none;max-width: 25em;width: 540px"
+		>
+		<?php foreach ( $product_cats as $product_cat ) : ?>
+			<?php $selected = ( is_array( $saved_items ) && in_array( $product_cat->term_id, $saved_items, true ) ) ? ' selected="selected"' : ''; ?>
+			<option value="<?php echo esc_attr( $product_cat->term_id ); ?>" <?php echo esc_attr( $selected ); ?>><?php echo esc_attr( $product_cat->name ); ?></option>
+		<?php endforeach; ?>
+		<select>
+		<p class="description"><?php echo esc_html__( 'Map FB Product Set to WC Product Categories', 'facebook-for-woocommerce' ); ?>.</p>
+		<?php
+	}
+}

--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -19,14 +19,14 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 /**
  * General handler for the product set admin functionality.
  *
- * @since 2.1.5
+ * @since 2.2.1-dev.1
  */
 class Product_Sets {
 
 	/**
 	 * Allowed HTML for wp_kses
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @var array
 	 */
@@ -47,7 +47,7 @@ class Product_Sets {
 	/**
 	 * Categories field name
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @var string
 	 */
@@ -57,7 +57,7 @@ class Product_Sets {
 	/**
 	 * Handler constructor.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 */
 	public function __construct() {
 
@@ -76,7 +76,7 @@ class Product_Sets {
 	/**
 	 * Add field to FB Product Set new term
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 */
 	public function category_field_on_new() {
 		?>
@@ -91,7 +91,7 @@ class Product_Sets {
 	/**
 	 * Add field to FB Product Set new term
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param WP_Term $term Term object.
 	 */
@@ -117,7 +117,7 @@ class Product_Sets {
 	/**
 	 * Saves custom field data
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param int $term_id Term ID.
 	 * @param int $tt_id Term taxonomy ID.
@@ -142,7 +142,7 @@ class Product_Sets {
 	/**
 	 * Return field label HTML
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 */
 	protected function get_field_label() {
 		?>
@@ -154,7 +154,7 @@ class Product_Sets {
 	/**
 	 * Return field HTML
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param int $term_id The Term ID that is editing.
 	 */

--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -10,7 +10,9 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Admin;
 
-defined( 'ABSPATH' ) or exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 use SkyVerge\WooCommerce\PluginFramework\v5_5_4 as Framework;
 
@@ -49,7 +51,8 @@ class Product_Sets {
 	 *
 	 * @var string
 	 */
-	protected $categories_field = 'wc_product_cats';
+	protected $categories_field = '';
+
 
 	/**
 	 * Handler constructor.
@@ -57,6 +60,8 @@ class Product_Sets {
 	 * @since 2.1.5
 	 */
 	public function __construct() {
+
+		$this->categories_field = \WC_Facebookcommerce::PRODUCT_SET_META;
 
 		// add taxonomy custom field
 		add_action( 'fb_product_set_add_form_fields', array( $this, 'category_field_on_new' ) );
@@ -66,6 +71,7 @@ class Product_Sets {
 		add_action( 'created_fb_product_set', array( $this, 'save_custom_field' ), 10, 2 );
 		add_action( 'edited_fb_product_set', array( $this, 'save_custom_field' ), 10, 2 );
 	}
+
 
 	/**
 	 * Add field to FB Product Set new term
@@ -80,6 +86,7 @@ class Product_Sets {
 		</div>
 		<?php
 	}
+
 
 	/**
 	 * Add field to FB Product Set new term
@@ -106,6 +113,7 @@ class Product_Sets {
 		<?php
 	}
 
+
 	/**
 	 * Saves custom field data
 	 *
@@ -116,19 +124,20 @@ class Product_Sets {
 	 */
 	public function save_custom_field( $term_id, $tt_id ) {
 
-		$wc_product_cats_temp = empty( $_POST[ $this->categories_field ] ) ? '' : $_POST[ $this->categories_field ]; //phpcs:ignore
-		if ( ! empty( $wc_product_cats_temp ) ) {
+		$wc_product_cats = empty( $_POST[ $this->categories_field ] ) ? '' : $_POST[ $this->categories_field ]; //phpcs:ignore
+		if ( ! empty( $wc_product_cats ) ) {
 
 			$wc_product_cats = array_map(
 				function( $item ) {
 					return absint( $item );
 				},
-				$wc_product_cats_temp
+				$wc_product_cats
 			);
-
-			update_term_meta( $term_id, $this->categories_field, $wc_product_cats );
 		}
+
+		update_term_meta( $term_id, $this->categories_field, $wc_product_cats );
 	}
+
 
 	/**
 	 * Return field label HTML
@@ -140,6 +149,7 @@ class Product_Sets {
 		<label for="<?php echo esc_attr( $this->categories_field ); ?>"><?php echo esc_html__( 'WC Product Categories', 'facebook-for-woocommerce' ); ?></label>
 		<?php
 	}
+
 
 	/**
 	 * Return field HTML

--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -160,19 +160,8 @@ class Product_Sets {
 	 */
 	protected function get_field( $term_id = '' ) {
 
-		$saved_items = get_term_meta( $term_id, $this->categories_field, true );
-
-		// gets Product Cats that has Google Category set
-		$product_cats_args = array(
-			'hide_empty' => 0,
-			'meta_query' => array(
-				array(
-					'key'     => \SkyVerge\WooCommerce\Facebook\Products::GOOGLE_PRODUCT_CATEGORY_META_KEY,
-					'compare' => 'EXISTS',
-				),
-			),
-		);
-		$product_cats      = get_terms( 'product_cat', $product_cats_args );
+		$saved_items  = get_term_meta( $term_id, $this->categories_field, true );
+		$product_cats = get_terms( 'product_cat', array( 'hide_empty' => 0 ) );
 
 		?>
 		<div class="select2 updating-message"><p></p></div>

--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -171,7 +171,7 @@ class Product_Sets {
 		multiple="multiple"
 		disabled="disabled"
 		class="select2 wc-facebook product_cats"
-		style="display:none;max-width: 25em;width: 540px"
+		style="display:none;"
 		>
 		<?php foreach ( $product_cats as $product_cat ) : ?>
 			<?php $selected = ( is_array( $saved_items ) && in_array( $product_cat->term_id, $saved_items, true ) ) ? ' selected="selected"' : ''; ?>

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -41,6 +41,7 @@ class Settings {
 		$this->screens = array(
 			Settings_Screens\Connection::ID   => new Settings_Screens\Connection(),
 			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
+			Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 			Settings_Screens\Messenger::ID    => new Settings_Screens\Messenger(),
 			Settings_Screens\Advertise::ID    => new Settings_Screens\Advertise(),
 		);

--- a/includes/Admin/Settings_Screens/Product_Sets.php
+++ b/includes/Admin/Settings_Screens/Product_Sets.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Admin\Settings_Screens;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Facebook\Admin;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_4\SV_WC_Helper;
+
+/**
+ * The Product sets redirect object.
+ */
+class Product_Sets extends Admin\Abstract_Settings_Screen {
+
+
+	/** @var string screen ID */
+	const ID = 'product_sets';
+
+	/**
+	 * Connection constructor.
+	 */
+	public function __construct() {
+
+		$this->id    = self::ID;
+		$this->label = __( 'Product Sets', 'facebook-for-woocommerce' );
+		$this->title = __( 'Product Sets', 'facebook-for-woocommerce' );
+	}
+
+	public function render() {
+		wp_safe_redirect( admin_url( 'edit-tags.php?taxonomy=fb_product_set&post_type=product' ) );
+		exit;
+	}
+
+	public function get_settings() {}
+}

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -1,0 +1,382 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\ProductSets;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The product set sync handler.
+ *
+ * @since 2.1.5
+ */
+class Sync {
+
+
+	/**
+	 * Prefix used with the product IDs
+	 *
+	 * @var string
+	 */
+	const PRODUCT_INDEX_PREFIX = 'wc_post_id_';
+
+	/**
+	 * Update action name
+	 *
+	 * @var string
+	 */
+	const ACTION_UPDATE = 'UPDATE';
+
+	/**
+	 * Delete action name
+	 *
+	 * @var string
+	 */
+	const ACTION_DELETE = 'DELETE';
+
+	/**
+	 * Requests array for sync schedule
+	 *
+	 * @var array
+	 */
+	protected $requests = array();
+
+	/**
+	 * Product's Category Previous List
+	 *
+	 * @since 2.1.5
+	 *
+	 * @var array
+	 */
+	protected static $prev_product_cat = array();
+
+	/**
+	 * Product's Category New List
+	 *
+	 * @since 2.1.5
+	 *
+	 * @var array
+	 */
+	protected static $new_product_cat = array();
+
+	/**
+	 * Product's Product Set Previous List
+	 *
+	 * @since 2.1.5
+	 *
+	 * @var array
+	 */
+	protected static $prev_product_set = array();
+
+	/**
+	 * Product's Product Set New List
+	 *
+	 * @since 2.1.5
+	 *
+	 * @var array
+	 */
+	protected static $new_product_set = array();
+
+	/**
+	 * Categories field name
+	 *
+	 * @since 2.1.5
+	 *
+	 * @var string
+	 */
+	protected $categories_field = '';
+
+
+	/**
+	 * Sync constructor.
+	 *
+	 * @since 2.1.5
+	 */
+	public function __construct() {
+
+		$this->categories_field = \WC_Facebookcommerce::PRODUCT_SET_META;
+
+		$this->add_hooks();
+	}
+
+
+	/**
+	 * Adds needed hooks to support product set sync.
+	 *
+	 * @since 2.1.5
+	 */
+	public function add_hooks() {
+
+		// product hooks, compare taxonomies the lists before and after saving product to see if must sync
+		add_filter( 'wp_insert_post_data', array( $this, 'filter_product_data' ), 99, 2 );
+		add_action( 'save_post', array( $this, 'maybe_sync_product_sets' ), 99, 2 );
+
+		// product set hooks, compare taxonomies the lists before and after saving product to see if must sync
+		add_action( 'created_fb_product_set', array( $this, 'fb_product_set_hook_before' ), 1 );
+		add_action( 'created_fb_product_set', array( $this, 'fb_product_set_hook_after' ), 99 );
+		add_action( 'edited_fb_product_set', array( $this, 'fb_product_set_hook_before' ), 1 );
+		add_action( 'edited_fb_product_set', array( $this, 'fb_product_set_hook_after' ), 99 );
+
+		// product cat and product set delete hooks, remove or check if must remove any product set
+		add_action( 'pre_delete_term', array( $this, 'sync_remove_product_set' ), 1, 2 );
+		add_action( 'delete_product_cat', array( $this, 'maybe_sync_product_set_on_product_cat_remove' ), 99 );
+	}
+
+
+	/** Hook methods *******************************************************************************************/
+
+
+	/**
+	 * Stores the list of categories and product set of a product to compare later on 'save_post' hook.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param array $data Post Data.
+	 * @param array $post Post.
+	 */
+	public function filter_product_data( $data, $post ) {
+
+		// gets product's current categories IDs
+		if ( 'product' === $post['post_type'] ) {
+			self::$prev_product_cat = wc_get_product_cat_ids( $post['ID'] );
+			self::$prev_product_set = wc_get_product_term_ids( $post['ID'], 'fb_product_set' );
+		}
+
+		return $data;
+	}
+
+
+	/**
+	 * Stores the list of categories and product set of a product to compare with the previous and check if must sync
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post Post Object.
+	 */
+	public function maybe_sync_product_sets( $post_id, $post ) {
+
+		if ( 'product' !== $post->post_type ) {
+			return;
+		}
+
+		// gets product's new categories IDs to compare if there are differences to sync
+		self::$new_product_cat = wc_get_product_cat_ids( $post_id );
+		self::$new_product_set = wc_get_product_term_ids( $post_id, 'fb_product_set' );
+
+		// get differences
+		$product_cat_diffs = $this->get_all_diff( 'product_cat' );
+		$product_set_diffs = $this->get_all_diff( 'product_set' );
+		if ( ! $product_cat_diffs && ! $product_set_diffs ) {
+			return;
+		}
+
+		// will search products that belongs to these terms
+		if ( empty( $product_set_diffs ) || ! is_array( $product_set_diffs ) ) {
+			$product_set_diffs = array();
+		}
+		$product_set_term_ids = array_merge( array(), $product_set_diffs );
+
+		// check if product cat belongs to a product_set
+		foreach ( $product_cat_diffs as $product_cat_id ) {
+
+			$product_sets = $this->get_product_cat_sets( $product_cat_id );
+			if ( ! empty( $product_sets ) ) {
+				$product_set_term_ids = array_merge( $product_set_term_ids, $product_sets );
+			}
+		}
+
+		foreach ( $product_set_term_ids as $product_set_id ) {
+			$this->maybe_sync_product_set( $product_set_id );
+		}
+	}
+
+
+	/**
+	 * Stores the list of categories of a product set to compare later.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param int $term_id Term ID.
+	 */
+	public function fb_product_set_hook_before( $term_id ) {
+		self::$prev_product_cat = get_term_meta( $term_id, $this->categories_field, true );
+	}
+
+
+	/**
+	 * Stores the list of categories of a product set to compare with the previous and check if must sync
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param int $term_id Term ID.
+	 */
+	public function fb_product_set_hook_after( $term_id ) {
+		self::$new_product_cat = get_term_meta( $term_id, $this->categories_field, true );
+		if ( ! empty( $this->get_all_diff( 'product_cat' ) ) ) {
+			$this->maybe_sync_product_set( $term_id );
+		}
+	}
+
+
+	/**
+	 * Check if must sync Product Set from FB when removing Product Cat
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param int $term_id Product Cat Term ID.
+	 */
+	public function maybe_sync_product_set_on_product_cat_remove( $term_id ) {
+
+		$product_sets = $this->get_product_cat_sets( $term_id );
+		if ( empty( $product_sets ) ) {
+			return;
+		}
+
+		foreach ( $product_sets as $product_set_id ) {
+			$this->maybe_sync_product_set( $product_set_id );
+		}
+	}
+
+
+	/**
+	 * Call API to remove Product Set from FB
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param int $product_set_term_id Product Set Term ID.
+	 */
+	public function sync_remove_product_set( $product_set_term_id, $taxonomy ) {
+
+		if ( 'fb_product_set' !== $taxonomy ) {
+			return;
+		}
+
+		// get product set FB ID
+		$fb_product_set_id = get_term_meta( $product_set_term_id, \WC_Facebookcommerce_Integration::FB_PRODUCT_SET_ID, true );
+		if ( empty( $fb_product_set_id ) ) {
+			return;
+		}
+
+		do_action( 'fb_wc_product_set_delete', $fb_product_set_id );
+	}
+
+
+	/** Utility methods *******************************************************************************************/
+
+
+	/**
+	 * Maybe sync product set
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param int $product_set_id FB Product Set Term ID.
+	 */
+	public function maybe_sync_product_set( $product_set_id ) {
+
+		// get Product Set
+		$term = get_term( $product_set_id );
+		if ( empty( $term ) ) {
+			return;
+		}
+
+		// get categories
+		$product_cat_ids = get_term_meta( $product_set_id, $this->categories_field, true );
+
+		// get products for the taxonomies
+		$products      = array();
+		$products_args = array(
+			'fields'         => 'ids',
+			'post_type'      => 'product',
+			'posts_per_page' => -1,
+			'tax_query'      => array(
+				'relation' => 'OR',
+				array(
+					'taxonomy' => 'fb_product_set',
+					'field'    => 'term_taxonomy_id',
+					'terms'    => array( $product_set_id ),
+					'operator' => 'IN',
+				),
+				array(
+					'taxonomy' => 'product_cat',
+					'field'    => 'term_taxonomy_id',
+					'terms'    => $product_cat_ids,
+					'operator' => 'IN',
+				),
+			),
+		);
+		$product_ids   = get_posts( $products_args );
+
+		// formats filter value
+		foreach ( $product_ids as $product_id ) {
+			array_push(
+				$products,
+				array( 'retailer_id' => array( 'eq' => self::PRODUCT_INDEX_PREFIX . $product_id ) )
+			);
+		}
+		$data = array(
+			'name'   => $term->name,
+			'filter' => wp_json_encode( array( 'or' => $products ) ),
+		);
+
+		do_action( 'fb_wc_product_set_sync', $data, $product_set_id );
+	}
+
+
+	/**
+	 * Return the list of product sets of a given product category term
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param string $product_cat_id product cat Term ID.
+	 *
+	 * @return array
+	 */
+	protected function get_product_cat_sets( $product_cat_id ) {
+
+		$args = array(
+			'fields'     => 'ids',
+			'taxonomy'   => 'fb_product_set',
+			'hide_empty' => false,
+			'meta_query' => array(
+				array(
+					'key'     => 'wc_product_cats',
+					'value'   => sprintf( ':%d;', $product_cat_id ),
+					'compare' => 'LIKE',
+				),
+			),
+		);
+		return get_terms( $args );
+	}
+
+	/**
+	 * Return the list of differences between two list of terms
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param string $taxonomy Taxonomy slug.
+	 *
+	 * @return array
+	 */
+	protected function get_all_diff( $taxonomy = 'product_cat' ) {
+
+		$prev = empty( self::${ 'prev_' . $taxonomy } ) ? array() : self::${ 'prev_' . $taxonomy };
+		$new  = empty( self::${ 'new_' . $taxonomy } ) ? array() : self::${ 'new_' . $taxonomy };
+
+		$removed = array_diff( $prev, $new );
+		$added   = array_diff( $new, $prev );
+
+		return array_merge( $removed, $added );
+	}
+
+
+}

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -118,10 +118,11 @@ class Sync {
 
 		// product hooks, compare taxonomies the lists before and after saving product to see if must sync
 		add_filter( 'wp_insert_post_data', array( $this, 'check_product_data_before_save' ), 99, 2 );
-		add_action( 'save_post', array( $this, 'check_product_data_after_save' ), 99, 2 );//maybe_sync_product_sets
+		add_action( 'save_post', array( $this, 'check_product_data_after_save' ), 99, 2 );
 
 		// product hooks, sync product's product set when deleting or restoring product
 		add_action( 'trashed_post', array( $this, 'sync_product_product_sets' ), 99 );
+		add_action( 'before_delete_post', array( $this, 'sync_product_product_sets' ), 99 );
 		add_action( 'untrashed_post', array( $this, 'sync_product_product_sets' ), 99 );
 
 		// product set hooks, compare taxonomies the lists before and after saving product to see if must sync

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -353,7 +353,6 @@ class Sync {
 		$product_ids   = get_posts( $products_args );
 
 		if ( empty( $product_ids ) ) {
-error_log( 'NO PRODUCTS, WILL REMOVE' );
 			$fb_product_set_id = get_term_meta( $product_set_id, \WC_Facebookcommerce_Integration::FB_PRODUCT_SET_ID, true );
 			update_term_meta( $product_set_id, \WC_Facebookcommerce_Integration::FB_PRODUCT_SET_ID, '' );
 			do_action( 'fb_wc_product_set_delete', $fb_product_set_id );

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * The product set sync handler.
  *
- * @since 2.1.5
+ * @since 2.2.1-dev.1
  */
 class Sync {
 
@@ -46,7 +46,7 @@ class Sync {
 	/**
 	 * Product's Category Previous List
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @var array
 	 */
@@ -55,7 +55,7 @@ class Sync {
 	/**
 	 * Product's Category New List
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @var array
 	 */
@@ -64,7 +64,7 @@ class Sync {
 	/**
 	 * Product's Product Set Previous List
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @var array
 	 */
@@ -73,7 +73,7 @@ class Sync {
 	/**
 	 * Product's Product Set New List
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @var array
 	 */
@@ -82,7 +82,7 @@ class Sync {
 	/**
 	 * Categories field name
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @var string
 	 */
@@ -92,7 +92,7 @@ class Sync {
 	/**
 	 * Sync constructor.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 */
 	public function __construct() {
 
@@ -105,7 +105,7 @@ class Sync {
 	/**
 	 * Adds needed hooks to support product set sync.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 */
 	public function add_hooks() {
 
@@ -136,7 +136,7 @@ class Sync {
 	/**
 	 * Stores the list of categories and product set of a product to compare later on 'save_post' hook.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param array $data Post Data.
 	 * @param array $post Post.
@@ -174,7 +174,7 @@ class Sync {
 	/**
 	 * Stores the list of categories and product set of a product to compare with the previous
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param int     $post_id Post ID.
 	 * @param WP_Post $post Post Object.
@@ -203,7 +203,7 @@ class Sync {
 	/**
 	 * Check if must sync Product Sets from given lists
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param array $product_cats Product Category Term IDs.
 	 * @param array $product_sets Product Set Term IDs.
@@ -233,7 +233,7 @@ class Sync {
 	/**
 	 * Stores the list of categories of a product set to compare later.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param int $term_id Term ID.
 	 */
@@ -245,7 +245,7 @@ class Sync {
 	/**
 	 * Stores the list of categories of a product set to compare with the previous and check if must sync
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param int $term_id Term ID.
 	 */
@@ -260,7 +260,7 @@ class Sync {
 	/**
 	 * Check if must sync Product Set from FB when removing Product Cat
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param int $term_id Product Cat Term ID.
 	 */
@@ -280,7 +280,7 @@ class Sync {
 	/**
 	 * Call API to remove Product Set from FB
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param int $product_set_term_id Product Set Term ID.
 	 */
@@ -306,7 +306,7 @@ class Sync {
 	/**
 	 * Maybe sync product set
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param int $product_set_id FB Product Set Term ID.
 	 */
@@ -394,7 +394,7 @@ class Sync {
 	/**
 	 * Return the list of product sets of a given product category term
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param string $product_cat_id product cat Term ID.
 	 *
@@ -420,7 +420,7 @@ class Sync {
 	/**
 	 * Return the list of differences between two list of terms
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param string $taxonomy Taxonomy slug.
 	 *

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -408,7 +408,7 @@ class Sync {
 			'hide_empty' => false,
 			'meta_query' => array(
 				array(
-					'key'     => 'wc_product_cats',
+					'key'     => \WC_Facebookcommerce::PRODUCT_SET_META,
 					'value'   => sprintf( ':%d;', $product_cat_id ),
 					'compare' => 'LIKE',
 				),

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -23,13 +23,6 @@ class Sync {
 
 
 	/**
-	 * Prefix used with the product IDs
-	 *
-	 * @var string
-	 */
-	const PRODUCT_INDEX_PREFIX = 'wc_post_id_';
-
-	/**
 	 * Update action name
 	 *
 	 * @var string
@@ -368,9 +361,13 @@ class Sync {
 
 		// formats filter value
 		foreach ( $product_ids as $product_id ) {
+
+			$product        = new \WC_Product( $product_id );
+			$fb_retailer_id = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product );
+
 			array_push(
 				$products,
-				array( 'retailer_id' => array( 'eq' => self::PRODUCT_INDEX_PREFIX . $product_id ) )
+				array( 'retailer_id' => array( 'eq' => $fb_retailer_id ) )
 			);
 		}
 		$data = array(

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -316,6 +316,13 @@ class Sync {
 		);
 		$product_ids   = get_posts( $products_args );
 
+		// gets products variations
+		global $wpdb;
+		$variation_ids = $wpdb->get_results( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = 'product_variation' AND post_parent IN (%s) ", implode( ',', $product_ids ) ) );
+		if ( ! empty( $variation_ids ) ) {
+			$product_ids = array_merge( $product_ids, wp_list_pluck( $variation_ids, 'ID' ) );
+		}
+
 		// formats filter value
 		foreach ( $product_ids as $product_id ) {
 			array_push(

--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -394,6 +394,19 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 			return self::_delete( $product_group_url );
 		}
 
+		// POST https://graph.facebook.com/vX.X/{product-catalog-id}/product_sets
+		public function create_product_set_item( $product_catalog_id, $data ) {
+			$url = $this->build_url( $product_catalog_id, '/product_sets', '8.0' );
+			return self::_post( $url, $data );
+		}
+
+		// POST https://graph.facebook.com/vX.X/{product-set-id}
+		public function update_product_set_item( $product_set_id, $data ) {
+			$url = $this->build_url( $product_set_id, '', '8.0' );
+			return self::_post( $url, $data );
+		}
+
+
 		public function log( $ems_id, $message, $error ) {
 			$log_url = $this->build_url( $ems_id, '/log_events' );
 

--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -160,8 +160,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 				'timeout' => self::CURL_TIMEOUT,
 			];
 
-			$fbasync = new WC_Facebookcommerce_Async_Request();
 
+			$fbasync = new WC_Facebookcommerce_Async_Request();
 			$fbasync->query_url  = $url;
 			$fbasync->query_args = array();
 			$fbasync->post_args  = $request_args;
@@ -568,10 +568,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 			return self::_post( $url, $data );
 		}
 
-		private function build_url( $field_id, $param = '' ) {
-			return self::GRAPH_API_URL . (string) $field_id . $param;
+		private function build_url( $field_id, $param = '', $api_version = '' ) {
+			$api_url = self::GRAPH_API_URL;
+			if ( ! empty( $api_version ) ) {
+				$api_url = str_replace( '2.9', str_replace( 'v', '', trim( $api_version ) ), $api_url );
+			}
+			return $api_url . (string) $field_id . $param;
 		}
-
 	}
 
 endif;

--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -406,6 +406,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 			return self::_post( $url, $data );
 		}
 
+		public function delete_product_set_item( $product_set_id ) {
+			$url = $this->build_url( $product_set_id, '', '8.0' );
+			return self::_delete( $url );
+		}
+
 
 		public function log( $ems_id, $message, $error ) {
 			$log_url = $this->build_url( $ems_id, '/log_events' );


### PR DESCRIPTION
## Summary
Implement Facebook Product Sets as a product taxonomy.
The user must setup each FB Product Set one or more product categories.

## UI Changes
Product Sets tab added to Marketing > Facebook
The tab open FB Product Set taxonomy.

<img width="944" alt="Screen Shot 2021-02-10 at 21 15 42" src="https://user-images.githubusercontent.com/66959731/107589624-2b1dfb00-6be5-11eb-9cec-da33e968e739.png">

 
## QA
### Setup:
Install Facebook for WooCommerce from this PR.

### Steps:
- Browse Marketing > Facebook > Product Sets
- Create a new Product Set and assign one or more *WC Product Categories*
- Browse your Facebook Catalog.
- The _Product Sets_ you'll create in WooCommerce will be in your Facebook Catalog, under *Sets*.