### PR TITLE
Fix product set

### DIFF
--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -127,10 +127,6 @@ class Sync {
 		// product cat and product set delete hooks, remove or check if must remove any product set
 		add_action( 'pre_delete_term', array( $this, 'sync_remove_product_set' ), 1, 2 );
 		add_action( 'delete_product_cat', array( $this, 'maybe_sync_product_set_on_product_cat_remove' ), 99 );
-
-		// filter Product Set delete method to allow live Product Sets deletion
-		// @see https://developers.facebook.com/docs/graph-api/changelog/version9.0#catalog-api
-		add_filter( 'wc_facebook_commerce_allow_live_product_set_deletion', '__return_true' );
 	}
 
 

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -350,10 +350,12 @@ class Sync {
 		);
 		$product_ids   = get_posts( $products_args );
 
+		// Removes the Product Set doesn't have products.
 		if ( empty( $product_ids ) ) {
 			$fb_product_set_id = get_term_meta( $product_set_id, \WC_Facebookcommerce_Integration::FB_PRODUCT_SET_ID, true );
 			update_term_meta( $product_set_id, \WC_Facebookcommerce_Integration::FB_PRODUCT_SET_ID, '' );
 			do_action( 'fb_wc_product_set_delete', $fb_product_set_id );
+			return;
 		}
 
 		// gets products variations

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -346,7 +346,7 @@ class Sync {
 		);
 		$product_ids   = get_posts( $products_args );
 
-		// Removes the Product Set doesn't have products.
+		// Removes the Product Set if it doesn't have products.
 		if ( empty( $product_ids ) ) {
 			$fb_product_set_id = get_term_meta( $product_set_id, \WC_Facebookcommerce_Integration::FB_PRODUCT_SET_ID, true );
 			update_term_meta( $product_set_id, \WC_Facebookcommerce_Integration::FB_PRODUCT_SET_ID, '' );

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -127,6 +127,10 @@ class Sync {
 		// product cat and product set delete hooks, remove or check if must remove any product set
 		add_action( 'pre_delete_term', array( $this, 'sync_remove_product_set' ), 1, 2 );
 		add_action( 'delete_product_cat', array( $this, 'maybe_sync_product_set_on_product_cat_remove' ), 99 );
+
+		// filter Product Set delete method to allow live Product Sets deletion
+		// @see https://developers.facebook.com/docs/graph-api/changelog/version9.0#catalog-api
+		add_filter( 'wc_facebook_commerce_allow_live_product_set_deletion', '__return_true' );
 	}
 
 

--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -408,7 +408,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 
 		public function delete_product_set_item( $product_set_id ) {
 
-			$params = ( true === apply_filters( 'wc_facebook_commerce_allow_live_product_set_deletion', $product_set_id ) ) ? '?allow_live_product_set_deletion=true' : '';
+			$params = ( true === apply_filters( 'wc_facebook_commerce_allow_live_product_set_deletion', true, $product_set_id ) ) ? '?allow_live_product_set_deletion=true' : '';
 
 			$url = $this->build_url( $product_set_id, $params, '9.0' );
 

--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -407,7 +407,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 		}
 
 		public function delete_product_set_item( $product_set_id ) {
-			$url = $this->build_url( $product_set_id, '', '8.0' );
+
+			$params = ( true === apply_filters( 'wc_facebook_commerce_allow_live_product_set_deletion', $product_set_id ) ) ? '?allow_live_product_set_deletion=true' : '';
+
+			$url = $this->build_url( $product_set_id, $params, '9.0' );
+
 			return self::_delete( $url );
 		}
 


### PR DESCRIPTION
- Bug fixed when Product Set is empty.
- Change the version used for Product Set deletion.
- Implement a filter to send the _allow_live_product_set_deletion_ parameter in _true_ by default in Product Set deletion process.
Reference: [Facebook Documentation](https://developers.facebook.com/docs/marketing-api/reference/product-set#Deleting)