### PR TITLE
Don’t autoload OPTION_GOOGLE_PRODUCT_CATEGORIES

### DIFF
--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -64,7 +64,7 @@ class Google_Product_Category_Field {
 			if ( ! empty( $categories ) ) {
 
 				set_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, $categories, WEEK_IN_SECONDS );
-				update_option( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, $categories );
+				update_option( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, $categories, 'no' );
 			}
 		}
 


### PR DESCRIPTION
This option is quite large. The web request response itself is 483kb and after the parsing I'm seeing it around 708kb on a client site.

Because it's currently autoloaded, this means the `OPTION_GOOGLE_PRODUCT_CATEGORIES` option itself is pushing a site very close to their `alloptions` exceeding 1MB, which is where most object caches stop working. And when `alloptions` can't be stored in the object cache, the database load increases drastically - generally breaking high-traffic sites at that point.

The solution here is quite simple though. Since this option is both only accessed in the admin (I think?) and also accessed primarily from it's own transient, it's an easy win to just not autoload it using the third param here: https://developer.wordpress.org/reference/functions/update_option/