### PR TITLE
Sanitize attribute names to correctly auto-match EC attributes

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1127,13 +1127,11 @@ class Products {
 		$value = $product->get_meta( self::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . $key );
 
 		if ( empty( $value ) ) {
-			$product_id = $product->get_id();
-
 			// Check normal product attributes
 			foreach ( $product->get_attributes() as $slug => $attribute ) {
 				if ( $product->is_type( 'variation' ) ) {
-					$attr_name      = $slug;
-					$attr_val       = \WC_Facebookcommerce_Utils::get_variant_option_name( $product_id, 'attribute_' . $slug, $attribute );
+					$attr_name = $slug;
+					$attr_val  = $attribute;
 				} else {
 					$attr_name = $attribute->get_name();
 					$attr_val  = $product->get_attribute( $slug );

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1137,7 +1137,7 @@ class Products {
 					$attr_val  = $product->get_attribute( $slug );
 				}
 
-				if ( strtolower( $attr_name ) === $key ) {
+				if ( \WC_Facebookcommerce_Utils::sanitize_variant_name( $attr_name, false ) === $key ) {
 					$value = $attr_val;
 					break;
 				}

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1127,11 +1127,13 @@ class Products {
 		$value = $product->get_meta( self::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . $key );
 
 		if ( empty( $value ) ) {
+			$product_id = $product->get_id();
+
 			// Check normal product attributes
 			foreach ( $product->get_attributes() as $slug => $attribute ) {
 				if ( $product->is_type( 'variation' ) ) {
-					$attr_name = $slug;
-					$attr_val  = $attribute;
+					$attr_name      = $slug;
+					$attr_val       = \WC_Facebookcommerce_Utils::get_variant_option_name( $product_id, 'attribute_' . $slug, $attribute );
 				} else {
 					$attr_name = $attribute->get_name();
 					$attr_val  = $product->get_attribute( $slug );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -439,13 +439,6 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			);
 		}
 
-		public function get_variant_option_name( $label, $default_value ) {
-			// For the given label, get the Visible name rather than the slug
-			$meta           = get_post_meta( $this->id, $label, true );
-			$attribute_name = str_replace( 'attribute_', '', $label );
-			$term           = get_term_by( 'slug', $meta, $attribute_name );
-			return $term && $term->name ? $term->name : $default_value;
-		}
 
 		public function update_visibility( $is_product_page, $visible_box_checked ) {
 			$visibility = get_post_meta( $this->id, self::FB_VISIBILITY, true );
@@ -670,7 +663,8 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$enhanced_data = array();
 
 			$category       = $category_handler->get_category_with_attrs( $google_category_id );
-			$all_attributes = $category['attributes'];
+			$all_attributes = $this->get_matched_attributes_for_product( $this->woo_product, $category['attributes'] );
+
 			foreach ( $all_attributes as $attribute ) {
 				$value            = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
 				$convert_to_array = (
@@ -691,6 +685,33 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 
 			return array_merge( $product_data, $enhanced_data );
 		}
+
+
+		/**
+		 * Filters list of attributes to only those available for a given product
+		 *
+		 * @param \WC_Product $product WooCommerce Product
+		 * @param array $all_attributes List of Enhanced Catalog attributes to match
+		 * @return array
+		 */
+		public function get_matched_attributes_for_product( $product, $all_attributes ) {
+			$matched_attributes = array();
+			$sanitized_keys = array_map(
+				function( $key ) {
+						return \WC_Facebookcommerce_Utils::sanitize_variant_name( $key, false );
+				},
+				array_keys( $product->get_attributes() )
+			);
+
+			$matched_attributes = array_filter( $all_attributes,
+				function( $attribute ) use ($sanitized_keys) {
+					return in_array( $attribute['key'], $sanitized_keys );
+				}
+			);
+
+			return $matched_attributes;
+		}
+
 
 		/**
 		 * Normalizes variant data for Facebook.
@@ -734,7 +755,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				// Sometimes WC returns an array, sometimes it's an assoc array, depending
 				// on what type of taxonomy it's using.  array_values will guarantee we
 				// only get a flat array of values.
-				if ( $options = $this->get_variant_option_name( $label, $attributes[ $original_variant_name ] ) ) {
+				if ( $options = \WC_Facebookcommerce_Utils::get_variant_option_name( $this->id, $label, $attributes[ $original_variant_name ] ) ) {
 
 					if ( is_array( $options ) ) {
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -439,6 +439,13 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			);
 		}
 
+		public function get_variant_option_name( $label, $default_value ) {
+			// For the given label, get the Visible name rather than the slug
+			$meta           = get_post_meta( $this->id, $label, true );
+			$attribute_name = str_replace( 'attribute_', '', $label );
+			$term           = get_term_by( 'slug', $meta, $attribute_name );
+			return $term && $term->name ? $term->name : $default_value;
+		}
 
 		public function update_visibility( $is_product_page, $visible_box_checked ) {
 			$visibility = get_post_meta( $this->id, self::FB_VISIBILITY, true );
@@ -663,8 +670,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$enhanced_data = array();
 
 			$category       = $category_handler->get_category_with_attrs( $google_category_id );
-			$all_attributes = $this->get_matched_attributes_for_product( $this->woo_product, $category['attributes'] );
-
+			$all_attributes = $category['attributes'];
 			foreach ( $all_attributes as $attribute ) {
 				$value            = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
 				$convert_to_array = (
@@ -685,33 +691,6 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 
 			return array_merge( $product_data, $enhanced_data );
 		}
-
-
-		/**
-		 * Filters list of attributes to only those available for a given product
-		 *
-		 * @param \WC_Product $product WooCommerce Product
-		 * @param array $all_attributes List of Enhanced Catalog attributes to match
-		 * @return array
-		 */
-		public function get_matched_attributes_for_product( $product, $all_attributes ) {
-			$matched_attributes = array();
-			$sanitized_keys = array_map(
-				function( $key ) {
-						return \WC_Facebookcommerce_Utils::sanitize_variant_name( $key, false );
-				},
-				array_keys( $product->get_attributes() )
-			);
-
-			$matched_attributes = array_filter( $all_attributes,
-				function( $attribute ) use ($sanitized_keys) {
-					return in_array( $attribute['key'], $sanitized_keys );
-				}
-			);
-
-			return $matched_attributes;
-		}
-
 
 		/**
 		 * Normalizes variant data for Facebook.
@@ -755,7 +734,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				// Sometimes WC returns an array, sometimes it's an assoc array, depending
 				// on what type of taxonomy it's using.  array_values will guarantee we
 				// only get a flat array of values.
-				if ( $options = \WC_Facebookcommerce_Utils::get_variant_option_name( $this->id, $label, $attributes[ $original_variant_name ] ) ) {
+				if ( $options = $this->get_variant_option_name( $label, $attributes[ $original_variant_name ] ) ) {
 
 					if ( is_array( $options ) ) {
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -729,9 +729,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				$label = wc_attribute_label( $original_variant_name, $product );
 
 				// Clean up variant name (e.g. pa_color should be color)
-				// Replace "custom_data:foo" with just "foo" so we can use the key
-				// Product item API expects "custom_data" instead of "custom_data:foo"
-				$new_name = str_replace( 'custom_data:', '', \WC_Facebookcommerce_Utils::sanitize_variant_name( $original_variant_name ) );
+				$new_name = \WC_Facebookcommerce_Utils::sanitize_variant_name( $original_variant_name, false );
 
 				// Sometimes WC returns an array, sometimes it's an assoc array, depending
 				// on what type of taxonomy it's using.  array_values will guarantee we

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -418,18 +418,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			return ( self::$store_name ) ? ( self::$store_name ) : 'A Store Has No Name';
 		}
 
-
-		/*
-		 * Get visible name for variant attribute rather than the slug
-		*/
-		public function get_variant_option_name( $wp_id, $label, $default_value ) {
-			$meta           = get_post_meta( $wp_id, $label, true );
-			$attribute_name = str_replace( 'attribute_', '', $label );
-			$term           = get_term_by( 'slug', $meta, $attribute_name );
-			return $term && $term->name ? $term->name : $default_value;
-		}
-
-
 		/*
 		* Change variant product field name from Woo taxonomy to FB name
 		*/

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -418,6 +418,18 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			return ( self::$store_name ) ? ( self::$store_name ) : 'A Store Has No Name';
 		}
 
+
+		/*
+		 * Get visible name for variant attribute rather than the slug
+		*/
+		public function get_variant_option_name( $wp_id, $label, $default_value ) {
+			$meta           = get_post_meta( $wp_id, $label, true );
+			$attribute_name = str_replace( 'attribute_', '', $label );
+			$term           = get_term_by( 'slug', $meta, $attribute_name );
+			return $term && $term->name ? $term->name : $default_value;
+		}
+
+
 		/*
 		* Change variant product field name from Woo taxonomy to FB name
 		*/

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -421,7 +421,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		/*
 		* Change variant product field name from Woo taxonomy to FB name
 		*/
-		public static function sanitize_variant_name( $name ) {
+		public static function sanitize_variant_name( $name, $use_custom_data = true ) {
 			$name = str_replace( array( 'attribute_', 'pa_' ), '', strtolower( $name ) );
 
 			// British spelling
@@ -429,15 +429,17 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 				$name = self::FB_VARIANT_COLOR;
 			}
 
-			switch ( $name ) {
-				case self::FB_VARIANT_SIZE:
-				case self::FB_VARIANT_COLOR:
-				case self::FB_VARIANT_GENDER:
-				case self::FB_VARIANT_PATTERN:
-					break;
-				default:
-					$name = 'custom_data:' . strtolower( $name );
-					break;
+			if ( $use_custom_data ) {
+				switch ( $name ) {
+					case self::FB_VARIANT_SIZE:
+					case self::FB_VARIANT_COLOR:
+					case self::FB_VARIANT_GENDER:
+					case self::FB_VARIANT_PATTERN:
+						break;
+					default:
+						$name = 'custom_data:' . strtolower( $name );
+						break;
+				}
 			}
 
 			return $name;


### PR DESCRIPTION
This change correctly sanitizes WooCommerce attributes to automatically match EC attribute names