### PR TITLE
Create 2.3.3. upgrade function.

### DIFF
--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -42,6 +42,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 			'2.0.0',
 			'2.0.3',
 			'2.0.4',
+			'2.3.3',
 		];
 	}
 
@@ -336,5 +337,17 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 		}
 	}
 
+	/**
+	 * Upgrades to version 2.3.3
+	 *
+	 * @since 2.3.3.
+	 */
+	protected function upgrade_to_2_3_3() {
+		$sync_enabled = 'yes' === get_option( \WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC, 'yes' );
+		if ( ! $sync_enabled ) {
+			return;
+		}
+		facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
+	}
 
 }


### PR DESCRIPTION
This code forces all product resync on plugin update to "2.3.3" version.

Fixes: #1807 

The update procedure is triggered on `wp_loaded` hook so:

> do_action( 'wp_loaded' )
This hook is fired once WP, all plugins, and the theme are fully loaded and instantiated.

This means that we have access to all that we have. 

`facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();`
Just registers the products for updates. The actual update process is triggered by the `shutdown` hook and later carried on in the background by `$job_handler = facebook_for_woocommerce()->get_products_sync_background_handler();`

