### PR TITLE
Facebook version bump marketing api to 9.0

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -32,7 +32,7 @@ class API extends Framework\SV_WC_API_Base {
 
 
 	/** @var string URI used for the request */
-	protected $request_uri = 'https://graph.facebook.com/v7.0';
+	protected $request_uri = \WC_Facebookcommerce_Graph_API::GRAPH_API_URL . \WC_Facebookcommerce_Graph_API::API_VERSION;
 
 	/** @var string the configured access token */
 	protected $access_token;

--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -93,7 +93,7 @@ class Advertise extends Admin\Abstract_Settings_Screen {
 					appId            : '<?php echo esc_js( $connection_handler->get_client_id() ); ?>',
 					autoLogAppEvents : true,
 					xfbml            : true,
-					version          : 'v8.0',
+					version          : 'v8.0', // Note: This expires on November 1 2022
 				} );
 			};
 		</script>

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -395,7 +395,9 @@ class Connection {
 
 		facebook_for_woocommerce()->log( 'Retrieving page access token' );
 
-		$response = wp_remote_get( 'https://graph.facebook.com/v7.0/me/accounts?access_token=' . $this->get_access_token() );
+		$api_url = \WC_Facebookcommerce_Graph_API::GRAPH_API_URL . \WC_Facebookcommerce_Graph_API::API_VERSION;
+
+		$response = wp_remote_get( $api_url . '/me/accounts?access_token=' . $this->get_access_token() );
 
 		$body = wp_remote_retrieve_body( $response );
 		$body = json_decode( $body, true );

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -387,6 +387,7 @@ class Sync {
 		$data = array(
 			'name'   => $term->name,
 			'filter' => wp_json_encode( array( 'or' => $products ) ),
+			'metadata' => wp_json_encode( array( 'description' => $term->description ) ),
 		);
 
 		do_action( 'fb_wc_product_set_sync', $data, $product_set_id );

--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -24,7 +24,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 	 * FB Graph API helper functions
 	 */
 	class WC_Facebookcommerce_Graph_API {
-		const GRAPH_API_URL = 'https://graph.facebook.com/v2.9/';
+		const GRAPH_API_URL = 'https://graph.facebook.com/';
+		const API_VERSION   = 'v9.0';
 		const CURL_TIMEOUT  = 500;
 
 		/**
@@ -396,13 +397,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 
 		// POST https://graph.facebook.com/vX.X/{product-catalog-id}/product_sets
 		public function create_product_set_item( $product_catalog_id, $data ) {
-			$url = $this->build_url( $product_catalog_id, '/product_sets', '8.0' );
+			$url = $this->build_url( $product_catalog_id, '/product_sets', 'v8.0' );
 			return self::_post( $url, $data );
 		}
 
 		// POST https://graph.facebook.com/vX.X/{product-set-id}
 		public function update_product_set_item( $product_set_id, $data ) {
-			$url = $this->build_url( $product_set_id, '', '8.0' );
+			$url = $this->build_url( $product_set_id, '' );
 			return self::_post( $url, $data );
 		}
 
@@ -410,7 +411,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 
 			$params = ( true === apply_filters( 'wc_facebook_commerce_allow_live_product_set_deletion', true, $product_set_id ) ) ? '?allow_live_product_set_deletion=true' : '';
 
-			$url = $this->build_url( $product_set_id, $params, '9.0' );
+			$url = $this->build_url( $product_set_id, $params, 'v9.0' );
 
 			return self::_delete( $url );
 		}
@@ -593,7 +594,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 		private function build_url( $field_id, $param = '', $api_version = '' ) {
 			$api_url = self::GRAPH_API_URL;
 			if ( ! empty( $api_version ) ) {
-				$api_url = str_replace( '2.9', str_replace( 'v', '', trim( $api_version ) ), $api_url );
+				$api_url = $api_url . $api_version . '/';
+			} else {
+				$api_url = $api_url . self::API_VERSION . '/';
 			}
 			return $api_url . (string) $field_id . $param;
 		}

--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -397,7 +397,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 
 		// POST https://graph.facebook.com/vX.X/{product-catalog-id}/product_sets
 		public function create_product_set_item( $product_catalog_id, $data ) {
-			$url = $this->build_url( $product_catalog_id, '/product_sets', 'v8.0' );
+			$url = $this->build_url( $product_catalog_id, '/product_sets' );
 			return self::_post( $url, $data );
 		}
 
@@ -411,7 +411,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 
 			$params = ( true === apply_filters( 'wc_facebook_commerce_allow_live_product_set_deletion', true, $product_set_id ) ) ? '?allow_live_product_set_deletion=true' : '';
 
-			$url = $this->build_url( $product_set_id, $params, 'v9.0' );
+			$url = $this->build_url( $product_set_id, $params );
 
 			return self::_delete( $url );
 		}

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -19,7 +19,7 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @var \IntegrationTester */
 	protected $tester;
 
-	private $base_uri;
+	private $base_facebook_uri;
 
 
 	/**

--- a/tests/integration/APITest.php
+++ b/tests/integration/APITest.php
@@ -19,6 +19,8 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 	/** @var \IntegrationTester */
 	protected $tester;
 
+	private $base_uri;
+
 
 	/**
 	 * Runs before each test.
@@ -32,6 +34,8 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 
 		// create an instance of the API and load all the request and response classes
 		facebook_for_woocommerce()->get_api();
+
+		$this->base_facebook_uri = \WC_Facebookcommerce_Graph_API::GRAPH_API_URL . \WC_Facebookcommerce_Graph_API::API_VERSION;
 	}
 
 
@@ -574,7 +578,7 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 
 		$response_data = [
 			'paging' => [
-				'next' => 'https://graph.facebook.com/v7.0/1234/products?fields=id,retailer_id&limit=1000&after=ABCD',
+				'next' => $this->base_facebook_uri . '/1234/products?fields=id,retailer_id&limit=1000&after=ABCD',
 			],
 		];
 
@@ -625,7 +629,7 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 
 		$response_data = [
 			'paging' => [
-				'next' => 'https://graph.facebook.com/v7.0/1234/products?fields=id,retailer_id&limit=1000&after=ABCD',
+				'next' => $this->base_facebook_uri . '/1234/products?fields=id,retailer_id&limit=1000&after=ABCD',
 			],
 		];
 


### PR DESCRIPTION
Move plugin to use v9.0 of the marketing version as it's currently on 7.0 (mostly) and will be deprecated soon. Also cleaned up how the version is referenced to make this easier to manage.

Fixed the tests then checked that product sync and product updates still work (the only potentially affected endpoint being the slightly odd way that the plugin attempts to update a product, not the batch sync but the single product update).

## Relevant changelogs:
https://developers.facebook.com/docs/graph-api/changelog/version8.0#marketing-api
https://developers.facebook.com/docs/graph-api/changelog/version9.0#marketing-api

## Version List:
https://developers.facebook.com/docs/graph-api/changelog/versions#marketing-api

## Context:
> Your app will be affected by the deprecation of Marketing API versions prior to v8.0.
> 
> Your app WooCommerce Integration, currently accesses a Marketing API version prior to v8.0. We will be deprecating all versions prior to v8.0 on Wednesday, March 3, 2021. To ensure a smooth transition, please migrate all calls to Marketing API v8.0 or higher. We recommend migrating to the most recent version, Marketing API v9.0, to reduce the number of future migrations for developers.
> 
> Visit our changelog to see all upcoming Marketing API deprecation dates as well as the full list of changes in all versions