### PR TITLE
FIX for: Logs being recorded even with debug option disabled

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -368,6 +368,21 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			new WP_Facebook_Integration();
 		}
 
+		/**
+		 * Saves errors or messages to WooCommerce Log (woocommerce/logs/plugin-id-xxx.txt)
+		 *
+		 * @since 2.0.0
+		 * @param string $message error or message to save to log
+		 * @param string $log_id optional log id to segment the files by, defaults to plugin id
+		 */
+		public function log( $message, $log_id = null ) {
+			// bail if logging isn't enabled
+			if ( ! $this->get_integration() || ! $this->get_integration()->is_debug_mode_enabled() ) {
+				return;
+			}
+
+			parent::log( $message, $log_id );
+		}
 
 		/**
 		 * Logs an API request.

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -371,7 +371,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Saves errors or messages to WooCommerce Log (woocommerce/logs/plugin-id-xxx.txt)
 		 *
-		 * @since 2.3.1-dev.1
+		 * @since 2.3.3
 		 * @param string $message error or message to save to log
 		 * @param string $log_id optional log id to segment the files by, defaults to plugin id
 		 */

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -371,7 +371,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/**
 		 * Saves errors or messages to WooCommerce Log (woocommerce/logs/plugin-id-xxx.txt)
 		 *
-		 * @since 2.0.0
+		 * @since 2.3.1-dev.1
 		 * @param string $message error or message to save to log
 		 * @param string $log_id optional log id to segment the files by, defaults to plugin id
 		 */


### PR DESCRIPTION
Also reported here: https://wordpress.org/support/topic/logs-being-recorded-even-with-debug-option-disabled/

There are are messages spamming the logs, even with the debug option being disabled in the plugin config.

It comes from:
facebook-for-woocommerce\includes\Handlers\Connection.php

Line 394: private function retrieve_page_access_token( $page_id )
One of them is:
facebook_for_woocommerce()->log( ‘Retrieving page access token’ );

What I saw is that the log function has not been overridden to check the debug option as it’s done in the similar function log_api_request.

I'll create a PR with the suggested change to fix that.

Hopefully it can make the next release.
It’s annoying the need to keep cleaning up my logs if I chose to not log anything from this plugin.