### PR TITLE
Fix Products::get_ordered_categories_for_product() to handle WP_Error

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -677,6 +677,11 @@ class Products {
 			while ( (int) $parent_category->parent !== 0 ) {
 
 				$parent_category = get_term( $parent_category->parent, 'product_cat' );
+
+				if ( ! $parent_category instanceof \WP_Term ) {
+					break;
+				}
+
 				$level ++;
 			}
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -674,7 +674,8 @@ class Products {
 			$level           = 0;
 			$parent_category = $category;
 
-			while ( $parent_category->parent !== 0 ) {
+			while ( (int) $parent_category->parent !== 0 ) {
+
 				$parent_category = get_term( $parent_category->parent, 'product_cat' );
 				$level ++;
 			}


### PR DESCRIPTION
This is a follow up PR for #1745 to fix the same error in another method that uses an identical `foreach` loop.

# Summary

Updates `Products::get_ordered_categories_for_product()` to handle `WP_Error` and `null` return types from `get_term()` to prevent the error  below:

>Thu Jan 28 12:43:02.972673 2021] [php7:notice] [pid 5491] [client 35.189.117.91:26368] PHP Notice: Undefined property: WP_Error::$parent in /nas/content/live/imediastores2/wp-content/plugins/facebook-for-woocommerce/includes/Products.php on line 677, referer: https://www.imediastores.com/wp-admin/admin-ajax.php?action=wc_facebook_background_product_sync&nonce=c115a04ae6

### Story: [CH 74849](https://app.clubhouse.io/skyverge/story/74849)
### Release #1720 

## QA

- [ ] Code review
- [ ] `codecept run integration` pass