### PR TITLE
Ensure that events have an action_source

### DIFF
--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -88,6 +88,7 @@ class Event {
 	protected function prepare_data( $data ) {
 
 		$this->data = wp_parse_args( $data, [
+			'action_source'    => 'website',
 			'event_time'       => time(),
 			'event_id'         => $this->generate_event_id(),
 			'event_source_url' => $this->get_current_url(),

--- a/tests/integration/Events/EventTest.php
+++ b/tests/integration/Events/EventTest.php
@@ -121,6 +121,7 @@ class EventTest extends \Codeception\TestCase\WPTestCase {
 	public function test_prepare_data( $property, $expected ) {
 
 		$data = [
+			'action_source'    => 'other',
 			'event_time'       => '1234',
 			'event_id'         => 'event-id',
 			'event_source_url' => 'current-url',
@@ -142,6 +143,7 @@ class EventTest extends \Codeception\TestCase\WPTestCase {
 	public function provider_prepare_data() {
 
 		return [
+		  'action source'     => [ 'action_source',    'other' ],
 			'event time'        => [ 'event_time',       '1234' ],
 			'event id'          => [ 'event_id',         'event-id' ],
 			'event source url'  => [ 'event_source_url', 'current-url' ],
@@ -280,6 +282,16 @@ class EventTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayHasKey( 'test', $actual );
 		$this->assertEquals( 'test', $actual['test'] );
+	}
+
+	/** @see Event::get_data(), Event::prepare_data() */
+	public function test_default_value_for_action_source() {
+
+		$event  = new Event( [] );
+		$actual = $event->get_data();
+
+		$this->assertArrayHasKey( 'action_source', $actual );
+		$this->assertEquals( 'website', $actual['action_source'] );
 	}
 
 


### PR DESCRIPTION
Summary: Events sent via woocommerce plugin don't currently have an action_source, this is to fix that. Opted for a defaults of 'website'

Differential Revision: D26545761

